### PR TITLE
Polish mini-app placeholder pages

### DIFF
--- a/apps/web/src/lib/components/MiniAppPlaceholder.svelte
+++ b/apps/web/src/lib/components/MiniAppPlaceholder.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+  export let title: string;
+  export let description: string;
+  export let routePath: string;
+  export let commandContext: string;
+  export let milestoneNote = 'Coming in Milestone 2.x';
+  export let plannedExperience: string[] = [];
+  export let accent: 'entry' | 'review' | 'drills' = 'entry';
+</script>
+
+<section class={`center stack placeholder-page placeholder-page--${accent}`}>
+  <header class="stack placeholder-page__header">
+    <p class="placeholder-page__eyebrow text-muted">Mini-app</p>
+    <h1>{title}</h1>
+    <p class="placeholder-page__summary">{description}</p>
+  </header>
+
+  <div class="cluster placeholder-page__meta" aria-label="Page metadata">
+    <p class="placeholder-chip">{routePath}</p>
+    <p class="placeholder-chip">Command bar context: {commandContext}</p>
+    <p class="placeholder-chip placeholder-chip--accent">{milestoneNote}</p>
+  </div>
+
+  <div class="placeholder-page__layout">
+    <section class="placeholder-preview stack" aria-label={`${title} preview`}>
+      <slot name="preview" />
+    </section>
+
+    <aside class="placeholder-notes stack">
+      <div class="stack placeholder-notes__section">
+        <h2>Planned experience</h2>
+        <ul class="placeholder-list">
+          {#each plannedExperience as item}
+            <li>{item}</li>
+          {/each}
+        </ul>
+      </div>
+
+      <div class="placeholder-note">
+        <p>This screen is intentionally polished now so navigation, context, and shell behavior feel complete before the working workflows arrive.</p>
+      </div>
+    </aside>
+  </div>
+</section>
+
+<style>
+  .placeholder-page {
+    --center-max: 72rem;
+    padding-inline: var(--space-5);
+    padding-block: var(--space-5);
+    --stack-space: var(--space-5);
+  }
+
+  .placeholder-page__header {
+    max-inline-size: 46rem;
+    --stack-space: var(--space-2);
+  }
+
+  .placeholder-page__eyebrow,
+  .placeholder-page__summary,
+  .placeholder-page__header h1,
+  .placeholder-note p {
+    margin: 0;
+  }
+
+  .placeholder-page__eyebrow {
+    font-family: var(--font-ui);
+    font-size: var(--font-size-ui);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .placeholder-page__summary {
+    color: var(--color-text-secondary);
+    max-inline-size: var(--measure-body);
+  }
+
+  .placeholder-page__meta {
+    gap: var(--space-2);
+    align-items: center;
+  }
+
+  .placeholder-chip {
+    margin: 0;
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-caption);
+  }
+
+  .placeholder-chip--accent {
+    border-color: var(--placeholder-accent-border);
+    background: var(--placeholder-accent-bg);
+    color: var(--placeholder-accent-text);
+  }
+
+  .placeholder-page__layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1.5fr) minmax(18rem, 24rem);
+    gap: var(--space-5);
+    align-items: start;
+  }
+
+  .placeholder-preview,
+  .placeholder-notes {
+    padding: var(--space-5);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .placeholder-preview {
+    min-block-size: 26rem;
+    --stack-space: var(--space-4);
+  }
+
+  .placeholder-notes,
+  .placeholder-notes__section {
+    --stack-space: var(--space-4);
+  }
+
+  .placeholder-notes h2,
+  .placeholder-note p {
+    font-size: var(--font-size-h4);
+  }
+
+  .placeholder-notes h2,
+  .placeholder-list {
+    margin: 0;
+  }
+
+  .placeholder-list {
+    padding-inline-start: 1.25rem;
+    color: var(--color-text-secondary);
+  }
+
+  .placeholder-note {
+    padding: var(--space-4);
+    border: 1px solid var(--placeholder-accent-border);
+    border-radius: var(--radius-md);
+    background: var(--placeholder-accent-bg);
+    color: var(--placeholder-accent-text);
+  }
+
+  .placeholder-page--entry {
+    --placeholder-accent-border: var(--color-success-border);
+    --placeholder-accent-bg: color-mix(in srgb, var(--color-success-bg) 70%, var(--color-surface));
+    --placeholder-accent-text: var(--color-success-text);
+  }
+
+  .placeholder-page--review {
+    --placeholder-accent-border: var(--color-info-border);
+    --placeholder-accent-bg: color-mix(in srgb, var(--color-info-bg) 70%, var(--color-surface));
+    --placeholder-accent-text: var(--color-info-text);
+  }
+
+  .placeholder-page--drills {
+    --placeholder-accent-border: var(--color-primary);
+    --placeholder-accent-bg: var(--color-primary-subtle);
+    --placeholder-accent-text: var(--color-primary-text);
+  }
+
+  @media (max-width: 64rem) {
+    .placeholder-page__layout {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  @media (max-width: 48rem) {
+    .placeholder-page {
+      padding-inline: var(--space-4);
+    }
+  }
+</style>

--- a/apps/web/src/routes/[lang]/card-entry/+page.svelte
+++ b/apps/web/src/routes/[lang]/card-entry/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import MiniAppPlaceholder from '$lib/components/MiniAppPlaceholder.svelte';
   import { page } from '$app/stores';
 </script>
 
@@ -6,27 +7,139 @@
   <title>Card Entry – StudyPuck</title>
 </svelte:head>
 
-<section class="center stack app-screen" style="--stack-space: var(--space-5)">
-  <header class="stack" style="--stack-space: var(--space-2)">
-    <p class="screen-eyebrow text-muted">Mini-app</p>
-    <h1>Card Entry</h1>
-    <p>
-      This placeholder inbox route establishes the permanent shell and URL structure for
-      /{$page.params.lang}/card-entry.
-    </p>
-  </header>
-</section>
+<MiniAppPlaceholder
+  title="Card Entry"
+  accent="entry"
+  routePath={`/${$page.params.lang}/card-entry`}
+  commandContext="Card Entry"
+  description="Capture rough vocabulary notes quickly, then come back for a calmer pass that turns them into structured study cards."
+  plannedExperience={[
+    'An inbox of unprocessed notes ordered for focused cleanup time.',
+    'Fast capture from anywhere in the app through quick-add and command-bar entry.',
+    'A dedicated processing workspace for creating draft or active cards from one note.'
+  ]}
+>
+  <div slot="preview" class="entry-preview stack">
+    <div class="entry-preview__capture cluster">
+      <div class="entry-preview__capture-input">Quick capture a word, phrase, or sentence...</div>
+      <div class="entry-preview__capture-button">Add</div>
+    </div>
+
+    <div class="entry-preview__badge">Inbox • 12 notes waiting</div>
+
+    <article class="entry-note stack">
+      <div class="cluster entry-note__meta">
+        <p>Newest note</p>
+        <span>2m ago</span>
+      </div>
+      <p class="entry-note__content">“to make up for lost time”</p>
+      <div class="cluster entry-note__actions">
+        <span>Process</span>
+        <span>Defer</span>
+        <span>Delete</span>
+      </div>
+    </article>
+
+    <article class="entry-note entry-note--muted stack">
+      <div class="cluster entry-note__meta">
+        <p>Processing workspace</p>
+        <span>draft mode</span>
+      </div>
+      <p class="entry-note__content">One source note, multiple structured cards, optional AI help.</p>
+    </article>
+  </div>
+</MiniAppPlaceholder>
 
 <style>
-  .app-screen {
-    --center-max: 60rem;
-    padding-inline: var(--space-5);
+  .entry-preview {
+    --stack-space: var(--space-4);
   }
 
-  .screen-eyebrow {
+  .entry-preview__capture,
+  .entry-note__meta,
+  .entry-note__actions {
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  .entry-preview__capture-input,
+  .entry-preview__capture-button,
+  .entry-preview__badge,
+  .entry-note {
+    border-radius: var(--radius-md);
     font-family: var(--font-ui);
-    font-size: var(--font-size-ui);
+  }
+
+  .entry-preview__capture-input {
+    flex: 1;
+    min-block-size: 2.75rem;
+    padding: var(--space-3);
+    border: 1px solid var(--color-border);
+    background: var(--color-surface-subtle);
+    color: var(--color-text-muted);
+  }
+
+  .entry-preview__capture-button {
+    min-inline-size: 4.5rem;
+    min-block-size: 2.75rem;
+    padding: var(--space-3);
+    border: 1px solid var(--color-success-border);
+    background: var(--color-success-bg);
+    color: var(--color-success-text);
+    text-align: center;
+  }
+
+  .entry-preview__badge {
+    inline-size: fit-content;
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--color-success-border);
+    background: color-mix(in srgb, var(--color-success-bg) 60%, var(--color-surface));
+    color: var(--color-success-text);
+    font-size: var(--font-size-caption);
     letter-spacing: var(--tracking-caps);
     text-transform: uppercase;
+  }
+
+  .entry-note {
+    padding: var(--space-4);
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    box-shadow: var(--shadow-sm);
+    --stack-space: var(--space-3);
+  }
+
+  .entry-note--muted {
+    background: var(--color-surface-subtle);
+  }
+
+  .entry-note__meta p,
+  .entry-note__content {
+    margin: 0;
+  }
+
+  .entry-note__meta {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-caption);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-caps);
+  }
+
+  .entry-note__content {
+    font-size: var(--font-size-h4);
+  }
+
+  .entry-note__actions {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-small);
+  }
+
+  @media (max-width: 40rem) {
+    .entry-preview__capture,
+    .entry-note__meta,
+    .entry-note__actions {
+      align-items: stretch;
+      flex-direction: column;
+    }
   }
 </style>

--- a/apps/web/src/routes/[lang]/card-review/+page.svelte
+++ b/apps/web/src/routes/[lang]/card-review/+page.svelte
@@ -1,25 +1,120 @@
+<script lang="ts">
+  import MiniAppPlaceholder from '$lib/components/MiniAppPlaceholder.svelte';
+  import { page } from '$app/stores';
+</script>
+
 <svelte:head>
   <title>Card Review – StudyPuck</title>
 </svelte:head>
 
-<section class="center stack app-screen" style="--stack-space: var(--space-5)">
-  <header class="stack" style="--stack-space: var(--space-2)">
-    <p class="screen-eyebrow text-muted">Mini-app</p>
-    <h1>Card Review</h1>
-    <p>This placeholder route gives the global shell a real review destination and active state.</p>
-  </header>
-</section>
+<MiniAppPlaceholder
+  title="Card Review"
+  accent="review"
+  routePath={`/${$page.params.lang}/card-review`}
+  commandContext="Card Review"
+  description="Run deliberate spaced-repetition sessions with typography-forward cards, subtle progress, and fast review actions."
+  plannedExperience={[
+    'A focused setup screen for choosing what is due and how much to review.',
+    'A distraction-light review card with excellent readability for CJK and longer notes.',
+    'Fast rating controls for easy, medium, and hard without fumbling for the interface.'
+  ]}
+>
+  <div slot="preview" class="review-preview stack">
+    <div class="review-preview__status cluster">
+      <p>Due today</p>
+      <span>18 cards</span>
+    </div>
+
+    <article class="review-card stack">
+      <p class="review-card__eyebrow">Current card</p>
+      <h2>补偿</h2>
+      <p>to make up for / to compensate</p>
+      <p class="review-card__example">Example: 我们以后再补偿这次错过的时间。</p>
+    </article>
+
+    <div class="review-actions cluster">
+      <span class="review-actions__pill">Easy</span>
+      <span class="review-actions__pill">Medium</span>
+      <span class="review-actions__pill">Hard</span>
+    </div>
+  </div>
+</MiniAppPlaceholder>
 
 <style>
-  .app-screen {
-    --center-max: 60rem;
-    padding-inline: var(--space-5);
+  .review-preview,
+  .review-card {
+    --stack-space: var(--space-4);
   }
 
-  .screen-eyebrow {
+  .review-preview__status,
+  .review-actions {
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  .review-preview__status,
+  .review-actions__pill,
+  .review-card {
     font-family: var(--font-ui);
-    font-size: var(--font-size-ui);
+  }
+
+  .review-preview__status {
+    color: var(--color-info-text);
+    font-size: var(--font-size-caption);
     letter-spacing: var(--tracking-caps);
     text-transform: uppercase;
+  }
+
+  .review-preview__status p {
+    margin: 0;
+  }
+
+  .review-card {
+    padding: var(--space-5);
+    border: 1px solid var(--color-info-border);
+    border-radius: var(--radius-lg);
+    background: color-mix(in srgb, var(--color-info-bg) 55%, var(--color-surface));
+    box-shadow: var(--shadow-sm);
+  }
+
+  .review-card__eyebrow,
+  .review-card p,
+  .review-card h2 {
+    margin: 0;
+  }
+
+  .review-card__eyebrow {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-caption);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .review-card h2 {
+    font-size: clamp(2.25rem, 8vw, 3.25rem);
+    line-height: var(--leading-tight);
+  }
+
+  .review-card__example {
+    color: var(--color-text-secondary);
+  }
+
+  .review-actions__pill {
+    flex: 1;
+    min-block-size: 2.75rem;
+    padding: var(--space-3);
+    border: 1px solid var(--color-info-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text-primary);
+    text-align: center;
+    font-size: var(--font-size-ui);
+  }
+
+  @media (max-width: 40rem) {
+    .review-actions {
+      flex-direction: column;
+    }
   }
 </style>

--- a/apps/web/src/routes/[lang]/translation-drills/+page.svelte
+++ b/apps/web/src/routes/[lang]/translation-drills/+page.svelte
@@ -1,25 +1,117 @@
+<script lang="ts">
+  import MiniAppPlaceholder from '$lib/components/MiniAppPlaceholder.svelte';
+  import { page } from '$app/stores';
+</script>
+
 <svelte:head>
   <title>Translation Drills – StudyPuck</title>
 </svelte:head>
 
-<section class="center stack app-screen" style="--stack-space: var(--space-5)">
-  <header class="stack" style="--stack-space: var(--space-2)">
-    <p class="screen-eyebrow text-muted">Mini-app</p>
-    <h1>Translation Drills</h1>
-    <p>This placeholder route anchors the shell’s drills navigation while the full workflow is built.</p>
-  </header>
-</section>
+<MiniAppPlaceholder
+  title="Translation Drills"
+  accent="drills"
+  routePath={`/${$page.params.lang}/translation-drills`}
+  commandContext="Translation Drills"
+  description="Practice translation in an AI-guided conversation while keeping the relevant card context close at hand."
+  plannedExperience={[
+    'A chat-like drill with the current sentence prompt visually separated from feedback.',
+    'A context panel for drawing, snoozing, and dismissing cards without leaving the drill.',
+    'Scheduling decisions that feel human-readable instead of cryptic SRS jargon.'
+  ]}
+>
+  <div slot="preview" class="drills-preview stack">
+    <article class="drill-message drill-message--assistant stack">
+      <p class="drill-message__label">Prompt</p>
+      <p>Translate into Chinese: “We should make up for the time we lost.”</p>
+    </article>
+
+    <article class="drill-message drill-message--user stack">
+      <p class="drill-message__label">Your translation</p>
+      <p>我们应该补偿失去的时间。</p>
+    </article>
+
+    <div class="drills-context stack">
+      <div class="cluster drills-context__header">
+        <p>Active context</p>
+        <span>3 cards</span>
+      </div>
+      <div class="cluster drills-context__pills">
+        <span>补偿</span>
+        <span>失去</span>
+        <span>时间</span>
+      </div>
+    </div>
+  </div>
+</MiniAppPlaceholder>
 
 <style>
-  .app-screen {
-    --center-max: 60rem;
-    padding-inline: var(--space-5);
+  .drills-preview,
+  .drill-message,
+  .drills-context {
+    --stack-space: var(--space-3);
   }
 
-  .screen-eyebrow {
+  .drill-message {
+    padding: var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .drill-message--assistant {
+    border-color: var(--color-primary);
+    background: var(--color-primary-subtle);
+  }
+
+  .drill-message--user {
+    margin-inline-start: var(--space-7);
+  }
+
+  .drill-message p,
+  .drills-context__header p {
+    margin: 0;
+  }
+
+  .drill-message__label,
+  .drills-context__header {
     font-family: var(--font-ui);
-    font-size: var(--font-size-ui);
+    font-size: var(--font-size-caption);
     letter-spacing: var(--tracking-caps);
     text-transform: uppercase;
+    color: var(--color-text-secondary);
+  }
+
+  .drills-context {
+    padding: var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-subtle);
+  }
+
+  .drills-context__header,
+  .drills-context__pills {
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2);
+  }
+
+  .drills-context__pills {
+    flex-wrap: wrap;
+  }
+
+  .drills-context__pills span {
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+  }
+
+  @media (max-width: 40rem) {
+    .drill-message--user {
+      margin-inline-start: 0;
+    }
   }
 </style>


### PR DESCRIPTION
## Summary
- add a shared polished placeholder component for mini-app routes
- redesign the card entry, card review, and translation drills placeholder pages with distinct previews
- keep the authenticated shell, command context, and route structure intact while making the placeholders feel intentional

Closes #71