### PR TITLE
Implement CSS design token foundation

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -3,6 +3,12 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+		<link
+			href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=Playfair+Display:ital,wght@0,400;0,500;0,700;0,900;1,400;1,700&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,400&display=swap"
+			rel="stylesheet"
+		/>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/apps/web/src/lib/styles/app.css
+++ b/apps/web/src/lib/styles/app.css
@@ -1,0 +1,3 @@
+@import './tokens.css';
+@import './reset.css';
+@import './global.css';

--- a/apps/web/src/lib/styles/global.css
+++ b/apps/web/src/lib/styles/global.css
@@ -1,0 +1,1 @@
+/* Placeholder for issue #66. */

--- a/apps/web/src/lib/styles/reset.css
+++ b/apps/web/src/lib/styles/reset.css
@@ -1,0 +1,1 @@
+/* Placeholder for issue #65. */

--- a/apps/web/src/lib/styles/tokens.css
+++ b/apps/web/src/lib/styles/tokens.css
@@ -1,0 +1,172 @@
+/* ============================================
+   STUDYPUCK DESIGN TOKENS
+   Source: docs/ux/visual-style-spec.md
+   ============================================ */
+
+/* --- Typography --- */
+:root {
+  --font-heading: 'Playfair Display', 'Georgia', serif;
+  --font-body: 'Lora', 'Georgia', 'Noto Serif SC', 'STSong', 'SimSun', serif;
+  --font-ui: 'DM Sans', system-ui, sans-serif;
+  --font-mono: 'ui-monospace', 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+
+  --font-size-display: 3.5rem;
+  --font-size-h1: 2.5rem;
+  --font-size-h2: 2rem;
+  --font-size-h3: 1.5rem;
+  --font-size-h4: 1.2rem;
+  --font-size-body: 1.0625rem;
+  --font-size-ui: 0.875rem;
+  --font-size-small: 0.875rem;
+  --font-size-caption: 0.75rem;
+
+  --leading-tight: 1.1;
+  --leading-heading: 1.15;
+  --leading-body: 1.65;
+  --leading-relaxed: 1.75;
+
+  --tracking-heading: -0.02em;
+  --tracking-caps: 0.1em;
+  --tracking-normal: 0em;
+
+  --para-spacing: 0.85em;
+  --measure-body: 68ch;
+}
+
+/* --- Colors: Light mode (default) --- */
+:root {
+  --neutral-100: #faf6f2;
+  --neutral-200: #f2ece5;
+  --neutral-300: #e0d8ce;
+  --neutral-400: #c8beb4;
+  --neutral-500: #a09890;
+  --neutral-600: #7a706a;
+  --neutral-700: #504844;
+  --neutral-800: #2a2422;
+  --neutral-900: #1a1918;
+
+  --color-background: #faf6f2;
+  --color-surface: #ffffff;
+  --color-surface-raised: #ffffff;
+  --color-surface-subtle: #f2ece5;
+
+  --color-border: #e0d8ce;
+  --color-border-subtle: #ede8e0;
+
+  --color-primary: #8b1a1a;
+  --color-primary-hover: #a82222;
+  --color-primary-active: #701414;
+  --color-primary-subtle: #f5e8e8;
+  --color-primary-text: #8b1a1a;
+
+  --color-text-primary: #1a1918;
+  --color-text-secondary: #504844;
+  --color-text-muted: #7a706a;
+  --color-text-disabled: #a09890;
+  --color-text-inverse: #f5f0ee;
+  --color-text-accent: #8b1a1a;
+
+  --color-success-text: #166534;
+  --color-success-bg: #dcfce7;
+  --color-success-border: #86efac;
+
+  --color-warning-text: #92400e;
+  --color-warning-bg: #fef3c7;
+  --color-warning-border: #fcd34d;
+
+  --color-error-text: #991b1b;
+  --color-error-bg: #fee2e2;
+  --color-error-border: #fca5a5;
+
+  --color-info-text: #1e40af;
+  --color-info-bg: #dbeafe;
+  --color-info-border: #93c5fd;
+
+  --shadow-sm: 0 1px 3px rgba(26, 12, 10, 0.08), 0 1px 2px rgba(26, 12, 10, 0.05);
+  --shadow-md: 0 4px 12px rgba(26, 12, 10, 0.1), 0 2px 6px rgba(26, 12, 10, 0.06);
+  --shadow-lg: 0 12px 32px rgba(26, 12, 10, 0.14), 0 4px 12px rgba(26, 12, 10, 0.08);
+}
+
+/* --- Colors: Dark mode --- */
+[data-theme='dark'] {
+  --neutral-100: #0d1117;
+  --neutral-200: #161b22;
+  --neutral-300: #21262d;
+  --neutral-400: #30363d;
+  --neutral-500: #484f58;
+  --neutral-600: #6e7681;
+  --neutral-700: #8b949e;
+  --neutral-800: #b1bac4;
+  --neutral-900: #e6edf3;
+
+  --color-background: #0d1117;
+  --color-surface: #161b22;
+  --color-surface-raised: #1c2430;
+  --color-surface-subtle: #161b22;
+
+  --color-border: #30363d;
+  --color-border-subtle: #21262d;
+
+  --color-primary: #c04040;
+  --color-primary-hover: #d45050;
+  --color-primary-active: #a83030;
+  --color-primary-subtle: #1c1020;
+  --color-primary-text: #e07070;
+
+  --color-text-primary: #e6edf3;
+  --color-text-secondary: #b1bac4;
+  --color-text-muted: #8b949e;
+  --color-text-disabled: #484f58;
+  --color-text-inverse: #0d1117;
+  --color-text-accent: #e07070;
+
+  --color-success-text: #3fb950;
+  --color-success-bg: #0d1f15;
+  --color-success-border: #196c2e;
+
+  --color-warning-text: #d29922;
+  --color-warning-bg: #1c1500;
+  --color-warning-border: #7d5700;
+
+  --color-error-text: #f85149;
+  --color-error-bg: #1a0808;
+  --color-error-border: #6e2020;
+
+  --color-info-text: #58a6ff;
+  --color-info-bg: #051526;
+  --color-info-border: #1f4080;
+
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.6);
+}
+
+/* --- Spacing --- */
+:root {
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+  --space-7: 3rem;
+  --space-8: 4rem;
+  --space-9: 6rem;
+}
+
+/* --- Borders & Radius --- */
+:root {
+  --radius-sm: 2px;
+  --radius-md: 4px;
+  --radius-lg: 6px;
+}
+
+/* --- Transitions --- */
+:root {
+  --duration-fast: 150ms;
+  --duration-base: 250ms;
+  --duration-slow: 400ms;
+  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-decelerate: cubic-bezier(0, 0, 0.2, 1);
+  --ease-accelerate: cubic-bezier(0.4, 0, 1, 1);
+}

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import '$lib/styles/app.css';
   import { afterNavigate, invalidateAll } from '$app/navigation';
 
 	let { children } = $props();


### PR DESCRIPTION
## Summary
- add the shared CSS token layer from the visual style spec under apps/web/src/lib/styles
- wire the global app.css entrypoint into the SvelteKit layout and preload the selected Google Fonts
- add placeholder reset.css and global.css files so the style import chain is ready for issues #65 and #66

Closes #64