### PR TITLE
feat: add Card Entry backend foundation

### DIFF
--- a/apps/web/src/lib/server/homepage.ts
+++ b/apps/web/src/lib/server/homepage.ts
@@ -4,8 +4,8 @@ import {
   cardReviewDailyStats,
   cardReviewSrs,
   getDb,
+  getCardEntryCounts,
   getActiveUserLanguages,
-  inboxNotes,
   translationDrillDailyStats,
   type StudyLanguage,
 } from '@studypuck/database';
@@ -52,7 +52,7 @@ export async function loadDashboardStats(
 ): Promise<DashboardStats> {
   const nowEpochSeconds = Math.floor(Date.now() / 1000);
 
-  const [reviewDueResult, inboxResult, entryActivity, reviewActivity, drillActivity] = await Promise.all([
+  const [reviewDueResult, cardEntryCounts, entryActivity, reviewActivity, drillActivity] = await Promise.all([
     database
       .select({ count: sql<number>`count(*)` })
       .from(cardReviewSrs)
@@ -63,16 +63,7 @@ export async function loadDashboardStats(
           lte(cardReviewSrs.nextDue, nowEpochSeconds)
         )
       ),
-    database
-      .select({ count: sql<number>`count(*)` })
-      .from(inboxNotes)
-      .where(
-        and(
-          eq(inboxNotes.userId, userId),
-          eq(inboxNotes.languageId, languageId),
-          eq(inboxNotes.state, 'unprocessed')
-        )
-      ),
+    getCardEntryCounts(userId, languageId, database as never),
     database
       .select({ date: cardEntryDailyStats.date })
       .from(cardEntryDailyStats)
@@ -118,7 +109,7 @@ export async function loadDashboardStats(
 
   return {
     reviewDueCount: Number(reviewDueResult[0]?.count ?? 0),
-    inboxNoteCount: Number(inboxResult[0]?.count ?? 0),
+    inboxNoteCount: cardEntryCounts.unprocessedNoteCount,
     streakDays,
   };
 }

--- a/packages/database/migrations/0006_absent_dark_phoenix.sql
+++ b/packages/database/migrations/0006_absent_dark_phoenix.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "inbox_notes" ADD COLUMN "ai_state" text DEFAULT 'complete';--> statement-breakpoint
+CREATE INDEX "idx_inbox_ai_state" ON "inbox_notes" USING btree ("user_id","language_id","ai_state","created_at");

--- a/packages/database/migrations/meta/0006_snapshot.json
+++ b/packages/database/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1819 @@
+{
+  "id": "8ef25aa3-96df-4314-8ebc-7eca5860e5ff",
+  "prevId": "8a09ba4a-a81b-4af7-a99a-66857ecc6b5e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.study_languages": {
+      "name": "study_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_name": {
+          "name": "language_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "cefr_level": {
+          "name": "cefr_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'A1'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "study_languages_user_id_language_id_pk": {
+          "name": "study_languages_user_id_language_id_pk",
+          "columns": [
+            "user_id",
+            "language_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.card_groups": {
+      "name": "card_groups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_card_groups_by_group": {
+          "name": "idx_card_groups_by_group",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_card_groups_by_card": {
+          "name": "idx_card_groups_by_card",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "card_groups_user_id_language_id_card_id_group_id_pk": {
+          "name": "card_groups_user_id_language_id_card_id_group_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "card_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cards": {
+      "name": "cards",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "card_type": {
+          "name": "card_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'word'"
+        },
+        "meaning": {
+          "name": "meaning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "examples": {
+          "name": "examples",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mnemonics": {
+          "name": "mnemonics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llm_instructions": {
+          "name": "llm_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_generated_at": {
+          "name": "embedding_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cards_status_type": {
+          "name": "idx_cards_status_type",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "card_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cards_status_updated": {
+          "name": "idx_cards_status_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cards_embedding_similarity": {
+          "name": "idx_cards_embedding_similarity",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "idx_cards_active_type": {
+          "name": "idx_cards_active_type",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "card_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cards_active_updated": {
+          "name": "idx_cards_active_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cards_fulltext": {
+          "name": "idx_cards_fulltext",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"content\" || ' ' || COALESCE(\"meaning\", '') || ' ' || COALESCE(\"examples\"::text, '') || ' ' || COALESCE(\"mnemonics\"::text, ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_cards_fulltext_simple": {
+          "name": "idx_cards_fulltext_simple",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', \"content\" || ' ' || COALESCE(\"meaning\", '') || ' ' || COALESCE(\"examples\"::text, '') || ' ' || COALESCE(\"mnemonics\"::text, ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "cards_user_id_language_id_card_id_pk": {
+          "name": "cards_user_id_language_id_card_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "card_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_generated_at": {
+          "name": "embedding_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_groups_embedding_similarity": {
+          "name": "idx_groups_embedding_similarity",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "groups_user_id_language_id_group_id_pk": {
+          "name": "groups_user_id_language_id_group_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.card_entry_daily_stats": {
+      "name": "card_entry_daily_stats",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes_captured": {
+          "name": "notes_captured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "notes_processed": {
+          "name": "notes_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "notes_deferred": {
+          "name": "notes_deferred",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "notes_deleted": {
+          "name": "notes_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "draft_cards_created": {
+          "name": "draft_cards_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_promoted_to_active": {
+          "name": "cards_promoted_to_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "groups_created": {
+          "name": "groups_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_card_entry_stats_date": {
+          "name": "idx_card_entry_stats_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "card_entry_daily_stats_user_id_language_id_date_pk": {
+          "name": "card_entry_daily_stats_user_id_language_id_date_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_notes": {
+      "name": "inbox_notes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unprocessed'"
+        },
+        "ai_state": {
+          "name": "ai_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'complete'"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'manual'"
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_inbox_state": {
+          "name": "idx_inbox_state",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbox_ai_state": {
+          "name": "idx_inbox_ai_state",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ai_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbox_source": {
+          "name": "idx_inbox_source",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inbox_notes_user_id_language_id_note_id_pk": {
+          "name": "inbox_notes_user_id_language_id_note_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "note_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_card_links": {
+      "name": "note_card_links",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_note_card_links_note": {
+          "name": "idx_note_card_links_note",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_note_card_links_card": {
+          "name": "idx_note_card_links_card",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "note_card_links_user_id_language_id_note_id_card_id_pk": {
+          "name": "note_card_links_user_id_language_id_note_id_card_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "note_id",
+            "card_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.card_review_daily_stats": {
+      "name": "card_review_daily_stats",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cards_reviewed": {
+          "name": "cards_reviewed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "total_review_time_minutes": {
+          "name": "total_review_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_rated_easy": {
+          "name": "cards_rated_easy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_rated_medium": {
+          "name": "cards_rated_medium",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_rated_hard": {
+          "name": "cards_rated_hard",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_snoozed": {
+          "name": "cards_snoozed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_disabled": {
+          "name": "cards_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_pinned_to_drills": {
+          "name": "cards_pinned_to_drills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_card_review_stats_date": {
+          "name": "idx_card_review_stats_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "card_review_daily_stats_user_id_language_id_date_pk": {
+          "name": "card_review_daily_stats_user_id_language_id_date_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.card_review_srs": {
+      "name": "card_review_srs",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_due": {
+          "name": "next_due",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "interval_days": {
+          "name": "interval_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "ease_factor": {
+          "name": "ease_factor",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2.5
+        },
+        "review_count": {
+          "name": "review_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_reviewed": {
+          "name": "last_reviewed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_card_review_srs_due": {
+          "name": "idx_card_review_srs_due",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_card_review_srs_interval": {
+          "name": "idx_card_review_srs_interval",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "interval_days",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "card_review_srs_user_id_language_id_card_id_pk": {
+          "name": "card_review_srs_user_id_language_id_card_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "card_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_drill_context": {
+      "name": "translation_drill_context",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "added_from": {
+          "name": "added_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "state_until": {
+          "name": "state_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cefr_override": {
+          "name": "cefr_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_translation_context_state": {
+          "name": "idx_translation_context_state",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_context_added": {
+          "name": "idx_translation_context_added",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "added_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_context_rotation": {
+          "name": "idx_translation_context_rotation",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_used",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "translation_drill_context_user_id_language_id_card_id_pk": {
+          "name": "translation_drill_context_user_id_language_id_card_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "card_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_drill_daily_stats": {
+      "name": "translation_drill_daily_stats",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sentences_translated": {
+          "name": "sentences_translated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "total_session_time_minutes": {
+          "name": "total_session_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_dismissed": {
+          "name": "cards_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_snoozed": {
+          "name": "cards_snoozed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_drawn": {
+          "name": "cards_drawn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "new_context_groups_added": {
+          "name": "new_context_groups_added",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_translation_drill_stats_date": {
+          "name": "idx_translation_drill_stats_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "translation_drill_daily_stats_user_id_language_id_date_pk": {
+          "name": "translation_drill_daily_stats_user_id_language_id_date_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_drill_draw_piles": {
+      "name": "translation_drill_draw_piles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "draw_pile_name": {
+          "name": "draw_pile_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pile_size_limit": {
+          "name": "pile_size_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_draw_piles_enabled": {
+          "name": "idx_draw_piles_enabled",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "translation_drill_draw_piles_user_id_language_id_group_id_pk": {
+          "name": "translation_drill_draw_piles_user_id_language_id_group_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_drill_srs": {
+      "name": "translation_drill_srs",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_due": {
+          "name": "next_due",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "interval_days": {
+          "name": "interval_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performance_score": {
+          "name": "performance_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_translation_drill_srs_due": {
+          "name": "idx_translation_drill_srs_due",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "translation_drill_srs_user_id_language_id_card_id_pk": {
+          "name": "translation_drill_srs_user_id_language_id_card_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "card_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1743364800000,
       "tag": "0005_add_mnemonics_to_fulltext_index",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1776140298106,
+      "tag": "0006_absent_dark_phoenix",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -41,6 +41,7 @@
     "./types": "./src/types.ts",
     "./users": "./src/users.ts",
 		"./cards": "./src/cards.ts",
+		"./card-entry": "./src/card-entry.ts",
 		"./test-utils": "./src/test-utils.ts"
 	}
 }

--- a/packages/database/src/card-entry.ts
+++ b/packages/database/src/card-entry.ts
@@ -1,0 +1,672 @@
+import { and, asc, desc, eq, inArray, sql } from 'drizzle-orm';
+import type { PgDatabase } from 'drizzle-orm/pg-core';
+import {
+  cardEntryDailyStats,
+  cards,
+  inboxNotes,
+  noteCardLinks,
+  type Card,
+  type CardEntryDailyStats,
+  type InboxNote,
+  type NewCard,
+  type NewInboxNote,
+} from './schema.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyDb = PgDatabase<any, any, any>;
+type TransactionCapableDb = AnyDb & {
+  transaction: <T>(callback: (tx: AnyDb) => Promise<T>) => Promise<T>;
+};
+
+export type InboxNoteState = 'unprocessed' | 'deferred' | 'processed' | 'deleted';
+export type InboxNoteAiState = 'queued' | 'processing' | 'complete' | 'failed';
+export type InboxSortOrder = 'oldest-first' | 'newest-first';
+
+export type DraftCardSourceNote = Pick<InboxNote, 'noteId' | 'content' | 'state' | 'createdAt'> & {
+  linkedAt: Date | null;
+};
+
+export type DraftCardWithSources = Card & {
+  sourceNotes: DraftCardSourceNote[];
+};
+
+export type NoteWithDraftCards = {
+  note: InboxNote;
+  draftCards: Array<Card & { linkedAt: Date | null }>;
+};
+
+export type CardEntryCounts = {
+  unprocessedNoteCount: number;
+  draftCardCount: number;
+};
+
+export type DeleteInboxNoteResult = {
+  note: InboxNote;
+  softDeletedDraftCardCount: number;
+  preservedLinkedCardCount: number;
+};
+
+export type SignOffNoteResult = {
+  note: InboxNote;
+  promotedCardIds: string[];
+};
+
+type CardEntryStatsIncrements = Partial<{
+  notesCaptured: number;
+  notesProcessed: number;
+  notesDeferred: number;
+  notesDeleted: number;
+  draftCardsCreated: number;
+  cardsPromotedToActive: number;
+  groupsCreated: number;
+}>;
+
+export type CreateInboxNoteInput = Omit<NewInboxNote, 'noteId' | 'createdAt'> & {
+  noteId?: string;
+  aiState?: InboxNoteAiState;
+};
+
+export type CreateDraftCardFromNoteInput = Omit<
+  NewCard,
+  'userId' | 'languageId' | 'cardId' | 'status' | 'createdAt' | 'updatedAt'
+> & {
+  userId: string;
+  languageId: string;
+  noteId: string;
+  cardId?: string;
+};
+
+/** Returns the global lazily-initialised db, importing index only when needed */
+async function globalDb(): Promise<AnyDb> {
+  return (await import('./index.js')).db as AnyDb;
+}
+
+function createId(prefix: string): string {
+  const uuid = globalThis.crypto?.randomUUID?.();
+
+  if (uuid) {
+    return `${prefix}-${uuid}`;
+  }
+
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function getUtcDateKey(date = new Date()): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function normalizeInboxStates(
+  state?: InboxNoteState | InboxNoteState[]
+): InboxNoteState[] {
+  if (!state) {
+    return ['unprocessed'];
+  }
+
+  return Array.isArray(state) ? state : [state];
+}
+
+async function withTransaction<T>(
+  db: AnyDb | undefined,
+  callback: (tx: AnyDb) => Promise<T>
+): Promise<T> {
+  const conn = db ?? await globalDb();
+  const transactionCapableConn = conn as TransactionCapableDb;
+
+  if (typeof transactionCapableConn.transaction !== 'function') {
+    throw new Error('Card Entry operations require transaction support from the database driver');
+  }
+
+  return transactionCapableConn.transaction(callback);
+}
+
+async function incrementCardEntryDailyStats(
+  userId: string,
+  languageId: string,
+  increments: CardEntryStatsIncrements,
+  db: AnyDb
+): Promise<CardEntryDailyStats> {
+  const date = getUtcDateKey();
+  const [existing] = await db
+    .select()
+    .from(cardEntryDailyStats)
+    .where(and(
+      eq(cardEntryDailyStats.userId, userId),
+      eq(cardEntryDailyStats.languageId, languageId),
+      eq(cardEntryDailyStats.date, date)
+    ))
+    .limit(1);
+
+  const nextValues = {
+    notesCaptured: (existing?.notesCaptured ?? 0) + (increments.notesCaptured ?? 0),
+    notesProcessed: (existing?.notesProcessed ?? 0) + (increments.notesProcessed ?? 0),
+    notesDeferred: (existing?.notesDeferred ?? 0) + (increments.notesDeferred ?? 0),
+    notesDeleted: (existing?.notesDeleted ?? 0) + (increments.notesDeleted ?? 0),
+    draftCardsCreated: (existing?.draftCardsCreated ?? 0) + (increments.draftCardsCreated ?? 0),
+    cardsPromotedToActive: (existing?.cardsPromotedToActive ?? 0) + (increments.cardsPromotedToActive ?? 0),
+    groupsCreated: (existing?.groupsCreated ?? 0) + (increments.groupsCreated ?? 0),
+  };
+
+  if (!existing) {
+    const [created] = await db
+      .insert(cardEntryDailyStats)
+      .values({
+        userId,
+        languageId,
+        date,
+        ...nextValues,
+      })
+      .returning();
+
+    return created!;
+  }
+
+  const [updated] = await db
+    .update(cardEntryDailyStats)
+    .set(nextValues)
+    .where(and(
+      eq(cardEntryDailyStats.userId, userId),
+      eq(cardEntryDailyStats.languageId, languageId),
+      eq(cardEntryDailyStats.date, date)
+    ))
+    .returning();
+
+  return updated!;
+}
+
+async function getNoteCardIds(
+  userId: string,
+  languageId: string,
+  noteId: string,
+  db: AnyDb
+): Promise<string[]> {
+  const links = await db
+    .select({ cardId: noteCardLinks.cardId })
+    .from(noteCardLinks)
+    .where(and(
+      eq(noteCardLinks.userId, userId),
+      eq(noteCardLinks.languageId, languageId),
+      eq(noteCardLinks.noteId, noteId)
+    ))
+    .orderBy(asc(noteCardLinks.createdAt));
+
+  return links.map((link) => link.cardId);
+}
+
+export async function createInboxNote(
+  noteData: CreateInboxNoteInput,
+  db?: AnyDb
+): Promise<InboxNote> {
+  return withTransaction(db, async (tx) => {
+    const [created] = await tx
+      .insert(inboxNotes)
+      .values({
+        ...noteData,
+        noteId: noteData.noteId ?? createId('note'),
+        aiState: noteData.aiState ?? 'complete',
+        createdAt: new Date(),
+      })
+      .returning();
+
+    await incrementCardEntryDailyStats(noteData.userId, noteData.languageId, {
+      notesCaptured: 1,
+    }, tx);
+
+    return created!;
+  });
+}
+
+export async function getInboxNote(
+  userId: string,
+  languageId: string,
+  noteId: string,
+  db?: AnyDb
+): Promise<InboxNote | null> {
+  const conn = db ?? await globalDb();
+  const result = await conn
+    .select()
+    .from(inboxNotes)
+    .where(and(
+      eq(inboxNotes.userId, userId),
+      eq(inboxNotes.languageId, languageId),
+      eq(inboxNotes.noteId, noteId)
+    ))
+    .limit(1);
+
+  return result[0] || null;
+}
+
+export async function listInboxNotes(
+  userId: string,
+  languageId: string,
+  options?: {
+    state?: InboxNoteState | InboxNoteState[];
+    sort?: InboxSortOrder;
+    limit?: number;
+    offset?: number;
+  },
+  db?: AnyDb
+): Promise<InboxNote[]> {
+  const conn = db ?? await globalDb();
+  const states = normalizeInboxStates(options?.state);
+  let query = conn
+    .select()
+    .from(inboxNotes)
+    .where(and(
+      eq(inboxNotes.userId, userId),
+      eq(inboxNotes.languageId, languageId),
+      states.length === 1
+        ? eq(inboxNotes.state, states[0])
+        : inArray(inboxNotes.state, states)
+    ))
+    .orderBy(options?.sort === 'newest-first' ? desc(inboxNotes.createdAt) : asc(inboxNotes.createdAt));
+
+  if (typeof options?.offset === 'number') {
+    query = query.offset(options.offset);
+  }
+
+  if (typeof options?.limit === 'number') {
+    query = query.limit(options.limit);
+  }
+
+  return query;
+}
+
+export async function updateInboxNoteAiState(
+  userId: string,
+  languageId: string,
+  noteId: string,
+  aiState: InboxNoteAiState,
+  db?: AnyDb
+): Promise<InboxNote | null> {
+  const conn = db ?? await globalDb();
+  const result = await conn
+    .update(inboxNotes)
+    .set({ aiState })
+    .where(and(
+      eq(inboxNotes.userId, userId),
+      eq(inboxNotes.languageId, languageId),
+      eq(inboxNotes.noteId, noteId)
+    ))
+    .returning();
+
+  return result[0] || null;
+}
+
+export async function deferInboxNote(
+  userId: string,
+  languageId: string,
+  noteId: string,
+  db?: AnyDb
+): Promise<InboxNote | null> {
+  return withTransaction(db, async (tx) => {
+    const result = await tx
+      .update(inboxNotes)
+      .set({ state: 'deferred' })
+      .where(and(
+        eq(inboxNotes.userId, userId),
+        eq(inboxNotes.languageId, languageId),
+        eq(inboxNotes.noteId, noteId)
+      ))
+      .returning();
+
+    const note = result[0] || null;
+
+    if (!note) {
+      return null;
+    }
+
+    await incrementCardEntryDailyStats(userId, languageId, {
+      notesDeferred: 1,
+    }, tx);
+
+    return note;
+  });
+}
+
+export async function createDraftCardFromNote(
+  input: CreateDraftCardFromNoteInput,
+  db?: AnyDb
+): Promise<Card> {
+  return withTransaction(db, async (tx) => {
+    const note = await getInboxNote(input.userId, input.languageId, input.noteId, tx);
+
+    if (!note) {
+      throw new Error(`Inbox note not found: ${input.noteId}`);
+    }
+
+    const { noteId, ...cardData } = input;
+    const cardId = input.cardId ?? createId('card');
+    const now = new Date();
+    const [createdCard] = await tx
+      .insert(cards)
+      .values({
+        ...cardData,
+        cardId,
+        status: 'draft',
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning();
+
+    await tx.insert(noteCardLinks).values({
+      userId: input.userId,
+      languageId: input.languageId,
+      noteId,
+      cardId,
+      createdAt: now,
+    });
+
+    await incrementCardEntryDailyStats(input.userId, input.languageId, {
+      draftCardsCreated: 1,
+    }, tx);
+
+    return createdCard!;
+  });
+}
+
+export async function getNoteWithDraftCards(
+  userId: string,
+  languageId: string,
+  noteId: string,
+  db?: AnyDb
+): Promise<NoteWithDraftCards | null> {
+  const conn = db ?? await globalDb();
+  const note = await getInboxNote(userId, languageId, noteId, conn);
+
+  if (!note) {
+    return null;
+  }
+
+  const links = await conn
+    .select({ cardId: noteCardLinks.cardId, linkedAt: noteCardLinks.createdAt })
+    .from(noteCardLinks)
+    .where(and(
+      eq(noteCardLinks.userId, userId),
+      eq(noteCardLinks.languageId, languageId),
+      eq(noteCardLinks.noteId, noteId)
+    ))
+    .orderBy(asc(noteCardLinks.createdAt));
+
+  const cardIds = links.map((link) => link.cardId);
+
+  if (cardIds.length === 0) {
+    return {
+      note,
+      draftCards: [],
+    };
+  }
+
+  const draftCards = await conn
+    .select()
+    .from(cards)
+    .where(and(
+      eq(cards.userId, userId),
+      eq(cards.languageId, languageId),
+      eq(cards.status, 'draft'),
+      inArray(cards.cardId, cardIds)
+    ));
+
+  const draftCardMap = new Map(draftCards.map((card) => [card.cardId, card]));
+  const orderedDraftCards = links
+    .map((link) => {
+      const card = draftCardMap.get(link.cardId);
+
+      if (!card) {
+        return null;
+      }
+
+      return {
+        ...card,
+        linkedAt: link.linkedAt,
+      };
+    })
+    .filter((card): card is Card & { linkedAt: Date | null } => Boolean(card));
+
+  return {
+    note,
+    draftCards: orderedDraftCards,
+  };
+}
+
+export async function getDraftCardsForLanguage(
+  userId: string,
+  languageId: string,
+  db?: AnyDb
+): Promise<DraftCardWithSources[]> {
+  const conn = db ?? await globalDb();
+  const draftCards = await conn
+    .select()
+    .from(cards)
+    .where(and(
+      eq(cards.userId, userId),
+      eq(cards.languageId, languageId),
+      eq(cards.status, 'draft')
+    ))
+    .orderBy(desc(cards.updatedAt));
+
+  if (draftCards.length === 0) {
+    return [];
+  }
+
+  const cardIds = draftCards.map((card) => card.cardId);
+  const linkRows = await conn
+    .select({
+      cardId: noteCardLinks.cardId,
+      noteId: inboxNotes.noteId,
+      noteContent: inboxNotes.content,
+      noteState: inboxNotes.state,
+      noteCreatedAt: inboxNotes.createdAt,
+      linkedAt: noteCardLinks.createdAt,
+    })
+    .from(noteCardLinks)
+    .innerJoin(inboxNotes, and(
+      eq(inboxNotes.userId, noteCardLinks.userId),
+      eq(inboxNotes.languageId, noteCardLinks.languageId),
+      eq(inboxNotes.noteId, noteCardLinks.noteId)
+    ))
+    .where(and(
+      eq(noteCardLinks.userId, userId),
+      eq(noteCardLinks.languageId, languageId),
+      inArray(noteCardLinks.cardId, cardIds)
+    ))
+    .orderBy(asc(noteCardLinks.createdAt));
+
+  const sourcesByCardId = new Map<string, DraftCardSourceNote[]>();
+
+  for (const row of linkRows) {
+    const existingSources = sourcesByCardId.get(row.cardId) ?? [];
+    existingSources.push({
+      noteId: row.noteId,
+      content: row.noteContent,
+      state: row.noteState,
+      createdAt: row.noteCreatedAt,
+      linkedAt: row.linkedAt,
+    });
+    sourcesByCardId.set(row.cardId, existingSources);
+  }
+
+  return draftCards.map((card) => ({
+    ...card,
+    sourceNotes: sourcesByCardId.get(card.cardId) ?? [],
+  }));
+}
+
+export async function getCardEntryCounts(
+  userId: string,
+  languageId: string,
+  db?: AnyDb
+): Promise<CardEntryCounts> {
+  const conn = db ?? await globalDb();
+  const [unprocessedResult, draftResult] = await Promise.all([
+    conn
+      .select({ count: sql<number>`count(*)` })
+      .from(inboxNotes)
+      .where(and(
+        eq(inboxNotes.userId, userId),
+        eq(inboxNotes.languageId, languageId),
+        eq(inboxNotes.state, 'unprocessed')
+      )),
+    conn
+      .select({ count: sql<number>`count(*)` })
+      .from(cards)
+      .where(and(
+        eq(cards.userId, userId),
+        eq(cards.languageId, languageId),
+        eq(cards.status, 'draft')
+      )),
+  ]);
+
+  return {
+    unprocessedNoteCount: Number(unprocessedResult[0]?.count ?? 0),
+    draftCardCount: Number(draftResult[0]?.count ?? 0),
+  };
+}
+
+export async function signOffNote(
+  userId: string,
+  languageId: string,
+  noteId: string,
+  db?: AnyDb
+): Promise<SignOffNoteResult> {
+  return withTransaction(db, async (tx) => {
+    const note = await getInboxNote(userId, languageId, noteId, tx);
+
+    if (!note) {
+      throw new Error(`Inbox note not found: ${noteId}`);
+    }
+
+    const linkedCardIds = await getNoteCardIds(userId, languageId, noteId, tx);
+
+    if (linkedCardIds.length === 0) {
+      throw new Error(`Cannot sign off note ${noteId} because it has no linked cards`);
+    }
+
+    const linkedDraftCards = await tx
+      .select({ cardId: cards.cardId })
+      .from(cards)
+      .where(and(
+        eq(cards.userId, userId),
+        eq(cards.languageId, languageId),
+        eq(cards.status, 'draft'),
+        inArray(cards.cardId, linkedCardIds)
+      ));
+
+    const draftCardIds = linkedDraftCards.map((card) => card.cardId);
+
+    if (draftCardIds.length === 0) {
+      throw new Error(`Cannot sign off note ${noteId} because it has no linked draft cards`);
+    }
+
+    const now = new Date();
+    await tx
+      .update(cards)
+      .set({
+        status: 'active',
+        updatedAt: now,
+      })
+      .where(and(
+        eq(cards.userId, userId),
+        eq(cards.languageId, languageId),
+        inArray(cards.cardId, draftCardIds)
+      ));
+
+    const noteResult = await tx
+      .update(inboxNotes)
+      .set({ state: 'processed' })
+      .where(and(
+        eq(inboxNotes.userId, userId),
+        eq(inboxNotes.languageId, languageId),
+        eq(inboxNotes.noteId, noteId)
+      ))
+      .returning();
+
+    await incrementCardEntryDailyStats(userId, languageId, {
+      notesProcessed: 1,
+      cardsPromotedToActive: draftCardIds.length,
+    }, tx);
+
+    return {
+      note: noteResult[0]!,
+      promotedCardIds: draftCardIds,
+    };
+  });
+}
+
+export async function deleteInboxNote(
+  userId: string,
+  languageId: string,
+  noteId: string,
+  db?: AnyDb
+): Promise<DeleteInboxNoteResult | null> {
+  return withTransaction(db, async (tx) => {
+    const note = await getInboxNote(userId, languageId, noteId, tx);
+
+    if (!note) {
+      return null;
+    }
+
+    const linkedCardIds = await getNoteCardIds(userId, languageId, noteId, tx);
+    let softDeletedDraftCardCount = 0;
+    let preservedLinkedCardCount = 0;
+
+    if (linkedCardIds.length > 0) {
+      const linkedCards = await tx
+        .select({ cardId: cards.cardId, status: cards.status })
+        .from(cards)
+        .where(and(
+          eq(cards.userId, userId),
+          eq(cards.languageId, languageId),
+          inArray(cards.cardId, linkedCardIds)
+        ));
+
+      const draftCardIds = linkedCards
+        .filter((card) => card.status === 'draft')
+        .map((card) => card.cardId);
+      preservedLinkedCardCount = linkedCards.length - draftCardIds.length;
+
+      if (draftCardIds.length > 0) {
+        const now = new Date();
+        await tx
+          .update(cards)
+          .set({
+            status: 'deleted',
+            deletedAt: now,
+            updatedAt: now,
+          })
+          .where(and(
+            eq(cards.userId, userId),
+            eq(cards.languageId, languageId),
+            inArray(cards.cardId, draftCardIds)
+          ));
+
+        softDeletedDraftCardCount = draftCardIds.length;
+      }
+
+      await tx
+        .delete(noteCardLinks)
+        .where(and(
+          eq(noteCardLinks.userId, userId),
+          eq(noteCardLinks.languageId, languageId),
+          eq(noteCardLinks.noteId, noteId)
+        ));
+    }
+
+    await tx
+      .delete(inboxNotes)
+      .where(and(
+        eq(inboxNotes.userId, userId),
+        eq(inboxNotes.languageId, languageId),
+        eq(inboxNotes.noteId, noteId)
+      ));
+
+    await incrementCardEntryDailyStats(userId, languageId, {
+      notesDeleted: 1,
+    }, tx);
+
+    return {
+      note,
+      softDeletedDraftCardCount,
+      preservedLinkedCardCount,
+    };
+  });
+}

--- a/packages/database/src/card-entry.ts
+++ b/packages/database/src/card-entry.ts
@@ -248,7 +248,7 @@ export async function listInboxNotes(
 ): Promise<InboxNote[]> {
   const conn = db ?? await globalDb();
   const states = normalizeInboxStates(options?.state);
-  let query = conn
+  const query = conn
     .select()
     .from(inboxNotes)
     .where(and(
@@ -260,12 +260,16 @@ export async function listInboxNotes(
     ))
     .orderBy(options?.sort === 'newest-first' ? desc(inboxNotes.createdAt) : asc(inboxNotes.createdAt));
 
-  if (typeof options?.offset === 'number') {
-    query = query.offset(options.offset);
+  if (typeof options?.offset === 'number' && typeof options?.limit === 'number') {
+    return query.offset(options.offset).limit(options.limit);
   }
 
   if (typeof options?.limit === 'number') {
-    query = query.limit(options.limit);
+    return query.limit(options.limit);
+  }
+
+  if (typeof options?.offset === 'number') {
+    return query.offset(options.offset);
   }
 
   return query;

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -104,6 +104,7 @@ export * from './schema.js';
 // Re-export operations modules
 export * from './users.js';
 export * from './cards.js';
+export * from './card-entry.js';
 
 // Re-export relations and types
 // Note: validation schemas are NOT re-exported here to avoid pulling drizzle-zod

--- a/packages/database/src/schema/card-entry.ts
+++ b/packages/database/src/schema/card-entry.ts
@@ -6,12 +6,14 @@ export const inboxNotes = pgTable('inbox_notes', {
   noteId: text('note_id').notNull(),
   content: text('content').notNull(),
   state: text('state').default('unprocessed'),
+  aiState: text('ai_state').default('complete'),
   sourceType: text('source_type').default('manual'),
   sourceMetadata: jsonb('source_metadata'),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
 }, (table) => ({
   pk: primaryKey({ columns: [table.userId, table.languageId, table.noteId] }),
   stateIdx: index('idx_inbox_state').on(table.userId, table.languageId, table.state, table.createdAt),
+  aiStateIdx: index('idx_inbox_ai_state').on(table.userId, table.languageId, table.aiState, table.createdAt),
   sourceIdx: index('idx_inbox_source').on(table.userId, table.languageId, table.sourceType),
 }));
 

--- a/packages/database/src/tests/card-entry.test.ts
+++ b/packages/database/src/tests/card-entry.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import postgres from 'postgres';
+import { eq, and } from 'drizzle-orm';
+import { setupTestDatabase, cleanupTestDatabase, resetTestTables, type TestDb } from '../test-utils.js';
+import { users, studyLanguages, cards, inboxNotes, noteCardLinks, cardEntryDailyStats } from '../schema.js';
+import {
+  createDraftCardFromNote,
+  createInboxNote,
+  deferInboxNote,
+  deleteInboxNote,
+  getCardEntryCounts,
+  getDraftCardsForLanguage,
+  getNoteWithDraftCards,
+  listInboxNotes,
+  signOffNote,
+  updateInboxNoteAiState,
+} from '../card-entry.js';
+
+const TEST_USER = { userId: 'auth0|card-entry-user', email: 'card-entry@example.com' };
+const TEST_LANG = { userId: TEST_USER.userId, languageId: 'es', languageName: 'Spanish' };
+
+describe('Card Entry database operations', () => {
+  let db: TestDb;
+  let sql: ReturnType<typeof postgres>;
+
+  beforeAll(async () => {
+    ({ db, sql } = await setupTestDatabase());
+  });
+
+  afterAll(async () => {
+    if (sql) await cleanupTestDatabase(sql);
+  });
+
+  beforeEach(async () => {
+    await resetTestTables(db);
+    await db.insert(users).values(TEST_USER);
+    await db.insert(studyLanguages).values(TEST_LANG);
+  });
+
+  it('creates inbox notes with default ai_state and updates capture stats', async () => {
+    const created = await createInboxNote({
+      userId: TEST_USER.userId,
+      languageId: TEST_LANG.languageId,
+      content: 'repasar aunque vs sin embargo',
+      sourceType: 'manual',
+    }, db);
+
+    expect(created.noteId).toMatch(/^note-/);
+    expect(created.state).toBe('unprocessed');
+    expect(created.aiState).toBe('complete');
+
+    const [stats] = await db.select().from(cardEntryDailyStats);
+    expect(stats.notesCaptured).toBe(1);
+    expect(stats.notesProcessed).toBe(0);
+  });
+
+  it('lists inbox notes in both oldest-first and newest-first order while hiding processed by default', async () => {
+    await db.insert(inboxNotes).values([
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        noteId: 'note-oldest',
+        content: 'oldest',
+        createdAt: new Date('2026-04-01T00:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        noteId: 'note-middle',
+        content: 'middle',
+        createdAt: new Date('2026-04-02T00:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        noteId: 'note-processed',
+        content: 'processed',
+        state: 'processed',
+        createdAt: new Date('2026-04-03T00:00:00.000Z'),
+      },
+    ]);
+
+    const oldestFirst = await listInboxNotes(TEST_USER.userId, TEST_LANG.languageId, undefined, db);
+    const newestFirst = await listInboxNotes(TEST_USER.userId, TEST_LANG.languageId, {
+      sort: 'newest-first',
+    }, db);
+
+    expect(oldestFirst.map((note) => note.noteId)).toEqual(['note-oldest', 'note-middle']);
+    expect(newestFirst.map((note) => note.noteId)).toEqual(['note-middle', 'note-oldest']);
+  });
+
+  it('creates draft cards from a note and exposes them with source-note context', async () => {
+    const note = await createInboxNote({
+      userId: TEST_USER.userId,
+      languageId: TEST_LANG.languageId,
+      noteId: 'note-draft-source',
+      content: 'hablar de “se me ocurrió”',
+      sourceType: 'manual',
+    }, db);
+
+    const firstDraft = await createDraftCardFromNote({
+      userId: TEST_USER.userId,
+      languageId: TEST_LANG.languageId,
+      noteId: note.noteId,
+      content: 'se me ocurrió',
+      meaning: 'it occurred to me',
+    }, db);
+
+    const secondDraft = await createDraftCardFromNote({
+      userId: TEST_USER.userId,
+      languageId: TEST_LANG.languageId,
+      noteId: note.noteId,
+      content: 'ocurrírsele a alguien',
+      meaning: 'to occur to someone',
+    }, db);
+
+    const workspace = await getNoteWithDraftCards(TEST_USER.userId, TEST_LANG.languageId, note.noteId, db);
+    const drafts = await getDraftCardsForLanguage(TEST_USER.userId, TEST_LANG.languageId, db);
+    const counts = await getCardEntryCounts(TEST_USER.userId, TEST_LANG.languageId, db);
+
+    expect(workspace).not.toBeNull();
+    expect(workspace!.draftCards.map((card) => card.cardId)).toEqual([firstDraft.cardId, secondDraft.cardId]);
+    expect(drafts).toHaveLength(2);
+    expect(drafts[0].sourceNotes[0]?.noteId).toBe(note.noteId);
+    expect(counts.unprocessedNoteCount).toBe(1);
+    expect(counts.draftCardCount).toBe(2);
+
+    const [stats] = await db.select().from(cardEntryDailyStats);
+    expect(stats.draftCardsCreated).toBe(2);
+  });
+
+  it('signs off a note transactionally by promoting draft cards and marking the note processed', async () => {
+    const note = await createInboxNote({
+      userId: TEST_USER.userId,
+      languageId: TEST_LANG.languageId,
+      noteId: 'note-to-sign-off',
+      content: 'repasar subjuntivo con para que',
+      sourceType: 'manual',
+    }, db);
+
+    const draft = await createDraftCardFromNote({
+      userId: TEST_USER.userId,
+      languageId: TEST_LANG.languageId,
+      noteId: note.noteId,
+      cardId: 'draft-signoff-card',
+      content: 'para que + subjuntivo',
+    }, db);
+
+    const result = await signOffNote(TEST_USER.userId, TEST_LANG.languageId, note.noteId, db);
+
+    expect(result.promotedCardIds).toEqual([draft.cardId]);
+    expect(result.note.state).toBe('processed');
+
+    const [storedCard] = await db
+      .select()
+      .from(cards)
+      .where(eq(cards.cardId, draft.cardId));
+    expect(storedCard.status).toBe('active');
+
+    const [storedNote] = await db
+      .select()
+      .from(inboxNotes)
+      .where(eq(inboxNotes.noteId, note.noteId));
+    expect(storedNote.state).toBe('processed');
+
+    const [stats] = await db.select().from(cardEntryDailyStats);
+    expect(stats.notesProcessed).toBe(1);
+    expect(stats.cardsPromotedToActive).toBe(1);
+  });
+
+  it('deletes a note by soft-deleting linked draft cards while preserving active cards', async () => {
+    const note = await createInboxNote({
+      userId: TEST_USER.userId,
+      languageId: TEST_LANG.languageId,
+      noteId: 'note-delete',
+      content: 'cleanup test',
+      sourceType: 'manual',
+    }, db);
+
+    const draft = await createDraftCardFromNote({
+      userId: TEST_USER.userId,
+      languageId: TEST_LANG.languageId,
+      noteId: note.noteId,
+      cardId: 'draft-delete-card',
+      content: 'borrador',
+    }, db);
+
+    await db.insert(cards).values({
+      userId: TEST_USER.userId,
+      languageId: TEST_LANG.languageId,
+      cardId: 'active-linked-card',
+      content: 'activo',
+      status: 'active',
+    });
+    await db.insert(noteCardLinks).values({
+      userId: TEST_USER.userId,
+      languageId: TEST_LANG.languageId,
+      noteId: note.noteId,
+      cardId: 'active-linked-card',
+    });
+
+    const result = await deleteInboxNote(TEST_USER.userId, TEST_LANG.languageId, note.noteId, db);
+
+    expect(result).not.toBeNull();
+    expect(result!.softDeletedDraftCardCount).toBe(1);
+    expect(result!.preservedLinkedCardCount).toBe(1);
+
+    const [storedDraft] = await db
+      .select()
+      .from(cards)
+      .where(eq(cards.cardId, draft.cardId));
+    expect(storedDraft.status).toBe('deleted');
+    expect(storedDraft.deletedAt).not.toBeNull();
+
+    const [storedActive] = await db
+      .select()
+      .from(cards)
+      .where(eq(cards.cardId, 'active-linked-card'));
+    expect(storedActive.status).toBe('active');
+
+    const remainingNoteRows = await db
+      .select()
+      .from(inboxNotes)
+      .where(eq(inboxNotes.noteId, note.noteId));
+    const remainingLinks = await db
+      .select()
+      .from(noteCardLinks)
+      .where(eq(noteCardLinks.noteId, note.noteId));
+
+    expect(remainingNoteRows).toHaveLength(0);
+    expect(remainingLinks).toHaveLength(0);
+
+    const [stats] = await db.select().from(cardEntryDailyStats);
+    expect(stats.notesDeleted).toBe(1);
+  });
+
+  it('updates ai_state and defer state independently for a note', async () => {
+    await createInboxNote({
+      userId: TEST_USER.userId,
+      languageId: TEST_LANG.languageId,
+      noteId: 'note-state-update',
+      content: 'pending ai',
+      sourceType: 'manual',
+    }, db);
+
+    const updatedAi = await updateInboxNoteAiState(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      'note-state-update',
+      'processing',
+      db
+    );
+    const deferred = await deferInboxNote(TEST_USER.userId, TEST_LANG.languageId, 'note-state-update', db);
+
+    expect(updatedAi?.aiState).toBe('processing');
+    expect(deferred?.state).toBe('deferred');
+
+    const [stats] = await db.select().from(cardEntryDailyStats);
+    expect(stats.notesDeferred).toBe(1);
+  });
+});

--- a/packages/database/src/tests/schema.test.ts
+++ b/packages/database/src/tests/schema.test.ts
@@ -56,6 +56,7 @@ describe('Full schema — Card Entry tables', () => {
     expect(retrieved).toBeDefined();
     expect(retrieved.content).toBe(note.content);
     expect(retrieved.state).toBe('unprocessed');
+    expect(retrieved.aiState).toBe('complete');
     expect(retrieved.sourceType).toBe('manual');
   });
 

--- a/packages/database/src/validation.ts
+++ b/packages/database/src/validation.ts
@@ -15,7 +15,8 @@ import {
 export const cardStatusSchema = z.enum(['draft', 'active', 'archived', 'deleted']);
 export const cardTypeSchema = z.enum(['word', 'pattern', 'complex_prompt']);
 export const cefrLevelSchema = z.enum(['A1', 'A2', 'B1', 'B2', 'C1', 'C2']);
-export const inboxNoteStateSchema = z.enum(['unprocessed', 'deferred', 'deleted']);
+export const inboxNoteStateSchema = z.enum(['unprocessed', 'deferred', 'processed', 'deleted']);
+export const inboxNoteAiStateSchema = z.enum(['queued', 'processing', 'complete', 'failed']);
 export const inboxSourceTypeSchema = z.enum(['manual', 'api', 'browser_extension', 'ifttt', 'zapier', 'n8n']);
 export const drillContextStateSchema = z.enum(['active', 'snoozed', 'dismissed']);
 
@@ -47,6 +48,7 @@ export const selectCardGroupSchema = createSelectSchema(cardGroups);
 // === Card Entry ===
 export const insertInboxNoteSchema = createInsertSchema(inboxNotes).extend({
   state: inboxNoteStateSchema.optional(),
+  aiState: inboxNoteAiStateSchema.optional(),
   sourceType: inboxSourceTypeSchema.optional(),
 });
 export const selectInboxNoteSchema = createSelectSchema(inboxNotes);


### PR DESCRIPTION
## Summary
- add a shared Card Entry database operations module for inbox, draft-card, count, sign-off, and delete workflows
- add i_state support plus the migration and validation updates needed for the approved Card Entry backend contract
- route homepage inbox counts through the shared Card Entry helper and add database coverage for the new operations

## Testing
- pnpm --filter @studypuck/database test
- pnpm turbo build --filter=web

Closes #115