### PR TITLE
Implement homepage onboarding and dashboard flow

### DIFF
--- a/apps/web/src/lib/components/AppNav.svelte
+++ b/apps/web/src/lib/components/AppNav.svelte
@@ -23,6 +23,11 @@
 
   let moreSheetOpen = false;
 
+  $: availableLanguages =
+    (($page.data as { availableLanguages?: SupportedLanguage[] }).availableLanguages ?? []).length > 0
+      ? (($page.data as { availableLanguages?: SupportedLanguage[] }).availableLanguages ?? [])
+      : [currentLanguage];
+
   $: navItems = [
     { label: 'Home', href: getLanguageHomeHref(currentLanguage.code), icon: '⌂', match: 'exact' },
     {
@@ -96,7 +101,7 @@
     </a>
 
     <div class="app-header__controls cluster">
-      <LanguageSwitcher currentLanguage={currentLanguage} />
+      <LanguageSwitcher currentLanguage={currentLanguage} availableLanguages={availableLanguages} />
       <div class="app-header__user">
         <UserMenu {session} {currentLanguage} />
       </div>

--- a/apps/web/src/lib/components/LanguageSwitcher.svelte
+++ b/apps/web/src/lib/components/LanguageSwitcher.svelte
@@ -2,11 +2,11 @@
   import { page } from '$app/stores';
   import {
     replaceLanguageInPath,
-    SUPPORTED_LANGUAGES,
     type SupportedLanguage,
   } from '$lib/config/languages.js';
 
   export let currentLanguage: SupportedLanguage;
+  export let availableLanguages: SupportedLanguage[] = [currentLanguage];
 
   let isOpen = false;
 
@@ -51,7 +51,7 @@
       </div>
 
       <div class="language-menu__list stack" style="--stack-space: var(--space-2)">
-        {#each SUPPORTED_LANGUAGES as language}
+        {#each availableLanguages as language}
           <a
             href={replaceLanguageInPath($page.url.pathname, language.code)}
             class:language-option--active={language.code === currentLanguage.code}

--- a/apps/web/src/lib/server/homepage.test.ts
+++ b/apps/web/src/lib/server/homepage.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { calculateStudyStreak, getPreferredLanguageCode, resolveAuthenticatedHomepage } from './homepage.js';
+
+describe('homepage helpers', () => {
+  it('routes first-time users to onboarding', () => {
+    expect(resolveAuthenticatedHomepage([])).toBe('/onboarding');
+  });
+
+  it('routes returning users to their first active language', () => {
+    expect(resolveAuthenticatedHomepage([{ languageId: 'zh' }, { languageId: 'es' }])).toBe('/zh/');
+    expect(getPreferredLanguageCode([{ languageId: 'es' }])).toBe('es');
+  });
+
+  it('counts only consecutive study days ending today', () => {
+    const today = new Date('2026-04-12T12:00:00Z');
+
+    expect(calculateStudyStreak(['2026-04-12', '2026-04-11', '2026-04-10'], today)).toBe(3);
+    expect(calculateStudyStreak(['2026-04-11', '2026-04-10'], today)).toBe(0);
+    expect(calculateStudyStreak(['2026-04-12', '2026-04-12', '2026-04-11'], today)).toBe(2);
+  });
+});

--- a/apps/web/src/lib/server/homepage.ts
+++ b/apps/web/src/lib/server/homepage.ts
@@ -1,0 +1,124 @@
+import { and, eq, lte, sql } from 'drizzle-orm';
+import {
+  cardEntryDailyStats,
+  cardReviewDailyStats,
+  cardReviewSrs,
+  getDb,
+  getActiveUserLanguages,
+  inboxNotes,
+  translationDrillDailyStats,
+  type StudyLanguage,
+} from '@studypuck/database';
+
+type DatabaseClient = ReturnType<typeof getDb>;
+
+export type DashboardStats = {
+  reviewDueCount: number;
+  inboxNoteCount: number;
+  streakDays: number;
+};
+
+export function getPreferredLanguageCode(languages: Pick<StudyLanguage, 'languageId'>[]): string | null {
+  return languages[0]?.languageId ?? null;
+}
+
+export function resolveAuthenticatedHomepage(languages: Pick<StudyLanguage, 'languageId'>[]): string {
+  const preferredLanguage = getPreferredLanguageCode(languages);
+  return preferredLanguage ? `/${preferredLanguage}/` : '/onboarding';
+}
+
+export function calculateStudyStreak(dates: string[], today = new Date()): number {
+  const activeDates = new Set(dates);
+  const cursor = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()));
+
+  let streak = 0;
+
+  while (activeDates.has(cursor.toISOString().slice(0, 10))) {
+    streak += 1;
+    cursor.setUTCDate(cursor.getUTCDate() - 1);
+  }
+
+  return streak;
+}
+
+export async function loadActiveStudyLanguages(userId: string, database: DatabaseClient) {
+  return getActiveUserLanguages(userId, database as never);
+}
+
+export async function loadDashboardStats(
+  userId: string,
+  languageId: string,
+  database: DatabaseClient
+): Promise<DashboardStats> {
+  const nowEpochSeconds = Math.floor(Date.now() / 1000);
+
+  const [reviewDueResult, inboxResult, entryActivity, reviewActivity, drillActivity] = await Promise.all([
+    database
+      .select({ count: sql<number>`count(*)` })
+      .from(cardReviewSrs)
+      .where(
+        and(
+          eq(cardReviewSrs.userId, userId),
+          eq(cardReviewSrs.languageId, languageId),
+          lte(cardReviewSrs.nextDue, nowEpochSeconds)
+        )
+      ),
+    database
+      .select({ count: sql<number>`count(*)` })
+      .from(inboxNotes)
+      .where(
+        and(
+          eq(inboxNotes.userId, userId),
+          eq(inboxNotes.languageId, languageId),
+          eq(inboxNotes.state, 'unprocessed')
+        )
+      ),
+    database
+      .select({ date: cardEntryDailyStats.date })
+      .from(cardEntryDailyStats)
+      .where(
+        and(
+          eq(cardEntryDailyStats.userId, userId),
+          eq(cardEntryDailyStats.languageId, languageId),
+          sql`(
+            ${cardEntryDailyStats.notesCaptured} > 0
+            OR ${cardEntryDailyStats.notesProcessed} > 0
+            OR ${cardEntryDailyStats.draftCardsCreated} > 0
+            OR ${cardEntryDailyStats.cardsPromotedToActive} > 0
+          )`
+        )
+      ),
+    database
+      .select({ date: cardReviewDailyStats.date })
+      .from(cardReviewDailyStats)
+      .where(
+        and(
+          eq(cardReviewDailyStats.userId, userId),
+          eq(cardReviewDailyStats.languageId, languageId),
+          sql`${cardReviewDailyStats.cardsReviewed} > 0`
+        )
+      ),
+    database
+      .select({ date: translationDrillDailyStats.date })
+      .from(translationDrillDailyStats)
+      .where(
+        and(
+          eq(translationDrillDailyStats.userId, userId),
+          eq(translationDrillDailyStats.languageId, languageId),
+          sql`${translationDrillDailyStats.sentencesTranslated} > 0`
+        )
+      ),
+  ]);
+
+  const streakDays = calculateStudyStreak([
+    ...entryActivity.map((row) => row.date),
+    ...reviewActivity.map((row) => row.date),
+    ...drillActivity.map((row) => row.date),
+  ]);
+
+  return {
+    reviewDueCount: Number(reviewDueResult[0]?.count ?? 0),
+    inboxNoteCount: Number(inboxResult[0]?.count ?? 0),
+    streakDays,
+  };
+}

--- a/apps/web/src/routes/+page.server.ts
+++ b/apps/web/src/routes/+page.server.ts
@@ -1,12 +1,17 @@
 import { redirect } from '@sveltejs/kit';
-import { DEFAULT_LANGUAGE } from '$lib/config/languages.js';
+import { getDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import { loadActiveStudyLanguages, resolveAuthenticatedHomepage } from '$lib/server/homepage.js';
 import type { PageServerLoad } from './$types.js';
 
 export const load: PageServerLoad = async (event) => {
   const { session } = await event.parent();
 
   if (session?.user?.id) {
-    throw redirect(303, `/${DEFAULT_LANGUAGE.code}/`);
+    const database = getDb(env.DATABASE_URL);
+    const activeLanguages = await loadActiveStudyLanguages(session.user.id, database);
+
+    throw redirect(303, resolveAuthenticatedHomepage(activeLanguages));
   }
 
   return {};

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1,123 +1,234 @@
 <script lang="ts">
-  import AuthButton from '$lib/components/AuthButton.svelte';
+  import { signIn } from '@auth/sveltekit/client';
   import type { PageData } from './$types.js';
 
   export let data: PageData;
-
-  $: typedSession = data.session as any;
   $: authError = (data as any).authError;
 </script>
 
 <svelte:head>
-	<title>StudyPuck - AI-Powered Language Learning</title>
-	<meta name="description" content="Learn languages with AI-powered translation drills and spaced repetition" />
+	<title>StudyPuck - Master vocabulary with focus</title>
+	<meta
+		name="description"
+		content="Master vocabulary through spaced repetition and AI translation practice."
+	/>
 </svelte:head>
 
-<main class="center stack landing-page">
-	<header class="stack landing-header">
-		<div class="stack" style="--stack-space: var(--space-2)">
-			<h1>🏒 StudyPuck</h1>
-			<p class="text-muted">AI-Powered Language Learning</p>
-		</div>
+<div class="landing-shell">
+	<header class="landing-topbar">
+		<div class="center landing-topbar__inner cluster">
+			<a class="brand cluster" href="/" aria-label="StudyPuck home">
+				<span class="brand__mark" aria-hidden="true">◉</span>
+				<span class="brand__name">StudyPuck</span>
+			</a>
 
-		{#if authError?.failed}
-			<div class="auth-error">
-				⚠️ Authentication temporarily unavailable
-			</div>
-		{/if}
+			<button type="button" class="signin-button signin-button--secondary" onclick={() => signIn('auth0')}>
+				Sign In
+			</button>
+		</div>
 	</header>
 
-	<section class="stack hero-panel">
-		<h2>Master Languages with AI-Powered Learning</h2>
-		<p>
-			StudyPuck combines spaced repetition flashcards with interactive AI translation drills
-			to help you learn languages more effectively.
-		</p>
+	<main class="center landing-page stack">
+		<section class="hero stack">
+			<p class="hero__eyebrow">StudyPuck</p>
+			<h1>Master vocabulary through spaced repetition and AI translation practice.</h1>
+			<p class="hero__summary">
+				A calm language-learning workspace for capturing notes, reviewing at the right moment,
+				and practicing active recall with AI-powered drills.
+			</p>
 
-		<div class="features grid" style="--grid-gap: var(--space-5); --grid-min-size: 18rem">
-			<div class="feature">
-				<h3>📚 Smart Cards</h3>
-				<p>Organize vocabulary with intelligent spaced repetition.</p>
+			<div class="hero__actions cluster">
+				<button type="button" class="signin-button" onclick={() => signIn('auth0')}>
+					Sign In <span aria-hidden="true">→</span>
+				</button>
 			</div>
 
-			<div class="feature">
-				<h3>🗣️ AI Conversations</h3>
-				<p>Practice translations in natural conversation flows.</p>
-			</div>
+			{#if authError?.failed}
+				<p class="auth-error" role="alert">Authentication is temporarily unavailable.</p>
+			{/if}
+		</section>
 
-			<div class="feature">
-				<h3>🎯 Personalized Learning</h3>
-				<p>Adaptive difficulty based on your progress.</p>
-			</div>
+		<section class="feature-grid" aria-label="StudyPuck features">
+			<article class="feature-card stack">
+				<p class="feature-card__icon" aria-hidden="true">📚</p>
+				<h2>Spaced Repetition</h2>
+				<p>Cards reviewed at the optimal moment, scientifically timed for long-term retention.</p>
+			</article>
+
+			<article class="feature-card stack">
+				<p class="feature-card__icon" aria-hidden="true">🤖</p>
+				<h2>AI Translation Drills</h2>
+				<p>Conversation-style practice powered by AI, tailored to your cards and study context.</p>
+			</article>
+		</section>
+	</main>
+
+	<footer class="landing-footer">
+		<div class="center landing-footer__inner cluster">
+			<p>© 2026 StudyPuck</p>
+			<a href="https://github.com/ZBlocker655/StudyPuck" rel="noreferrer" target="_blank">GitHub ↗</a>
 		</div>
-
-		<div class="stack landing-actions" style="--stack-space: var(--space-3)">
-			<p>Sign in to enter your active language workspace.</p>
-			<div class="landing-auth">
-				<AuthButton session={typedSession} />
-			</div>
-		</div>
-	</section>
-</main>
+	</footer>
+</div>
 
 <style>
-	.landing-page {
-		padding-block: var(--space-6);
-		--center-max: 62.5rem;
-		--stack-space: var(--space-6);
+	.landing-shell {
+		min-block-size: 100vh;
+		display: grid;
+		grid-template-rows: auto 1fr auto;
 	}
-	
-	.landing-page h1 {
-		font-size: var(--font-size-display);
+
+	.landing-topbar,
+	.landing-footer {
+		border-color: var(--color-border);
 	}
-	
-	.landing-header p {
+
+	.landing-topbar {
+		border-block-end: 1px solid var(--color-border);
+		background: color-mix(in srgb, var(--color-background) 88%, transparent);
+		backdrop-filter: blur(10px);
+	}
+
+	.landing-topbar__inner,
+	.landing-footer__inner {
+		justify-content: space-between;
+		min-block-size: 3.75rem;
+		--center-max: 72rem;
+		--cluster-space: var(--space-4);
+	}
+
+	.brand {
+		color: var(--color-text-primary);
+		text-decoration: none;
+		--cluster-space: var(--space-3);
+	}
+
+	.brand__name {
+		font-family: var(--font-heading);
 		font-size: var(--font-size-h4);
 	}
-	
-	.hero-panel {
-		background: var(--color-surface-subtle);
-		padding: var(--space-6);
-		border-radius: var(--radius-lg);
+
+	.landing-page {
+		padding-block: var(--space-8);
+		padding-inline: var(--space-5);
+		--center-max: 72rem;
+		--stack-space: var(--space-8);
 	}
 
-	.feature {
-		background: var(--color-surface);
-		padding: var(--space-5);
-		border-radius: var(--radius-lg);
-		box-shadow: var(--shadow-sm);
+	.hero {
+		max-inline-size: 44rem;
+		margin-inline: auto;
+		text-align: center;
+		--stack-space: var(--space-5);
 	}
 
-	.feature h3 {
-		margin: 0 0 var(--space-2) 0;
+	.hero__eyebrow {
+		margin: 0;
+		font-family: var(--font-ui);
+		font-size: var(--font-size-ui);
+		letter-spacing: var(--tracking-caps);
+		text-transform: uppercase;
+		color: var(--color-text-secondary);
 	}
 
-	.feature p {
-		margin: 0 0 var(--space-4) 0;
+	.hero h1,
+	.hero__summary,
+	.feature-card h2,
+	.feature-card p,
+	.landing-footer p {
+		margin: 0;
 	}
 
-	.landing-actions {
-		padding: var(--space-4);
+	.hero h1 {
+		font-size: clamp(var(--font-size-h1), 6vw, var(--font-size-display));
+		line-height: var(--leading-tight);
+		letter-spacing: var(--tracking-heading);
+	}
+
+	.hero__summary {
+		max-inline-size: 34rem;
+		margin-inline: auto;
+		font-size: var(--font-size-h4);
+		color: var(--color-text-secondary);
+	}
+
+	.hero__actions {
+		justify-content: center;
+	}
+
+	.signin-button {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: var(--space-2);
+		min-block-size: 2.75rem;
+		padding-block: var(--space-3);
+		padding-inline: var(--space-5);
+		border: 1px solid var(--color-primary);
 		border-radius: var(--radius-md);
+		background: var(--color-primary);
+		color: var(--color-text-inverse);
+		font-family: var(--font-ui);
+		font-size: var(--font-size-ui);
+		font-weight: 600;
+	}
+
+	.signin-button--secondary {
+		padding-block: var(--space-2);
+		padding-inline: var(--space-4);
+	}
+
+	.feature-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: var(--space-5);
+	}
+
+	.feature-card {
+		padding: var(--space-5);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-lg);
 		background: var(--color-surface);
+		box-shadow: var(--shadow-sm);
+		--stack-space: var(--space-3);
 	}
 
-	.landing-auth :global(.auth-container) {
-		justify-content: flex-start;
+	.feature-card__icon {
+		margin: 0;
+		font-size: 2rem;
 	}
 
-	@media (max-width: 768px) {
-		.landing-page h1 {
-			font-size: var(--font-size-h2);
-		}
+	.feature-card p {
+		color: var(--color-text-secondary);
+	}
+
+	.landing-footer {
+		border-block-start: 1px solid var(--color-border);
+	}
+
+	.landing-footer a {
+		color: var(--color-text-secondary);
+		text-decoration: none;
 	}
 
 	.auth-error {
-		background: var(--color-error-bg);
+		margin: 0 auto;
+		padding: var(--space-3) var(--space-4);
 		border: 1px solid var(--color-error-border);
-		color: var(--color-error-text);
-		padding: var(--space-2) var(--space-3);
 		border-radius: var(--radius-md);
-		font-weight: 500;
+		background: var(--color-error-bg);
+		color: var(--color-error-text);
+		font-family: var(--font-ui);
+	}
+
+	@media (max-width: 40rem) {
+		.landing-page {
+			padding-inline: var(--space-4);
+			padding-block: var(--space-7);
+		}
+
+		.feature-grid {
+			grid-template-columns: 1fr;
+		}
 	}
 </style>

--- a/apps/web/src/routes/[lang]/+layout.server.ts
+++ b/apps/web/src/routes/[lang]/+layout.server.ts
@@ -1,5 +1,8 @@
 import { redirect } from '@sveltejs/kit';
+import { getDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
 import { DEFAULT_LANGUAGE, replaceLanguageInPath, getLanguageByCode } from '$lib/config/languages.js';
+import { loadActiveStudyLanguages } from '$lib/server/homepage.js';
 import type { LayoutServerLoad } from './$types.js';
 
 export const load: LayoutServerLoad = async (event) => {
@@ -13,5 +16,24 @@ export const load: LayoutServerLoad = async (event) => {
     throw redirect(303, '/');
   }
 
-  return {};
+  const database = getDb(env.DATABASE_URL);
+  const activeLanguages = await loadActiveStudyLanguages(parentData.session.user.id, database);
+
+  if (activeLanguages.length === 0) {
+    throw redirect(303, '/onboarding');
+  }
+
+  const availableLanguages = activeLanguages
+    .map((language) => getLanguageByCode(language.languageId))
+    .filter((language) => language !== undefined);
+
+  const currentLanguageConfigured = availableLanguages.some((language) => language.code === event.params.lang);
+
+  if (!currentLanguageConfigured) {
+    throw redirect(303, `/${availableLanguages[0]?.code ?? DEFAULT_LANGUAGE.code}/`);
+  }
+
+  return {
+    availableLanguages,
+  };
 };

--- a/apps/web/src/routes/[lang]/+page.server.ts
+++ b/apps/web/src/routes/[lang]/+page.server.ts
@@ -1,0 +1,25 @@
+import { getDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import { loadDashboardStats } from '$lib/server/homepage.js';
+import type { PageServerLoad } from './$types.js';
+
+export const load: PageServerLoad = async (event) => {
+  const { session } = await event.parent();
+
+  if (!session?.user?.id) {
+    return {
+      dashboard: {
+        reviewDueCount: 0,
+        inboxNoteCount: 0,
+        streakDays: 0,
+      },
+    };
+  }
+
+  const database = getDb(env.DATABASE_URL);
+  const dashboard = await loadDashboardStats(session.user.id, event.params.lang, database);
+
+  return {
+    dashboard,
+  };
+};

--- a/apps/web/src/routes/[lang]/+page.svelte
+++ b/apps/web/src/routes/[lang]/+page.svelte
@@ -12,59 +12,169 @@
   <title>{currentLanguage?.label ?? 'StudyPuck'} – Dashboard</title>
 </svelte:head>
 
-<section class="center stack dashboard-page" style="--stack-space: var(--space-6)">
-  <header class="stack" style="--stack-space: var(--space-2)">
-    <p class="dashboard-eyebrow text-muted">Active language</p>
-    <h1>{currentLanguage?.label ?? 'StudyPuck'}</h1>
-    <p>
-      Welcome back, {data.session?.user?.name || data.session?.user?.email}. Your dashboard now
-      lives inside the global navigation shell.
-    </p>
-  </header>
+<section class="center dashboard-page stack">
+  <h1 class="visually-hidden">{currentLanguage?.label ?? 'StudyPuck'} dashboard</h1>
 
-  <div class="grid" style="--grid-gap: var(--space-5); --grid-min-size: 16rem">
-    <a class="dashboard-card stack" href={`/${$page.params.lang}/card-entry`} style="--stack-space: var(--space-2)">
-      <h2>Card Entry</h2>
-      <p>Capture notes and turn them into cards for your active language.</p>
-    </a>
+  <div class="dashboard-widgets">
+    <article class="action-card action-card--review stack">
+      <p class="action-card__label">Cards Due for Review</p>
 
-    <a class="dashboard-card stack" href={`/${$page.params.lang}/card-review`} style="--stack-space: var(--space-2)">
-      <h2>Card Review</h2>
-      <p>Run focused review sessions with your spaced-repetition queue.</p>
-    </a>
+      {#if data.dashboard.reviewDueCount > 0}
+        <p class="action-card__count">{data.dashboard.reviewDueCount}</p>
+        <a class="action-card__cta" href={`/${$page.params.lang}/card-review`}>Review Now →</a>
+      {:else}
+        <p class="action-card__empty">✓ No cards due today. Come back tomorrow!</p>
+      {/if}
+    </article>
 
-    <a class="dashboard-card stack" href={`/${$page.params.lang}/translation-drills`} style="--stack-space: var(--space-2)">
-      <h2>Translation Drills</h2>
-      <p>Practice active recall in conversational translation exercises.</p>
-    </a>
+    <article class="action-card action-card--inbox stack">
+      <p class="action-card__label">Notes in Inbox</p>
+
+      {#if data.dashboard.inboxNoteCount > 0}
+        <p class="action-card__count">{data.dashboard.inboxNoteCount}</p>
+        <a class="action-card__cta" href={`/${$page.params.lang}/card-entry`}>Enter Cards →</a>
+      {:else}
+        <p class="action-card__empty">✓ Inbox is clear.</p>
+      {/if}
+    </article>
   </div>
+
+  {#if data.dashboard.streakDays > 0}
+    <p class="dashboard-streak">🔥 {data.dashboard.streakDays}-day study streak</p>
+  {:else}
+    <p class="dashboard-streak dashboard-streak--empty">Start your streak today</p>
+  {/if}
+
+  <nav class="quick-access" aria-label="Quick access">
+    <a class="quick-access__link" href={`/${$page.params.lang}/card-entry`}>Card Entry</a>
+    <a class="quick-access__link" href={`/${$page.params.lang}/card-review`}>Card Review</a>
+    <a class="quick-access__link" href={`/${$page.params.lang}/translation-drills`}>Translation Drills</a>
+  </nav>
 </section>
 
 <style>
   .dashboard-page {
-    --center-max: 70rem;
+    --center-max: 56rem;
+    padding-block: var(--space-5);
     padding-inline: var(--space-5);
+    --stack-space: var(--space-5);
   }
 
-  .dashboard-eyebrow {
-    font-family: var(--font-ui);
-    font-size: var(--font-size-ui);
-    letter-spacing: var(--tracking-caps);
-    text-transform: uppercase;
+  .dashboard-widgets {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-5);
   }
 
-  .dashboard-card {
+  .action-card {
     padding: var(--space-5);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
     background: var(--color-surface);
     box-shadow: var(--shadow-sm);
-    color: inherit;
+    min-block-size: 16rem;
+    --stack-space: var(--space-4);
+  }
+
+  .action-card--review {
+    border-color: var(--color-info-border);
+    background: color-mix(in srgb, var(--color-info-bg) 35%, var(--color-surface));
+  }
+
+  .action-card--inbox {
+    border-color: var(--color-success-border);
+    background: color-mix(in srgb, var(--color-success-bg) 35%, var(--color-surface));
+  }
+
+  .action-card__label,
+  .action-card__count,
+  .action-card__empty,
+  .dashboard-streak {
+    margin: 0;
+  }
+
+  .action-card__label {
+    font-family: var(--font-ui);
+    font-size: var(--font-size-ui);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
+    color: var(--color-text-secondary);
+  }
+
+  .action-card__count {
+    font-size: clamp(3rem, 10vw, 4.5rem);
+    line-height: 1;
+    letter-spacing: var(--tracking-heading);
+  }
+
+  .action-card__cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    inline-size: fit-content;
+    min-block-size: 2.75rem;
+    padding-block: var(--space-3);
+    padding-inline: var(--space-4);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-raised);
+    color: var(--color-text-primary);
+    text-decoration: none;
+    font-family: var(--font-ui);
+    font-weight: 600;
+  }
+
+  .action-card__empty {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-h4);
+  }
+
+  .dashboard-streak {
+    font-family: var(--font-ui);
+    font-size: var(--font-size-h4);
+  }
+
+  .dashboard-streak--empty {
+    color: var(--color-text-muted);
+  }
+
+  .quick-access {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+  }
+
+  .quick-access__link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-block-size: 2.75rem;
+    padding-block: var(--space-3);
+    padding-inline: var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text-primary);
+    font-family: var(--font-ui);
     text-decoration: none;
   }
 
-  .dashboard-card:focus-visible {
+  .action-card__cta:focus-visible,
+  .quick-access__link:focus-visible {
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
+  }
+
+  @media (max-width: 48rem) {
+    .dashboard-page {
+      padding-inline: var(--space-4);
+    }
+
+    .dashboard-widgets {
+      grid-template-columns: 1fr;
+    }
+
+    .quick-access {
+      flex-direction: column;
+    }
   }
 </style>

--- a/apps/web/src/routes/onboarding/+page.server.ts
+++ b/apps/web/src/routes/onboarding/+page.server.ts
@@ -1,0 +1,78 @@
+import { fail, redirect } from '@sveltejs/kit';
+import { addStudyLanguage, getDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import { getLanguageByCode, SUPPORTED_LANGUAGES } from '$lib/config/languages.js';
+import { loadActiveStudyLanguages, resolveAuthenticatedHomepage } from '$lib/server/homepage.js';
+import type { Actions, PageServerLoad } from './$types.js';
+
+export const load: PageServerLoad = async (event) => {
+  const { session } = await event.parent();
+
+  if (!session?.user?.id) {
+    throw redirect(303, '/');
+  }
+
+  const database = getDb(env.DATABASE_URL);
+  const activeLanguages = await loadActiveStudyLanguages(session.user.id, database);
+
+  if (activeLanguages.length > 0) {
+    throw redirect(303, resolveAuthenticatedHomepage(activeLanguages));
+  }
+
+  return {
+    supportedLanguages: SUPPORTED_LANGUAGES,
+  };
+};
+
+export const actions: Actions = {
+  default: async (event) => {
+    const session = await event.locals.auth();
+
+    if (!session?.user?.id) {
+      throw redirect(303, '/');
+    }
+
+    const formData = await event.request.formData();
+    const selectedLanguages = Array.from(
+      new Set(
+        formData
+          .getAll('languages')
+          .map((value) => value.toString())
+          .filter((value) => getLanguageByCode(value))
+      )
+    );
+
+    if (selectedLanguages.length === 0) {
+      return fail(400, {
+        error: 'Select at least one language to continue.',
+        selectedLanguages,
+      });
+    }
+
+    const database = getDb(env.DATABASE_URL);
+    const activeLanguages = await loadActiveStudyLanguages(session.user.id, database);
+
+    if (activeLanguages.length > 0) {
+      throw redirect(303, resolveAuthenticatedHomepage(activeLanguages));
+    }
+
+    for (const languageCode of selectedLanguages) {
+      const language = getLanguageByCode(languageCode);
+
+      if (!language) {
+        continue;
+      }
+
+      await addStudyLanguage(
+        {
+          userId: session.user.id,
+          languageId: language.code,
+          languageName: language.label,
+        },
+        database as never
+      );
+    }
+
+    throw redirect(303, `/${selectedLanguages[0]}/`);
+  },
+};

--- a/apps/web/src/routes/onboarding/+page.svelte
+++ b/apps/web/src/routes/onboarding/+page.svelte
@@ -1,0 +1,288 @@
+<script lang="ts">
+  import type { ActionData, PageData } from './$types.js';
+
+  export let data: PageData;
+  export let form: ActionData;
+
+  let selectedLanguages = form?.selectedLanguages ?? [];
+
+  $: if (form?.selectedLanguages) {
+    selectedLanguages = form.selectedLanguages;
+  }
+
+  function getInitials() {
+    const source = data.session?.user?.name ?? data.session?.user?.email ?? 'StudyPuck';
+
+    return source
+      .split(/\s+/)
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((part) => part[0]?.toUpperCase())
+      .join('');
+  }
+</script>
+
+<svelte:head>
+  <title>Onboarding - StudyPuck</title>
+</svelte:head>
+
+<div class="onboarding-shell">
+  <header class="onboarding-topbar">
+    <div class="center onboarding-topbar__inner cluster">
+      <a class="brand cluster" href="/" aria-label="StudyPuck home">
+        <span class="brand__mark" aria-hidden="true">◉</span>
+        <span class="brand__name">StudyPuck</span>
+      </a>
+
+      <div class="avatar-badge" aria-label="Signed in account">
+        {#if data.session?.user?.image}
+          <img src={data.session.user.image} alt="" class="avatar-image" />
+        {:else}
+          <span>{getInitials()}</span>
+        {/if}
+      </div>
+    </div>
+  </header>
+
+  <main class="center onboarding-page">
+    <section class="onboarding-panel stack">
+      <header class="stack onboarding-copy">
+        <h1>Welcome to StudyPuck</h1>
+        <p class="text-muted">Choose a language to get started</p>
+      </header>
+
+      {#if form?.error}
+        <p class="onboarding-error" role="alert">{form.error}</p>
+      {/if}
+
+      <form method="POST" class="stack onboarding-form">
+        <div class="language-grid" role="group" aria-labelledby="language-choice-heading">
+          <span id="language-choice-heading" class="visually-hidden">Study languages</span>
+
+          {#each data.supportedLanguages as language}
+            <label class="language-tile">
+              <input
+                bind:group={selectedLanguages}
+                class="visually-hidden language-tile__input"
+                type="checkbox"
+                name="languages"
+                value={language.code}
+              />
+
+              <span class="language-tile__surface">
+                <span class="language-tile__mark" aria-hidden="true">
+                  {#if language.code === 'zh'}
+                    🇨🇳
+                  {:else if language.code === 'es'}
+                    🇪🇸
+                  {:else if language.code === 'nl'}
+                    🇳🇱
+                  {:else}
+                    🌐
+                  {/if}
+                </span>
+                <span class="language-tile__name">{language.label}</span>
+                {#if language.nativeLabel}
+                  <span class="language-tile__native">{language.nativeLabel}</span>
+                {/if}
+              </span>
+            </label>
+          {/each}
+        </div>
+
+        <button class="onboarding-cta" type="submit" disabled={selectedLanguages.length === 0}>
+          Get Started <span aria-hidden="true">→</span>
+        </button>
+      </form>
+    </section>
+  </main>
+</div>
+
+<style>
+  .onboarding-shell {
+    min-block-size: 100vh;
+  }
+
+  .onboarding-topbar {
+    border-block-end: 1px solid var(--color-border);
+    background: color-mix(in srgb, var(--color-background) 88%, transparent);
+    backdrop-filter: blur(10px);
+  }
+
+  .onboarding-topbar__inner {
+    justify-content: space-between;
+    min-block-size: 3.75rem;
+    --center-max: 72rem;
+    --cluster-space: var(--space-4);
+  }
+
+  .brand {
+    color: var(--color-text-primary);
+    text-decoration: none;
+    --cluster-space: var(--space-3);
+  }
+
+  .brand__name {
+    font-family: var(--font-heading);
+    font-size: var(--font-size-h4);
+  }
+
+  .avatar-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    inline-size: 2.75rem;
+    block-size: 2.75rem;
+    overflow: hidden;
+    border-radius: 50%;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text-primary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-ui);
+    font-weight: 700;
+  }
+
+  .avatar-image {
+    inline-size: 100%;
+    block-size: 100%;
+    object-fit: cover;
+  }
+
+  .onboarding-page {
+    display: grid;
+    place-items: center;
+    min-block-size: calc(100vh - 3.75rem);
+    padding-block: var(--space-8);
+    padding-inline: var(--space-5);
+    --center-max: 72rem;
+  }
+
+  .onboarding-panel,
+  .onboarding-copy,
+  .onboarding-form {
+    --stack-space: var(--space-5);
+  }
+
+  .onboarding-panel {
+    inline-size: min(100%, 52rem);
+    text-align: center;
+  }
+
+  .onboarding-copy h1,
+  .onboarding-copy p {
+    margin: 0;
+  }
+
+  .onboarding-copy p {
+    font-size: var(--font-size-h4);
+  }
+
+  .onboarding-error {
+    margin: 0;
+    padding: var(--space-3) var(--space-4);
+    border: 1px solid var(--color-error-border);
+    border-radius: var(--radius-md);
+    background: var(--color-error-bg);
+    color: var(--color-error-text);
+    font-family: var(--font-ui);
+    text-align: start;
+  }
+
+  .language-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+    gap: var(--space-4);
+  }
+
+  .language-tile {
+    display: block;
+  }
+
+  .language-tile__surface {
+    display: grid;
+    gap: var(--space-2);
+    min-block-size: 13rem;
+    padding: var(--space-5);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+    box-shadow: var(--shadow-sm);
+    place-items: center;
+    text-align: center;
+    transition:
+      border-color 160ms ease,
+      background-color 160ms ease,
+      transform 160ms ease,
+      box-shadow 160ms ease;
+  }
+
+  .language-tile__input:focus-visible + .language-tile__surface {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  .language-tile__input:checked + .language-tile__surface {
+    border-color: var(--color-primary);
+    background: var(--color-primary-subtle);
+    color: var(--color-primary-text);
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+  }
+
+  .language-tile__mark {
+    font-size: 2.5rem;
+  }
+
+  .language-tile__name {
+    font-family: var(--font-ui);
+    font-size: var(--font-size-h4);
+    font-weight: 600;
+  }
+
+  .language-tile__native {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-small);
+  }
+
+  .language-tile__input:checked + .language-tile__surface .language-tile__native {
+    color: currentColor;
+  }
+
+  .onboarding-cta {
+    justify-self: center;
+    min-inline-size: 12rem;
+    min-block-size: 2.75rem;
+    padding-block: var(--space-3);
+    padding-inline: var(--space-5);
+    border: 1px solid var(--color-primary);
+    border-radius: var(--radius-md);
+    background: var(--color-primary);
+    color: var(--color-text-inverse);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-ui);
+    font-weight: 600;
+  }
+
+  .onboarding-cta:disabled {
+    border-color: var(--color-border);
+    background: var(--color-surface-subtle);
+    color: var(--color-text-disabled);
+    cursor: not-allowed;
+  }
+
+  @media (max-width: 40rem) {
+    .onboarding-page {
+      padding-inline: var(--space-4);
+    }
+
+    .language-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .language-tile__surface {
+      min-block-size: 11rem;
+      padding: var(--space-4);
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- replace the placeholder landing page with the storyboard-based logged-out homepage
- add first-login onboarding at /onboarding backed by real study-language persistence
- add the returning-user dashboard flow, real counts/streak helpers, and configured-language switching

Closes #69