### PR TITLE
fix: remove basePath config to resolve Cloudflare Workers createActio…

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -29,7 +29,7 @@ export const { handle, signIn, signOut } = SvelteKitAuth({
     maxAge: 7 * 24 * 60 * 60, // 7 days
   },
   trustHost: true,
-  basePath: '/auth',
+  // Remove basePath - let Auth.js auto-detect for Cloudflare Workers compatibility
   callbacks: {
     async jwt({ token, user, account, profile }) {
       // Persist the id_token to the JWT token if it exists


### PR DESCRIPTION
…nURL error

- Remove explicit basePath: '/auth' from Auth.js configuration
- Auth.js defaults to /auth anyway, but avoids basePath?.replace runtime error
- Same callback URLs still work: /auth/callback/auth0
- Test: Build and dev server work without errors
- Addresses: TypeError: basePath?.replace is not a function in Cloudflare Workers