### PR TITLE
Fix Card Entry note creation in Workers

### DIFF
--- a/apps/web/src/routes/[lang]/card-entry/+page.server.ts
+++ b/apps/web/src/routes/[lang]/card-entry/+page.server.ts
@@ -1,5 +1,5 @@
 import { fail, redirect, type Actions, type ServerLoad } from '@sveltejs/kit';
-import { getDb } from '@studypuck/database';
+import { getDb, withTransactionDb } from '@studypuck/database';
 import { env } from '$env/dynamic/private';
 import {
   CardEntryRequestError,
@@ -64,12 +64,25 @@ export const actions: Actions = {
       throw redirect(303, '/');
     }
 
+    const userId = session.user.id;
+
     const formData = await event.request.formData();
     const content = formData.get('content')?.toString() ?? '';
-    const database = getDb(env.DATABASE_URL);
+    const databaseUrl = env.DATABASE_URL;
+
+    if (!databaseUrl) {
+      return fail(500, {
+        operation: 'add-note' as const,
+        errorMessage: 'The note service is not configured right now.',
+        submittedContent: content,
+      });
+    }
 
     try {
-      await createCardEntryNoteForLanguage(session.user.id, languageCode, content, database);
+      await withTransactionDb(
+        databaseUrl,
+        (database) => createCardEntryNoteForLanguage(userId, languageCode, content, database as never)
+      );
 
       return {
         operation: 'add-note' as const,
@@ -101,12 +114,25 @@ export const actions: Actions = {
       throw redirect(303, '/');
     }
 
+    const userId = session.user.id;
+
     const formData = await event.request.formData();
     const noteId = formData.get('noteId')?.toString() ?? '';
-    const database = getDb(env.DATABASE_URL);
+    const databaseUrl = env.DATABASE_URL;
+
+    if (!databaseUrl) {
+      return fail(500, {
+        operation: 'defer-note' as const,
+        noteId,
+        errorMessage: 'The note service is not configured right now.',
+      });
+    }
 
     try {
-      await deferCardEntryNoteForLanguage(session.user.id, languageCode, noteId, database);
+      await withTransactionDb(
+        databaseUrl,
+        (database) => deferCardEntryNoteForLanguage(userId, languageCode, noteId, database as never)
+      );
 
       return {
         operation: 'defer-note' as const,
@@ -139,12 +165,25 @@ export const actions: Actions = {
       throw redirect(303, '/');
     }
 
+    const userId = session.user.id;
+
     const formData = await event.request.formData();
     const noteId = formData.get('noteId')?.toString() ?? '';
-    const database = getDb(env.DATABASE_URL);
+    const databaseUrl = env.DATABASE_URL;
+
+    if (!databaseUrl) {
+      return fail(500, {
+        operation: 'delete-note' as const,
+        noteId,
+        errorMessage: 'The note service is not configured right now.',
+      });
+    }
 
     try {
-      await deleteCardEntryNoteForLanguage(session.user.id, languageCode, noteId, database);
+      await withTransactionDb(
+        databaseUrl,
+        (database) => deleteCardEntryNoteForLanguage(userId, languageCode, noteId, database as never)
+      );
 
       return {
         operation: 'delete-note' as const,

--- a/apps/web/src/routes/api/card-entry/notes/+server.ts
+++ b/apps/web/src/routes/api/card-entry/notes/+server.ts
@@ -1,5 +1,5 @@
 import { error, json, type RequestHandler } from '@sveltejs/kit';
-import { getDb } from '@studypuck/database';
+import { withTransactionDb } from '@studypuck/database';
 import { env } from '$env/dynamic/private';
 import { createCardEntryNoteSchema } from '$lib/schemas/card-entry.js';
 import { CardEntryRequestError, createCardEntryNoteForLanguage } from '$lib/server/card-entry.js';
@@ -11,20 +11,29 @@ export const POST: RequestHandler = async (event) => {
     throw error(401, 'You must be signed in to add notes.');
   }
 
+  const userId = session.user.id;
+
   const parsedBody = createCardEntryNoteSchema.safeParse(await event.request.json().catch(() => null));
 
   if (!parsedBody.success) {
     throw error(400, parsedBody.error.issues[0]?.message ?? 'The note request is invalid.');
   }
 
-  const database = getDb(env.DATABASE_URL);
+  const databaseUrl = env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    throw error(500, 'The note service is not configured right now.');
+  }
 
   try {
-    const note = await createCardEntryNoteForLanguage(
-      session.user.id,
-      parsedBody.data.languageId,
-      parsedBody.data.content,
-      database
+    const note = await withTransactionDb<Awaited<ReturnType<typeof createCardEntryNoteForLanguage>>>(
+      databaseUrl,
+      (database) => createCardEntryNoteForLanguage(
+        userId,
+        parsedBody.data.languageId,
+        parsedBody.data.content,
+        database as never
+      )
     );
 
     return json({

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -1,5 +1,6 @@
-import { neon } from '@neondatabase/serverless';
-import { drizzle } from 'drizzle-orm/neon-http';
+import { Pool, neon, neonConfig } from '@neondatabase/serverless';
+import { drizzle as drizzleHttp } from 'drizzle-orm/neon-http';
+import { drizzle as drizzleServerless } from 'drizzle-orm/neon-serverless';
 import * as schema from './schema.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -68,7 +69,17 @@ function createDatabaseConnection(databaseUrl: string) {
   }
 
   const sql = neon(databaseUrl);
-  return drizzle(sql, { schema });
+  return drizzleHttp(sql, { schema });
+}
+
+function createWorkerTransactionDatabaseConnection(databaseUrl: string): DatabaseConnection {
+  neonConfig.poolQueryViaFetch = true;
+
+  const pool = new Pool({
+    connectionString: databaseUrl,
+  });
+
+  return drizzleServerless(pool, { schema });
 }
 
 /**
@@ -86,6 +97,28 @@ export function getDb(databaseUrl?: string) {
   }
 
   return createDatabaseConnection(url);
+}
+
+/**
+ * Execute work with a transaction-capable database client in runtimes where
+ * neon-http cannot support Drizzle transactions.
+ */
+export async function withTransactionDb<T>(
+  databaseUrl: string,
+  callback: (db: DatabaseConnection) => Promise<T>
+): Promise<T> {
+  if (isNodeRuntime()) {
+    return callback(createNodeDatabaseConnection(databaseUrl));
+  }
+
+  const db = createWorkerTransactionDatabaseConnection(databaseUrl);
+  const pool = db.$client as Pool;
+
+  try {
+    return await callback(db);
+  } finally {
+    await pool.end();
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a transaction-capable worker database helper for write flows
- switch Card Entry add/defer/delete handlers to use that helper
- keep existing read paths unchanged while fixing the production regression

## Testing
- pnpm turbo test lint check-types build --filter=web

Closes #124