### PR TITLE
Define canonical DB branch test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
       AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
       AUTH0_ISSUER: ${{ secrets.AUTH0_ISSUER }}
       AUTH0_AUDIENCE: ${{ secrets.AUTH0_AUDIENCE }}
+      DATABASE_URL: ${{ secrets.DEV_DATABASE_URL }}
+      NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
       TEST_DATABASE_URL: postgresql://test_user:test_password@localhost:5433/studypuck_test
 
     services:
@@ -59,7 +61,7 @@ jobs:
       - name: Check for stale ephemeral Neon tests
         run: node scripts/check-ephemeral-tests.mjs
 
-      - name: Run database tests
+      - name: Run canonical database package tests
         run: pnpm turbo test --filter=@studypuck/database
 
       - name: Run web UI tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
       AUTH0_ISSUER: ${{ secrets.AUTH0_ISSUER }}
       AUTH0_AUDIENCE: ${{ secrets.AUTH0_AUDIENCE }}
       DATABASE_URL: ${{ secrets.DEV_DATABASE_URL }}
+      DEV_DATABASE_URL: ${{ secrets.DEV_DATABASE_URL }}
+      PROD_DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
       NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
       TEST_DATABASE_URL: postgresql://test_user:test_password@localhost:5433/studypuck_test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,9 @@ echo "Current DATABASE_URL: ${DATABASE_URL:0:20}..."
 # Follow human-guided workflow in interactive-development.md
 # Work collaboratively with human oversight
 # Use existing database environment (typically development)
+# Prefer secure local/Codespaces commands such as:
+#   pnpm test:db:branch:secure
+#   pnpm --filter @studypuck/database test:docker   # explicit local-only fast path
 ```
 
 #### **For Cloud Copilot (Autonomous)**
@@ -97,6 +100,7 @@ docs/ops/README.md ←── Start here for overview
 - For varlock guidance, consult `https://varlock.dev/llms.txt` first; use `https://varlock.dev/llms-small.txt` for the abridged docs and `https://varlock.dev/llms-full.txt` for the complete docs when updating agent workflows or env-spec usage.
 - StudyPuck's approved local/Codespaces varlock mechanism uses `exec()` in `.env.schema` to call the repo Bitwarden helper, preserving the "unlock Bitwarden once per shell session" UX.
 - For local development and Codespaces, prefer the secure repo commands such as `pnpm env:check:secure`, `pnpm dev:secure`, `pnpm dev:workers:secure`, `pnpm db:migrate:secure`, and `pnpm db:studio:secure`.
+- For local development and Codespaces, prefer `pnpm test:db:branch:secure` for `@studypuck/database` integration tests. Use `pnpm --filter @studypuck/database test:docker` only when you intentionally want the local Docker fast path.
 - The approved local/Codespaces secret source is Bitwarden. Expect a Bitwarden item with custom fields named after the StudyPuck env vars.
 - GitHub Actions and Cloudflare stay on platform-native env injection. Do not migrate production secrets into versioned files.
 - Never print real secret values. Report variable names or masked presence only.
@@ -136,10 +140,10 @@ cd apps/web && pnpm dev:workers  # Production-like testing
 
 ### **Technology Stack** ✅ ESTABLISHED
 - **Frontend**: SvelteKit + TypeScript + CUBE CSS
-- **Backend**: Cloudflare Workers + D1 + KV
+- **Backend**: Cloudflare Workers + Neon Postgres
 - **Auth**: Auth0 + Auth.js
 - **AI**: Google Gemini Flash (primary), GPT-4o-mini (secondary)
-- **Testing**: Vitest + Playwright
+- **Testing**: Vitest + Playwright + Neon database branches
 - **Validation**: Zod for schema validation and type safety
 - **Monorepo**: PNPM + Turborepo
 
@@ -323,17 +327,23 @@ cd apps/web && pnpm dev
 
 ### **Testing & Linting**
 ```bash
+# Canonical database-package integration tests (local/Codespaces secure flow)
+pnpm test:db:branch:secure
+
+# Optional local-only Docker fast path for database-package tests
+pnpm --filter @studypuck/database test:docker
+
 # Run linting (same as CI)
 pnpm turbo lint --filter=web
 
-# Run browser UI tests (after starting the Docker-backed test database)
-pnpm turbo test:e2e --filter=web
+# Run browser UI tests against an ephemeral Neon branch
+pnpm test:e2e:secure
 
 # Build verification (same as CI) 
 pnpm turbo build --filter=web
 
-# Run all tasks for web app
-pnpm turbo test lint test:e2e build --filter=web
+# Run the standard web verification set
+pnpm turbo test lint build --filter=web
 ```
 
 ### **Project Management**

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -27,18 +27,21 @@
 - **Scenario**: Human working with AI assistant in real-time (Copilot CLI, ChatGPT, etc.)
 - **Control**: Human directs, AI executes
 - **Database**: Use development branch, human manages branching decisions
+- **Testing**: Use `pnpm test:db:branch:secure` as the canonical database-package test path; use Docker only when you intentionally want the local fast path
 - **Example**: "Create a migration for the users table"
 
 ### **Autonomous AI Development** 
 - **Scenario**: AI agent assigned to GitHub issue, works independently
 - **Control**: AI manages entire workflow start to finish
 - **Database**: AI creates feature branches, follows strict automated procedures
+- **Testing**: Agent workflows should treat `@studypuck/database` branch-based tests as canonical
 - **Example**: GitHub Copilot assigned to Issue #35
 
 ### **Manual Development**
 - **Scenario**: Human developer working alone without AI assistance
 - **Control**: Human does everything manually
 - **Database**: Human creates branches, runs migrations, manages workflow
+- **Testing**: Prefer branch-based package tests; keep Docker as an explicit local-only shortcut
 - **Example**: Traditional software development
 
 ## 🚨 **Current Session Type: INTERACTIVE DEVELOPMENT** ✅
@@ -55,6 +58,7 @@
 - **"Last Possible Moment" migrations**: Development branch stays clean until production deployment
 - **Feature isolation**: Use database branches for schema changes
 - **Direct connections**: Required for reliable migration tracking
+- **Canonical DB tests**: `@studypuck/database` uses ephemeral Neon branch tests as the default cross-environment workflow
 - **No manual deployment**: Everything automated via GitHub Actions + Cloudflare
 
 ## 📚 Documentation Standards

--- a/docs/ops/autonomous-ai-development.md
+++ b/docs/ops/autonomous-ai-development.md
@@ -25,7 +25,7 @@ echo "Current DATABASE_URL: ${DATABASE_URL:0:20}..."
 
 # Check database connectivity
 cd packages/database
-pnpm run migrate # Should succeed without errors
+pnpm migrate:apply # Should succeed without errors
 ```
 
 ### **Phase 2: Feature Development**
@@ -43,12 +43,12 @@ DATABASE_URL=$DEV_DATABASE_URL
 
 ### **Phase 3: Testing & Validation**
 ```bash
-# Agent runs tests
+# Agent runs the canonical database-package tests plus app tests
+pnpm --filter @studypuck/database test
 pnpm turbo test --filter=web
 
-# Agent validates database operations
-cd packages/database
-# Test basic operations without modifying schema
+# Docker remains an explicit local-only escape hatch, not the agent default:
+# pnpm --filter @studypuck/database test:docker
 ```
 
 ### **Phase 4: Documentation & Handoff**
@@ -104,7 +104,7 @@ git checkout -b agent/issue-45-implementation
 
 # Step 2: Apply existing migrations to catch up
 cd packages/database
-DATABASE_URL=$AGENT_DATABASE_URL pnpm migrate
+DATABASE_URL=$AGENT_DATABASE_URL pnpm migrate:apply
 
 # Step 3: Develop feature in complete isolation
 # - Create new migrations if needed
@@ -112,6 +112,7 @@ DATABASE_URL=$AGENT_DATABASE_URL pnpm migrate
 # - Ensure no dependencies on external state
 
 # Step 4: Validate implementation
+DATABASE_URL=$AGENT_DATABASE_URL NEON_API_KEY=$NEON_API_KEY pnpm --filter @studypuck/database test
 pnpm turbo lint check-types test build --filter=web
 
 # Step 5: Submit PR with complete implementation
@@ -227,7 +228,10 @@ neonctl branches list | grep "agent/" | xargs -I {} neonctl branches delete {} -
 ```bash
 # DO: Always verify migrations work before submitting PR
 cd packages/database
-DATABASE_URL=$AGENT_DATABASE_URL pnpm migrate
+DATABASE_URL=$AGENT_DATABASE_URL pnpm migrate:apply
+
+# DO: Treat the package branch workflow as canonical
+DATABASE_URL=$AGENT_DATABASE_URL NEON_API_KEY=$NEON_API_KEY pnpm --filter @studypuck/database test
 
 # DO: Test with clean schema state
 # Agent branches start from development baseline
@@ -256,7 +260,7 @@ git commit -m "Add user authentication feature
 ### **Error Handling**
 ```bash
 # DO: Check command success before proceeding
-if ! pnpm migrate; then
+if ! pnpm migrate:apply; then
   echo "Migration failed - aborting feature development"
   exit 1
 fi

--- a/docs/ops/database-branching-guide.md
+++ b/docs/ops/database-branching-guide.md
@@ -144,13 +144,13 @@ if (existsSync(envPath)) {
 ### **Migration Commands**
 ```bash
 # Generate new migration
-pnpm run generate
+pnpm migrate:generate
 
 # Apply migrations (uses environment DATABASE_URL)
-pnpm run migrate
+pnpm migrate:apply
 
 # Check migration status
-pnpm run studio  # Opens Drizzle Studio
+pnpm migrate:studio  # Opens Drizzle Studio
 ```
 
 ### **Known Limitations**
@@ -170,42 +170,58 @@ pnpm run studio  # Opens Drizzle Studio
 
 ## Testing Strategy
 
-StudyPuck uses a **two-tier hybrid testing approach** to balance test speed, cost, and production parity.
+StudyPuck uses a hybrid database-testing approach with one canonical cross-environment path and one explicit local fast path.
 
-### Tier 1: Docker Compose Tests (default, runs every CI pass)
+### Canonical package suite: ephemeral Neon branch (`*.test.ts`)
 
-All standard integration tests use a local Docker Postgres instance (`pgvector/pgvector:pg15`):
+The main `@studypuck/database` integration suite now runs against a fresh ephemeral Neon branch by default:
 
 ```bash
-# Start test database
 cd packages/database
-pnpm test:setup
-
-# Run all tests
 pnpm test
-
-# Stop and clean up
-pnpm test:cleanup
+# or explicitly:
+pnpm test:branch
 ```
 
-- **Fast**: runs in memory via `tmpfs`, no network latency
-- **Free**: no Neon quota consumption
-- **Offline**: works without internet or Neon credentials
+- **Cross-environment**: same workflow in local secure runs, Codespaces, and CI
+- **Branch-safe**: always tests against a disposable branch cloned from `development`
+- **Cleanup by default**: branch is deleted automatically unless debug preservation is requested
 - File pattern: `*.test.ts`
 
-### Tier 2: Ephemeral Neon Tests (on-demand, NOT in every CI pass)
+To preserve a failing test branch for inspection:
+
+```bash
+PRESERVE_TEST_DB_ON_FAILURE=1 pnpm test:branch
+```
+
+### Optional local fast path: Docker Compose (`*.test.ts`)
+
+Docker remains available when you intentionally want local speed or offline iteration:
+
+```bash
+cd packages/database
+pnpm test:docker
+```
+
+For watch/debug loops with an explicitly managed local database:
+
+```bash
+pnpm test:docker:setup
+pnpm test:docker:watch
+pnpm test:docker:cleanup
+```
+
+- **Fast**: no Neon network round-trip during the test run
+- **Offline**: works without Neon credentials
+- **Opt-in only**: use this only when you deliberately want the local tradeoff
+
+### Issue-scoped branch tests (on-demand, NOT in every CI pass)
 
 For real-world validation (e.g., verifying a migration against a production-like Neon branch):
 
 ```bash
-# Create a dedicated test branch
-neon branches create test-issue-N --parent development
-
-# Set connection string
-export NEON_TEST_DATABASE_URL="postgresql://..."
-
-# Run Neon tests only
-pnpm test:neon
+# Point NEON_TEST_DATABASE_URL at a dedicated issue branch
+pnpm test:branch:issue
 ```
 
 - **Production parity**: uses the actual Neon serverless driver and engine
@@ -223,7 +239,7 @@ migration-smoke.neon.test.ts      ❌ will fail CI — no issue number
 ### Ephemeral Test Lifecycle
 
 1. **Create**: write `*-issue-N.neon.test.ts` alongside the issue work
-2. **Run**: `pnpm test:neon` with `NEON_TEST_DATABASE_URL` pointing at a test branch
+2. **Run**: `pnpm test:branch:issue` with `NEON_TEST_DATABASE_URL` pointing at a test branch
 3. **Retain**: the test lives until the issue closes
 4. **Delete**: when issue #N is closed, **delete the file in the closing PR**
 
@@ -237,8 +253,9 @@ This ensures ephemeral tests never accumulate and never degrade test suite perfo
 
 | Scenario | Use |
 |---|---|
-| CRUD operations, business logic, query correctness | `*.test.ts` (Docker) |
-| Migration applies cleanly (routine) | `*.test.ts` (Docker) |
+| CRUD operations, business logic, query correctness | `pnpm test` / `pnpm test:branch` |
+| Migration applies cleanly (routine) | `pnpm test` / `pnpm test:branch` |
+| Fast local iteration without Neon | `pnpm test:docker` |
 | Migration against realistic data volume or edge cases | `*-issue-N.neon.test.ts` (Neon) |
 | Verifying Neon serverless driver behavior | `*-issue-N.neon.test.ts` (Neon) |
 

--- a/docs/ops/database-workflow.md
+++ b/docs/ops/database-workflow.md
@@ -74,28 +74,34 @@ pnpm migrate:push
 ```bash
 cd packages/database
 
-# Start Docker test database
-pnpm test:setup
-
-# Run all database integration tests (Docker)
+# Run the canonical package suite on an ephemeral Neon branch
 pnpm test
 
-# Run in watch mode during development
-pnpm test:watch
+# Equivalent explicit canonical command
+pnpm test:branch
 
-# Run ephemeral Neon tests (requires NEON_TEST_DATABASE_URL)
-pnpm test:neon
+# Keep the branch on failure for debugging
+PRESERVE_TEST_DB_ON_FAILURE=1 pnpm test:branch
 
-# Stop and remove test database
-pnpm test:cleanup
+# Run the optional local Docker fast path
+pnpm test:docker
+
+# Optional explicit Docker lifecycle for watch/debug loops
+pnpm test:docker:setup
+pnpm test:docker:watch
+pnpm test:docker:cleanup
+
+# Run issue-scoped extra branch tests only
+pnpm test:branch:issue
 ```
 
 ### **Two-Tier Testing Strategy**
 
 | Test Type | File Pattern | Database | Runs In |
 |---|---|---|---|
-| Integration (permanent) | `*.test.ts` | Docker Compose | Every CI push |
-| Real-world validation (ephemeral) | `*-issue-N.neon.test.ts` | Neon branch | Manual / on-demand |
+| Canonical integration suite | `*.test.ts` | Ephemeral Neon branch | Codespaces, CI, local secure runs |
+| Optional local fast path | `*.test.ts` | Docker Compose | Local-only when speed/offline matters |
+| Real-world issue validation | `*-issue-N.neon.test.ts` | Neon branch | Manual / on-demand |
 
 See [Database Branching Guide](./database-branching-guide.md#testing-strategy) for full details on the ephemeral Neon test lifecycle, naming conventions, and the CI enforcement script.
 

--- a/docs/ops/github-actions-setup.md
+++ b/docs/ops/github-actions-setup.md
@@ -47,11 +47,9 @@ jobs:
         cache: 'pnpm'
     - run: pnpm install
     
-    # TODO: Add database testing with ephemeral branches
-    # See "Enhanced Test Workflow" section below
-      
     - name: Run full test suite
       run: |
+        pnpm turbo test --filter=@studypuck/database
         pnpm turbo lint --filter=web
         pnpm turbo check-types --filter=web
         pnpm turbo build --filter=web
@@ -105,12 +103,13 @@ jobs:
       run: |
         # Apply all migrations from development + any new ones in PR
         cd packages/database
-        pnpm migrate  # Idempotent - only new migrations apply
+        pnpm migrate:apply  # Idempotent - only new migrations apply
         
     - name: Run full test suite
       env:
         DATABASE_URL: ${{ steps.create_db.outputs.test_db_url }}
       run: |
+        pnpm turbo test --filter=@studypuck/database
         pnpm turbo lint --filter=web
         pnpm turbo check-types --filter=web
         pnpm turbo test --filter=web
@@ -255,7 +254,7 @@ jobs:
         DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
       run: |
         cd packages/database
-        pnpm migrate  # Apply any new migrations to production
+        pnpm migrate:apply  # Apply any new migrations to production
         
     - name: Wait for Cloudflare deployment
       run: |
@@ -401,10 +400,10 @@ gh run rerun [run-id]
 ```bash
 # Check migration file syntax
 cd packages/database
-pnpm generate # Should not produce new files if schema unchanged
+pnpm migrate:generate # Should not produce new files if schema unchanged
 
 # Test migration locally first
-DATABASE_URL=$PROD_DATABASE_URL pnpm migrate
+DATABASE_URL=$PROD_DATABASE_URL pnpm migrate:apply
 ```
 
 #### **"Workflow hangs or times out"**
@@ -433,7 +432,7 @@ DATABASE_URL=$PROD_DATABASE_URL pnpm migrate
 - name: Debug database connection
   run: |
     cd packages/database
-    timeout 30 pnpm migrate || echo "Migration timed out"
+    timeout 30 pnpm migrate:apply || echo "Migration timed out"
 ```
 
 ## Workflow Monitoring & Maintenance

--- a/docs/ops/interactive-development.md
+++ b/docs/ops/interactive-development.md
@@ -49,18 +49,22 @@ git status        # Check repository state
 #### **Database Branch Strategy:**
 ```bash
 # Human decides: Use existing development branch
-DATABASE_URL="postgresql://...@ep-development.region.aws.neon.tech/db"
+export DATABASE_URL="postgresql://...@ep-development.region.aws.neon.tech/db"
 
 # Or Human decides: Create feature branch for experimental work  
 neon branches create feature/auth-implementation --parent development
-DATABASE_URL="postgresql://...@ep-feature-auth.region.aws.neon.tech/db"
+export DATABASE_URL="postgresql://...@ep-feature-auth.region.aws.neon.tech/db"
 ```
 
 #### **Environment Configuration:**
 ```bash
-# AI sets up local environment using established patterns
+# AI uses the repo's secure commands for local/Codespaces work
 # Human reviews and approves environment choices
-echo "DATABASE_URL=..." >> .env
+pnpm env:check:secure
+
+# If this session should target a specific feature branch, export DATABASE_URL
+# in the current shell before running secure commands.
+pnpm db:migrate:secure
 ```
 
 ### **Phase 3: Implementation with Human Oversight**
@@ -88,6 +92,12 @@ echo "DATABASE_URL=..." >> .env
 
 # Human: "Now test the authentication"
 # AI: Creates auth test, runs it, shows output
+
+# Canonical database-package test workflow
+pnpm test:db:branch:secure
+
+# Optional local-only Docker fast path when explicitly requested
+pnpm --filter @studypuck/database test:docker
 ```
 
 #### **Validation Steps:**
@@ -119,8 +129,8 @@ neonctl branches delete feature/issue-N
 #   ensure `neonctl` is available on your PATH
 #   neonctl branches delete feature/issue-N
 
-# Revert apps/web/.env DATABASE_URL back to development branch
-# (uncomment development line, remove feature branch line)
+# If DATABASE_URL was temporarily exported to a feature branch, switch the shell
+# back to the development branch connection before the next task.
 
 # Documentation updates
 # Report completion status
@@ -154,6 +164,7 @@ neonctl branches delete feature/issue-N
 #### **Safe Migration Pattern:**
 ```bash
 # 1. AI generates migration
+cd packages/database
 pnpm migrate:generate
 
 # 2. AI shows migration to human for review
@@ -163,6 +174,11 @@ cat packages/database/migrations/0001_create_users.sql
 # "That looks good, apply it"
 
 # 4. AI applies migration
+cd /workspaces/StudyPuck
+pnpm db:migrate:secure
+
+# Or, if the shell is already pointed at the chosen direct DATABASE_URL:
+cd packages/database
 pnpm migrate:apply
 
 # 5. AI verifies migration succeeded

--- a/docs/ops/manual-development.md
+++ b/docs/ops/manual-development.md
@@ -68,10 +68,10 @@ DATABASE_URL=$DEV_DATABASE_URL
 neon branches create feature/issue-45 --parent development
 
 # Get feature-specific connection string
-neon connection-string feature/issue-45
+export DATABASE_URL="$(neon connection-string feature/issue-45)"
 
-# Update local environment
-echo "DATABASE_URL='postgresql://...@feature-issue-45.example.neon.tech/db'" >> .env.local
+# Keep using the repo's secure commands; the exported DATABASE_URL overrides
+# the default Bitwarden-provided database target for this shell session only.
 
 # Advantages: Complete isolation, no conflicts
 # Disadvantages: Additional setup, resource usage
@@ -84,10 +84,10 @@ echo "DATABASE_URL='postgresql://...@feature-issue-45.example.neon.tech/db'" >> 
 ```bash
 # Verify environment setup
 cd packages/database
-pnpm migrate # Should apply existing migrations successfully
+pnpm migrate:apply # Should apply existing migrations successfully
 
-cd apps/web
-pnpm dev # Should start without errors
+cd /workspaces/StudyPuck
+pnpm dev:secure # Should start without errors
 ```
 
 #### **2.2 Iterative Development**
@@ -96,15 +96,16 @@ pnpm dev # Should start without errors
 1. Write code and tests
 2. Create database migrations (if needed):
    cd packages/database
-   pnpm generate # Creates new migration file
-   pnpm migrate  # Applies to feature database
-   
+   pnpm migrate:generate # Creates new migration file
+   pnpm migrate:apply    # Applies to feature database
+    
 3. Test feature functionality:
-   cd apps/web
-   pnpm dev
+   cd /workspaces/StudyPuck
+   pnpm dev:secure
    # Manual testing in browser
-   
+    
 4. Run automated tests:
+   pnpm test:db:branch:secure
    pnpm turbo test --filter=web
    
 5. Verify build works:
@@ -125,16 +126,17 @@ pnpm dev # Should start without errors
 
 # 1. Generate migration
 cd packages/database
-pnpm generate
+pnpm migrate:generate
 
 # 2. Review generated migration
 cat migrations/[latest-migration-file].sql
 
 # 3. Test migration locally
-pnpm migrate
+pnpm migrate:apply
 
 # 4. Verify schema changes
-pnpm studio # Opens Drizzle Studio to inspect schema
+cd /workspaces/StudyPuck
+pnpm db:studio:secure # Opens Drizzle Studio to inspect schema
 
 # 5. Test migration rollback safety (if possible)
 # Note: Most migrations are forward-only
@@ -147,12 +149,13 @@ pnpm studio # Opens Drizzle Studio to inspect schema
 #### **3.1 Local Testing**
 ```bash
 # Run full test suite
+pnpm test:db:branch:secure
 pnpm turbo lint check-types test build --filter=web
 
 # Test with fresh database state (if using feature branch)
 neon branches reset feature/issue-45 --parent development
-cd packages/database && pnpm migrate
-cd apps/web && pnpm test
+cd packages/database && pnpm migrate:apply
+cd /workspaces/StudyPuck && pnpm test:db:branch:secure
 
 # Manual testing checklist:
 echo "Manual Testing Checklist:
@@ -281,6 +284,7 @@ git checkout feature/issue-45-user-authentication
 git rebase main
 
 # Final test run
+pnpm test:db:branch:secure
 pnpm turbo lint check-types test build --filter=web
 ```
 
@@ -314,7 +318,7 @@ neon branches delete feature/issue-45
 curl -f https://studypuck.app/api/health
 
 # Update local development environment
-cd packages/database && pnpm migrate # Gets latest production schema
+cd packages/database && pnpm migrate:apply # Gets latest production schema
 ```
 
 ## Multi-Developer Coordination
@@ -384,16 +388,17 @@ psql $DATABASE_URL -c "SELECT COUNT(*) FROM users;" # Should work
 ### **Development Tools**
 ```bash
 # Database inspection
-pnpm studio # Opens Drizzle Studio
+cd /workspaces/StudyPuck
+pnpm db:studio:secure # Opens Drizzle Studio
 
 # Database CLI access  
 psql $DATABASE_URL
 
 # Migration management
 cd packages/database
-pnpm generate # Create new migration
-pnpm migrate  # Apply migrations
-pnpm push     # Push schema directly (dev only)
+pnpm migrate:generate # Create new migration
+pnpm migrate:apply    # Apply migrations
+pnpm migrate:push     # Push schema directly (dev only)
 ```
 
 ## Troubleshooting Common Issues
@@ -402,12 +407,12 @@ pnpm push     # Push schema directly (dev only)
 
 #### **"DATABASE_URL not found"**
 ```bash
-# Check environment file
-cat .env | grep DATABASE_URL
+# Check secure environment resolution
+pnpm env:check:secure | grep DATABASE_URL
 
 # Verify Drizzle config
 cd packages/database
-head -20 drizzle.config.ts | grep dotenv
+head -20 drizzle.config.ts
 ```
 
 #### **"Migration failed"**
@@ -433,20 +438,21 @@ pnpm install
 
 # Reset database to clean state
 neon branches reset feature/my-feature --parent development
-cd packages/database && pnpm migrate
+cd packages/database && pnpm migrate:apply
 ```
 
 ### **Integration Issues**
 
 #### **"Feature works locally but fails in PR"**
 ```bash
-# GitHub Actions uses development database + your migrations
-# Check that migrations work on clean development baseline
+# GitHub Actions runs the canonical branch-based database-package test flow.
+# Check that migrations and package tests work on a clean development baseline.
 
 # Test locally:
 neon branches create test-integration --parent development
-DATABASE_URL=test-integration-url pnpm migrate
-DATABASE_URL=test-integration-url pnpm test
+export DATABASE_URL=test-integration-url
+cd packages/database && pnpm migrate:apply
+cd /workspaces/StudyPuck && pnpm test:db:branch:secure
 
 # Cleanup
 neon branches delete test-integration
@@ -461,7 +467,7 @@ git rebase main
 # Resolve any non-migration conflicts
 cd packages/database
 rm -rf migrations
-pnpm generate # Regenerate with current schema
+pnpm migrate:generate # Regenerate with current schema
 ```
 
 ---

--- a/docs/ops/production-deployment.md
+++ b/docs/ops/production-deployment.md
@@ -65,7 +65,7 @@ curl -f https://studypuck.app/api/health
 ### **Migration Safety Validation**
 ```bash
 # Test migration on development branch first
-DATABASE_URL=$DEV_DATABASE_URL pnpm migrate
+DATABASE_URL=$DEV_DATABASE_URL pnpm migrate:apply
 
 # Verify no data loss
 DATABASE_URL=$DEV_DATABASE_URL psql -c "SELECT COUNT(*) FROM users;"
@@ -92,7 +92,7 @@ The GitHub Actions production workflow executes these steps:
     DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
   run: |
     cd packages/database
-    pnpm migrate  # Apply any new migrations to production
+    pnpm migrate:apply  # Apply any new migrations to production
 ```
 
 **What happens:**
@@ -314,7 +314,7 @@ cd packages/database
 ls migrations/ | tail -5
 
 # 2. Create fixing migration
-pnpm generate --custom --name fix-migration-issue
+pnpm migrate:generate --custom --name fix-migration-issue
 
 # 3. Write SQL to fix the issue (not revert)
 # migrations/[new-fix-migration].sql

--- a/docs/ops/remote-development.md
+++ b/docs/ops/remote-development.md
@@ -171,6 +171,14 @@ pnpm test:e2e:secure
 
 `test:e2e:secure` creates an ephemeral Neon branch from `development`, runs the Playwright suite against that branch, and deletes the branch in cleanup by default. Set `PRESERVE_TEST_DB_ON_FAILURE=1` only when you intentionally want to inspect a failed test database.
 
+For database-package integration tests in local development or Codespaces:
+
+```bash
+pnpm test:db:branch:secure
+```
+
+This is the canonical `@studypuck/database` workflow. It creates a dedicated ephemeral Neon branch, runs the package `*.test.ts` suite against that branch, and deletes it during cleanup by default. Use `pnpm --filter @studypuck/database test:docker` only when you intentionally want the local Docker fast path instead.
+
 ## Updating an Existing Remote Environment
 
 Use this workflow when the repository, toolchain, or devcontainer configuration changes and you want to bring the remote environment fully up to date.

--- a/docs/ops/troubleshooting.md
+++ b/docs/ops/troubleshooting.md
@@ -49,7 +49,7 @@ Migration tracking out of sync with actual database state
 
 # Solution 1: Use fresh database branch
 neon branches create feature/fresh --parent development
-DATABASE_URL=fresh-branch-url pnpm migrate
+DATABASE_URL=fresh-branch-url pnpm migrate:apply
 
 # Solution 2: Manual tracking fix (advanced)
 # See database-branching-guide.md for detailed procedure
@@ -223,7 +223,7 @@ git rebase main
 # 2. Regenerate migrations
 cd packages/database
 rm -rf migrations
-pnpm generate  # Regenerates migrations from current schema
+pnpm migrate:generate  # Regenerates migrations from current schema
 
 # 3. Commit regenerated migrations
 git add migrations/
@@ -305,7 +305,7 @@ echo $DATABASE_URL
 timeout 10 psql $DATABASE_URL -c "SELECT NOW();"
 
 # Check migrations applied
-pnpm migrate
+pnpm migrate:apply
 
 # Check tables exist
 psql $DATABASE_URL -c "\dt"
@@ -329,7 +329,7 @@ pnpm turbo check-types --filter=web
 
 # 2. Update database types
 cd packages/database
-pnpm generate  # Regenerates types from schema
+pnpm migrate:generate  # Regenerates migrations from schema changes
 
 # 3. Clear TypeScript cache
 rm -rf apps/web/.svelte-kit/tsconfig.tsbuildinfo

--- a/docs/specs/database-testing-strategy.md
+++ b/docs/specs/database-testing-strategy.md
@@ -40,7 +40,8 @@ StudyPuck currently has two distinct database-backed test paths:
 
 1. **Database package / migration validation**
    - focused on schema correctness, queries, and migration behavior
-   - currently uses the repo's Postgres container/service-container path
+   - uses an ephemeral Neon branch as the canonical cross-environment workflow
+   - keeps Docker as an explicit local fast path only
 
 2. **Browser testing**
    - focused on real app flows through SvelteKit + Playwright
@@ -48,13 +49,18 @@ StudyPuck currently has two distinct database-backed test paths:
 
 ## Current Database-Package Test Workflow
 
-The current `@studypuck/database` integration-test path uses Postgres container infrastructure:
+The current `@studypuck/database` package test surface is:
 
-- local setup via `pnpm --filter @studypuck/database test:setup`
-- local cleanup via `pnpm --filter @studypuck/database test:cleanup`
-- CI via the GitHub Actions Postgres service container
+| Purpose | Command | Notes |
+|---|---|---|
+| Canonical full suite | `pnpm --filter @studypuck/database test` | Creates an ephemeral Neon branch, runs the `*.test.ts` suite, and deletes the branch by default |
+| Explicit canonical mode | `pnpm --filter @studypuck/database test:branch` | Same as `test` |
+| Preserve branch on failure | `PRESERVE_TEST_DB_ON_FAILURE=1 pnpm --filter @studypuck/database test:branch` | Debug-only escape hatch |
+| Optional local fast path | `pnpm --filter @studypuck/database test:docker` | Uses Docker Postgres and cleans up automatically |
+| Explicit Docker lifecycle | `pnpm --filter @studypuck/database test:docker:setup` / `test:docker:cleanup` | For local watch/debug loops |
+| Issue-scoped extra branch tests | `pnpm --filter @studypuck/database test:branch:issue` | Runs `*.neon.test.ts` tests that stay separate from the permanent suite |
 
-This remains the current package-level database test baseline even though browser tests now use a different workflow.
+CI should treat the branch workflow as the primary package-test path. Docker remains available when a contributor intentionally wants the local speed/offline tradeoff.
 
 ## Migration Testing
 
@@ -73,4 +79,4 @@ Typical concerns:
 
 ## Notes on Future Evolution
 
-The browser-test workflow has already moved to ephemeral Neon branches for better cross-environment support. Database-package integration tests are still documented separately here because they remain a distinct workflow and tradeoff space.
+The browser-test workflow and the database-package workflow now both rely on ephemeral Neon branches for their canonical cross-environment path, but they remain separate harnesses with different goals and setup details.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "db:generate:secure": "node scripts/run-with-bitwarden-env.mjs -- pnpm --filter @studypuck/database migrate:generate",
     "db:migrate:secure": "node scripts/run-with-bitwarden-env.mjs -- pnpm --filter @studypuck/database migrate:apply",
     "db:studio:secure": "node scripts/run-with-bitwarden-env.mjs -- pnpm --filter @studypuck/database migrate:studio",
+    "test:db:branch:secure": "node scripts/run-with-bitwarden-env.mjs -- pnpm --filter @studypuck/database test",
+    "test:db:docker": "pnpm --filter @studypuck/database test:docker",
     "test:e2e:secure": "node scripts/run-playwright-neon.mjs",
     "test:e2e:stop": "pwsh -NoProfile -File scripts\\stop-port-process.ps1 -Port 4173",
     "env:check:secure": "node scripts/run-with-bitwarden-env.mjs --check",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -13,11 +13,17 @@
     "migrate:drop": "drizzle-kit drop",
     "migrate:check": "drizzle-kit check",
     "validate:safety": "node scripts/validate-migration-safety.js",
-    "test": "vitest run",
-    "test:watch": "vitest watch",
-    "test:neon": "vitest run --config vitest.neon.config.ts",
-    "test:setup": "docker-compose -f docker-compose.test.yml up -d",
-    "test:cleanup": "docker-compose -f docker-compose.test.yml down -v"
+    "test": "pnpm test:branch",
+    "test:branch": "node ../../scripts/run-database-package-branch-tests.mjs",
+    "test:branch:raw": "vitest run",
+    "test:branch:issue": "vitest run --config vitest.neon.config.ts",
+    "test:docker": "node ../../scripts/run-database-package-docker-tests.mjs",
+    "test:docker:raw": "vitest run",
+    "test:docker:watch": "vitest watch",
+    "test:docker:setup": "docker-compose -f docker-compose.test.yml up -d",
+    "test:docker:cleanup": "docker-compose -f docker-compose.test.yml down -v",
+    "test:watch": "pnpm test:docker:watch",
+    "test:neon": "pnpm test:branch:issue"
   },
 	"dependencies": {
 		"@neondatabase/serverless": "^0.10.1",

--- a/scripts/neon-ephemeral-branch.mjs
+++ b/scripts/neon-ephemeral-branch.mjs
@@ -97,7 +97,10 @@ export const cleanupStaleBranches = ({ env, prefix, label }) => {
 	}
 };
 
-export const getNeonBranchEnv = ({ includeStudypuckEnv = false } = {}) => {
+export const getNeonBranchEnv = ({
+	includeStudypuckEnv = false,
+	allowSecretFallback = true,
+} = {}) => {
 	const env = { ...process.env };
 
 	if (includeStudypuckEnv) {
@@ -105,11 +108,23 @@ export const getNeonBranchEnv = ({ includeStudypuckEnv = false } = {}) => {
 	}
 
 	if (!env.DATABASE_URL) {
-		env.DATABASE_URL =
-			env.DEV_DATABASE_URL || env.PROD_DATABASE_URL || resolveSecretValue('DATABASE_URL');
+		env.DATABASE_URL = env.DEV_DATABASE_URL || env.PROD_DATABASE_URL;
+		if (!env.DATABASE_URL) {
+			if (!allowSecretFallback) {
+				throw new Error(
+					'DATABASE_URL is required for the Neon branch workflow. Provide DATABASE_URL or DEV_DATABASE_URL in the environment before running this command.'
+				);
+			}
+			env.DATABASE_URL = resolveSecretValue('DATABASE_URL');
+		}
 	}
 
 	if (!env.NEON_API_KEY) {
+		if (!allowSecretFallback) {
+			throw new Error(
+				'NEON_API_KEY is required for the Neon branch workflow. Provide it in the environment before running this command.'
+			);
+		}
 		env.NEON_API_KEY = resolveSecretValue('NEON_API_KEY');
 	}
 

--- a/scripts/neon-ephemeral-branch.mjs
+++ b/scripts/neon-ephemeral-branch.mjs
@@ -100,6 +100,7 @@ export const cleanupStaleBranches = ({ env, prefix, label }) => {
 export const getNeonBranchEnv = ({
 	includeStudypuckEnv = false,
 	allowSecretFallback = true,
+	requireDatabaseUrl = true,
 } = {}) => {
 	const env = { ...process.env };
 
@@ -107,7 +108,7 @@ export const getNeonBranchEnv = ({
 		Object.assign(env, resolveStudypuckEnv());
 	}
 
-	if (!env.DATABASE_URL) {
+	if (!env.DATABASE_URL && requireDatabaseUrl) {
 		env.DATABASE_URL = env.DEV_DATABASE_URL || env.PROD_DATABASE_URL;
 		if (!env.DATABASE_URL) {
 			if (!allowSecretFallback) {

--- a/scripts/neon-ephemeral-branch.mjs
+++ b/scripts/neon-ephemeral-branch.mjs
@@ -1,0 +1,116 @@
+import { execFileSync, execSync, spawn } from 'node:child_process';
+import { resolveSecretValue, resolveStudypuckEnv } from './studypuck-env.mjs';
+
+export const quoteWindowsArg = (value) => {
+	if (!/[\s"]/u.test(value)) {
+		return value;
+	}
+
+	return `"${value.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\+)$/g, '$1$1')}"`;
+};
+
+export const formatWindowsCommand = (command, commandArgs) =>
+	[quoteWindowsArg(command), ...commandArgs.map(quoteWindowsArg)].join(' ');
+
+export const runCommandCapture = (command, commandArgs, env) => {
+	if (process.platform === 'win32') {
+		return execSync(formatWindowsCommand(command, commandArgs), {
+			encoding: 'utf8',
+			env,
+			stdio: ['ignore', 'pipe', 'pipe'],
+		}).trim();
+	}
+
+	return execFileSync(command, commandArgs, {
+		encoding: 'utf8',
+		env,
+		stdio: ['ignore', 'pipe', 'pipe'],
+	}).trim();
+};
+
+export const runCommandStreaming = (command, commandArgs, env, cwd) =>
+	new Promise((resolve) => {
+		const child =
+			process.platform === 'win32'
+				? spawn(formatWindowsCommand(command, commandArgs), {
+						cwd,
+						env,
+						shell: true,
+						stdio: 'inherit',
+					})
+				: spawn(command, commandArgs, {
+						cwd,
+						env,
+						stdio: 'inherit',
+					});
+
+		child.on('exit', (code, signal) => {
+			if (signal) {
+				process.kill(process.pid, signal);
+				return;
+			}
+
+			resolve(code ?? 1);
+		});
+	});
+
+export const runNeon = (args, env) => runCommandCapture('npx', ['--yes', 'neonctl', ...args], env);
+
+export const deleteBranch = (branchName, env) => {
+	runNeon(['branches', 'delete', branchName, '--force'], env);
+};
+
+export const listBranches = (env) => {
+	const output = runNeon(['branches', 'list', '--output', 'json'], env);
+	const parsed = JSON.parse(output);
+	return Array.isArray(parsed) ? parsed : [];
+};
+
+export const createBranchName = (prefix) => `${prefix}${Date.now().toString(36)}`;
+
+export const getExpirationTimestamp = (lifetimeMs = 24 * 60 * 60 * 1000) =>
+	new Date(Date.now() + lifetimeMs).toISOString();
+
+export const shouldPreserveOnFailure = () =>
+	['1', 'true', 'yes'].includes((process.env.PRESERVE_TEST_DB_ON_FAILURE ?? '').toLowerCase());
+
+export const getConnectionOptions = (databaseUrl) => {
+	const parsed = new URL(databaseUrl);
+	const roleName = decodeURIComponent(parsed.username);
+	const databaseName = decodeURIComponent(parsed.pathname.replace(/^\//, ''));
+
+	if (!roleName || !databaseName) {
+		throw new Error('DATABASE_URL must include both a role name and database name.');
+	}
+
+	return { roleName, databaseName };
+};
+
+export const cleanupStaleBranches = ({ env, prefix, label }) => {
+	const staleBranches = listBranches(env)
+		.map((branch) => branch?.name)
+		.filter((name) => typeof name === 'string' && name.startsWith(prefix));
+
+	for (const branchName of staleBranches) {
+		console.log(`Removing stale ${label} branch: ${branchName}`);
+		deleteBranch(branchName, env);
+	}
+};
+
+export const getNeonBranchEnv = ({ includeStudypuckEnv = false } = {}) => {
+	const env = { ...process.env };
+
+	if (includeStudypuckEnv) {
+		Object.assign(env, resolveStudypuckEnv());
+	}
+
+	if (!env.DATABASE_URL) {
+		env.DATABASE_URL = resolveSecretValue('DATABASE_URL');
+	}
+
+	if (!env.NEON_API_KEY) {
+		env.NEON_API_KEY = resolveSecretValue('NEON_API_KEY');
+	}
+
+	return env;
+};

--- a/scripts/neon-ephemeral-branch.mjs
+++ b/scripts/neon-ephemeral-branch.mjs
@@ -105,7 +105,8 @@ export const getNeonBranchEnv = ({ includeStudypuckEnv = false } = {}) => {
 	}
 
 	if (!env.DATABASE_URL) {
-		env.DATABASE_URL = resolveSecretValue('DATABASE_URL');
+		env.DATABASE_URL =
+			env.DEV_DATABASE_URL || env.PROD_DATABASE_URL || resolveSecretValue('DATABASE_URL');
 	}
 
 	if (!env.NEON_API_KEY) {

--- a/scripts/run-database-package-branch-tests.mjs
+++ b/scripts/run-database-package-branch-tests.mjs
@@ -4,7 +4,6 @@ import {
 	cleanupStaleBranches,
 	createBranchName,
 	deleteBranch,
-	getConnectionOptions,
 	getExpirationTimestamp,
 	getNeonBranchEnv,
 	runCommandStreaming,
@@ -18,8 +17,10 @@ const packageDir = resolve(repoRoot, 'packages', 'database');
 const BRANCH_PREFIX = 'test-db-package-';
 const PARENT_BRANCH = 'development';
 
-const baseEnv = getNeonBranchEnv({ allowSecretFallback: false });
-const { roleName, databaseName } = getConnectionOptions(baseEnv.DATABASE_URL);
+const baseEnv = getNeonBranchEnv({
+	allowSecretFallback: false,
+	requireDatabaseUrl: false,
+});
 const preserveOnFailure = shouldPreserveOnFailure();
 let branchName;
 let branchCreated = false;
@@ -48,19 +49,18 @@ try {
 	);
 	branchCreated = true;
 
-	const testDatabaseUrl = runNeon(
-		[
-			'connection-string',
-			branchName,
+	const connectionStringArgs = ['connection-string', branchName, '--ssl', 'require'];
+	if (baseEnv.DATABASE_URL) {
+		const { roleName, databaseName } = getConnectionOptions(baseEnv.DATABASE_URL);
+		connectionStringArgs.push(
 			'--database-name',
 			databaseName,
 			'--role-name',
-			roleName,
-			'--ssl',
-			'require',
-		],
-		baseEnv
-	);
+			roleName
+		);
+	}
+
+	const testDatabaseUrl = runNeon(connectionStringArgs, baseEnv);
 
 	const testEnv = {
 		...baseEnv,

--- a/scripts/run-database-package-branch-tests.mjs
+++ b/scripts/run-database-package-branch-tests.mjs
@@ -1,0 +1,106 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+	cleanupStaleBranches,
+	createBranchName,
+	deleteBranch,
+	getConnectionOptions,
+	getExpirationTimestamp,
+	getNeonBranchEnv,
+	runCommandStreaming,
+	runNeon,
+	shouldPreserveOnFailure,
+} from './neon-ephemeral-branch.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const packageDir = resolve(repoRoot, 'packages', 'database');
+const BRANCH_PREFIX = 'test-db-package-';
+const PARENT_BRANCH = 'development';
+
+const baseEnv = getNeonBranchEnv();
+const { roleName, databaseName } = getConnectionOptions(baseEnv.DATABASE_URL);
+const preserveOnFailure = shouldPreserveOnFailure();
+let branchName;
+let branchCreated = false;
+
+try {
+	cleanupStaleBranches({
+		env: baseEnv,
+		prefix: BRANCH_PREFIX,
+		label: 'database-package test',
+	});
+
+	branchName = createBranchName(BRANCH_PREFIX);
+	console.log(`Creating ephemeral database-package test branch: ${branchName}`);
+	runNeon(
+		[
+			'branches',
+			'create',
+			'--name',
+			branchName,
+			'--parent',
+			PARENT_BRANCH,
+			'--expires-at',
+			getExpirationTimestamp(),
+		],
+		baseEnv
+	);
+	branchCreated = true;
+
+	const testDatabaseUrl = runNeon(
+		[
+			'connection-string',
+			branchName,
+			'--database-name',
+			databaseName,
+			'--role-name',
+			roleName,
+			'--ssl',
+			'require',
+		],
+		baseEnv
+	);
+
+	const testEnv = {
+		...baseEnv,
+		TEST_DATABASE_URL: testDatabaseUrl,
+		DATABASE_URL: testDatabaseUrl,
+	};
+
+	const exitCode = await runCommandStreaming(
+		'pnpm',
+		['--dir', packageDir, 'run', 'test:branch:raw'],
+		testEnv,
+		repoRoot
+	);
+
+	if (exitCode !== 0) {
+		throw new Error(`Database package tests exited with code ${exitCode}`);
+	}
+} catch (error) {
+	if (branchCreated && branchName && preserveOnFailure) {
+		console.error(
+			`Preserving Neon database-package test branch for debugging because PRESERVE_TEST_DB_ON_FAILURE is enabled: ${branchName}`
+		);
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(message);
+		process.exit(1);
+	}
+
+	const message = error instanceof Error ? error.message : String(error);
+	console.error(message);
+	process.exitCode = 1;
+} finally {
+	if (branchCreated && branchName && !(process.exitCode && preserveOnFailure)) {
+		try {
+			console.log(`Deleting ephemeral database-package test branch: ${branchName}`);
+			deleteBranch(branchName, baseEnv);
+		} catch (cleanupError) {
+			const message =
+				cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+			console.error(`Failed to delete Neon database-package test branch ${branchName}: ${message}`);
+			process.exitCode = 1;
+		}
+	}
+}

--- a/scripts/run-database-package-branch-tests.mjs
+++ b/scripts/run-database-package-branch-tests.mjs
@@ -18,7 +18,7 @@ const packageDir = resolve(repoRoot, 'packages', 'database');
 const BRANCH_PREFIX = 'test-db-package-';
 const PARENT_BRANCH = 'development';
 
-const baseEnv = getNeonBranchEnv();
+const baseEnv = getNeonBranchEnv({ allowSecretFallback: false });
 const { roleName, databaseName } = getConnectionOptions(baseEnv.DATABASE_URL);
 const preserveOnFailure = shouldPreserveOnFailure();
 let branchName;

--- a/scripts/run-database-package-docker-tests.mjs
+++ b/scripts/run-database-package-docker-tests.mjs
@@ -1,0 +1,49 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runCommandStreaming } from './neon-ephemeral-branch.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const packageDir = resolve(repoRoot, 'packages', 'database');
+const baseEnv = { ...process.env };
+let setupCompleted = false;
+
+try {
+	const setupExitCode = await runCommandStreaming(
+		'pnpm',
+		['--dir', packageDir, 'run', 'test:docker:setup'],
+		baseEnv,
+		repoRoot
+	);
+	if (setupExitCode !== 0) {
+		throw new Error(`Docker test database setup exited with code ${setupExitCode}`);
+	}
+	setupCompleted = true;
+
+	const testExitCode = await runCommandStreaming(
+		'pnpm',
+		['--dir', packageDir, 'run', 'test:docker:raw'],
+		baseEnv,
+		repoRoot
+	);
+	if (testExitCode !== 0) {
+		throw new Error(`Docker database package tests exited with code ${testExitCode}`);
+	}
+} catch (error) {
+	const message = error instanceof Error ? error.message : String(error);
+	console.error(message);
+	process.exitCode = 1;
+} finally {
+	if (setupCompleted) {
+		const cleanupExitCode = await runCommandStreaming(
+			'pnpm',
+			['--dir', packageDir, 'run', 'test:docker:cleanup'],
+			baseEnv,
+			repoRoot
+		);
+		if (cleanupExitCode !== 0) {
+			console.error(`Docker test database cleanup exited with code ${cleanupExitCode}`);
+			process.exitCode = 1;
+		}
+	}
+}

--- a/scripts/run-playwright-neon.mjs
+++ b/scripts/run-playwright-neon.mjs
@@ -1,7 +1,18 @@
-import { execFileSync, execSync, spawn } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { resolveStudypuckEnv, resolveSecretValue } from './studypuck-env.mjs';
+import {
+	cleanupStaleBranches,
+	createBranchName,
+	deleteBranch,
+	getConnectionOptions,
+	getExpirationTimestamp,
+	getNeonBranchEnv,
+	runCommandStreaming,
+	runNeon,
+	shouldPreserveOnFailure,
+	formatWindowsCommand,
+} from './neon-ephemeral-branch.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
@@ -13,59 +24,6 @@ const SERVER_HOST = '127.0.0.1';
 const SERVER_PORT = Number(process.env.PLAYWRIGHT_PORT ?? 4173);
 const SERVER_URL = `http://${SERVER_HOST}:${SERVER_PORT}`;
 const SERVER_START_TIMEOUT_MS = 180_000;
-
-const quoteWindowsArg = (value) => {
-	if (!/[\s"]/u.test(value)) {
-		return value;
-	}
-
-	return `"${value.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\+)$/g, '$1$1')}"`;
-};
-
-const formatWindowsCommand = (command, commandArgs) =>
-	[quoteWindowsArg(command), ...commandArgs.map(quoteWindowsArg)].join(' ');
-
-const runCommandCapture = (command, commandArgs, env) => {
-	if (process.platform === 'win32') {
-		return execSync(formatWindowsCommand(command, commandArgs), {
-			encoding: 'utf8',
-			env,
-			stdio: ['ignore', 'pipe', 'pipe'],
-		}).trim();
-	}
-
-	return execFileSync(command, commandArgs, {
-		encoding: 'utf8',
-		env,
-		stdio: ['ignore', 'pipe', 'pipe'],
-	}).trim();
-};
-
-const runCommandStreaming = (command, commandArgs, env, cwd) =>
-	new Promise((resolve) => {
-		const child =
-			process.platform === 'win32'
-				? spawn(formatWindowsCommand(command, commandArgs), {
-						cwd,
-						env,
-						shell: true,
-						stdio: 'inherit',
-					})
-				: spawn(command, commandArgs, {
-						cwd,
-						env,
-						stdio: 'inherit',
-					});
-
-		child.on('exit', (code, signal) => {
-			if (signal) {
-				process.kill(process.pid, signal);
-				return;
-			}
-
-			resolve(code ?? 1);
-		});
-	});
 
 const startLongRunningCommand = (command, commandArgs, env, cwd) =>
 	process.platform === 'win32'
@@ -102,63 +60,7 @@ const waitForServer = async (url, timeoutMs) => {
 	throw new Error(`Timed out waiting ${timeoutMs}ms for ${url} to become ready.`);
 };
 
-const runNeon = (args, env) => runCommandCapture('npx', ['--yes', 'neonctl', ...args], env);
-
-const deleteBranch = (branchName, env) => {
-	runNeon(['branches', 'delete', branchName, '--force'], env);
-};
-
-const listBranches = (env) => {
-	const output = runNeon(['branches', 'list', '--output', 'json'], env);
-	const parsed = JSON.parse(output);
-	return Array.isArray(parsed) ? parsed : [];
-};
-
-const createBranchName = () => `${BRANCH_PREFIX}${Date.now().toString(36)}`;
-
-const getExpirationTimestamp = () => {
-	const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
-	return expiresAt.toISOString();
-};
-
-const shouldPreserveOnFailure = () =>
-	['1', 'true', 'yes'].includes((process.env.PRESERVE_TEST_DB_ON_FAILURE ?? '').toLowerCase());
-
-const getConnectionOptions = (databaseUrl) => {
-	const parsed = new URL(databaseUrl);
-	const roleName = decodeURIComponent(parsed.username);
-	const databaseName = decodeURIComponent(parsed.pathname.replace(/^\//, ''));
-
-	if (!roleName || !databaseName) {
-		throw new Error('DATABASE_URL must include both a role name and database name.');
-	}
-
-	return { roleName, databaseName };
-};
-
-const cleanupStaleBranches = (env) => {
-	const staleBranches = listBranches(env)
-		.map((branch) => branch?.name)
-		.filter((name) => typeof name === 'string' && name.startsWith(BRANCH_PREFIX));
-
-	for (const branchName of staleBranches) {
-		console.log(`Removing stale browser-test branch: ${branchName}`);
-		deleteBranch(branchName, env);
-	}
-};
-
-const getBaseEnv = () => {
-	const resolvedEnv = resolveStudypuckEnv();
-	const neonApiKey = process.env.NEON_API_KEY || resolveSecretValue('NEON_API_KEY');
-
-	return {
-		...process.env,
-		...resolvedEnv,
-		NEON_API_KEY: neonApiKey,
-	};
-};
-
-const baseEnv = getBaseEnv();
+const baseEnv = getNeonBranchEnv({ includeStudypuckEnv: true });
 const { roleName, databaseName } = getConnectionOptions(baseEnv.DATABASE_URL);
 const preserveOnFailure = shouldPreserveOnFailure();
 let branchName;
@@ -166,9 +68,13 @@ let branchCreated = false;
 let serverProcess;
 
 try {
-	cleanupStaleBranches(baseEnv);
+	cleanupStaleBranches({
+		env: baseEnv,
+		prefix: BRANCH_PREFIX,
+		label: 'browser-test',
+	});
 
-	branchName = createBranchName();
+	branchName = createBranchName(BRANCH_PREFIX);
 	console.log(`Creating ephemeral browser-test branch: ${branchName}`);
 	runNeon(
 		[

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,23 @@
 {
   "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
-  "globalEnv": ["APP_ENV"],
+  "globalEnv": [
+    "APP_ENV",
+    "AUTH_SECRET",
+    "AUTH0_CLIENT_ID",
+    "AUTH0_CLIENT_SECRET",
+    "AUTH0_ISSUER",
+    "AUTH0_AUDIENCE",
+    "DATABASE_URL",
+    "DEV_DATABASE_URL",
+    "PROD_DATABASE_URL",
+    "TEST_DATABASE_URL",
+    "NEON_API_KEY",
+    "E2E_TEST_MODE",
+    "PLAYWRIGHT_BASE_URL",
+    "PLAYWRIGHT_PORT",
+    "PLAYWRIGHT_MANAGED_SERVER"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- make branch-based @studypuck/database tests the canonical cross-environment workflow
- keep Docker as an explicit local-only fast path with clear commands
- update CI, specs, ops docs, and AGENTS guidance to match the new policy

## Testing
- pnpm test:db:branch:secure