### PR TITLE
fix: guard e2e env lookup in production

### DIFF
--- a/apps/web/src/lib/server/e2e-auth.ts
+++ b/apps/web/src/lib/server/e2e-auth.ts
@@ -11,8 +11,16 @@ type E2ESessionPayload = {
 	image?: string | null;
 };
 
+function getProcessEnvValue(name: string) {
+	if (typeof process === 'undefined') {
+		return undefined;
+	}
+
+	return process.env?.[name];
+}
+
 export function isE2ETestModeEnabled() {
-	return process.env.E2E_TEST_MODE === 'enabled';
+	return getProcessEnvValue('E2E_TEST_MODE') === 'enabled';
 }
 
 export function isE2ETestRequestAllowed(event: Pick<RequestEvent, 'url'>) {


### PR DESCRIPTION
## Summary
- make the e2e test-mode env lookup safe when process is unavailable in the production runtime
- keep the e2e session harness disabled by default outside explicit test mode

## Validation
- pnpm turbo lint check-types test build --filter=web

## Context
- addresses the production deploy regression after #113