### PR TITLE
Implement Card Entry AI preprocessing pipeline

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -57,3 +57,25 @@ AUTH0_AUDIENCE=exec('node scripts/bitwarden-secret.mjs AUTH0_AUDIENCE')
 # Direct Neon database connection string.
 # @required @sensitive @type=string(startsWith="postgresql://")
 DATABASE_URL=exec('node scripts/bitwarden-secret.mjs DATABASE_URL')
+
+# --- AI Providers ---
+
+# Primary text-generation provider for server-side AI features.
+# @optional @type=enum(gemini,openai)
+STUDYPUCK_AI_PRIMARY_PROVIDER=gemini
+
+# Gemini API key used for the default low-cost multilingual provider.
+# @optional @sensitive @type=string
+GEMINI_API_KEY=exec('node scripts/bitwarden-optional-secret.mjs GEMINI_API_KEY')
+
+# Override for the Gemini text model name.
+# @optional
+GEMINI_TEXT_MODEL=gemini-2.5-flash
+
+# OpenAI API key used as the secondary/fallback text provider.
+# @optional @sensitive @type=string
+OPENAI_API_KEY=exec('node scripts/bitwarden-optional-secret.mjs OPENAI_API_KEY')
+
+# Override for the OpenAI text model name.
+# @optional
+OPENAI_TEXT_MODEL=gpt-4o-mini

--- a/apps/web/src/lib/server/ai-prompts/card-entry.ts
+++ b/apps/web/src/lib/server/ai-prompts/card-entry.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+export const cardEntryDraftSuggestionSchema = z.object({
+  content: z.string().trim().min(1).max(500),
+  meaning: z.string().trim().max(500).nullable().optional().default(null),
+  examples: z.array(z.string().trim().min(1).max(500)).max(5).optional().default([]),
+  mnemonics: z.array(z.string().trim().min(1).max(500)).max(5).optional().default([]),
+  llmInstructions: z.string().trim().max(1_000).nullable().optional().default(null),
+});
+
+export const cardEntryPreprocessResponseSchema = z.object({
+  draftCards: z.array(cardEntryDraftSuggestionSchema).min(1).max(5),
+});
+
+export type CardEntryPreprocessResponse = z.infer<typeof cardEntryPreprocessResponseSchema>;
+
+export function buildCardEntryPreprocessPrompt(input: {
+  languageId: string;
+  noteContent: string;
+}): {
+  systemPrompt: string;
+  userPrompt: string;
+} {
+  return {
+    systemPrompt: [
+      'You are generating draft language-learning cards for StudyPuck Card Entry.',
+      'Return only JSON.',
+      'Create 1 to 5 draft cards from the note.',
+      'Preserve the user note intent instead of inventing unrelated material.',
+      'Keep examples and mnemonics concise and useful for study.',
+      'If the note is ambiguous, produce the safest likely draft cards instead of refusing.',
+    ].join(' '),
+    userPrompt: [
+      `Active language code: ${input.languageId}.`,
+      'Return this JSON shape exactly:',
+      '{"draftCards":[{"content":"string","meaning":"string|null","examples":["string"],"mnemonics":["string"],"llmInstructions":"string|null"}]}',
+      'Source note:',
+      input.noteContent,
+    ].join('\n'),
+  };
+}

--- a/apps/web/src/lib/server/ai-service.test.ts
+++ b/apps/web/src/lib/server/ai-service.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { AiServiceConfigurationError, createAiService } from './ai-service.js';
+
+const responseSchema = z.object({
+  draftCards: z.array(z.object({ content: z.string() })),
+});
+
+const silentHooks = {
+  enforceQuota: vi.fn(),
+  readCache: vi.fn(async () => null),
+  writeCache: vi.fn(async () => undefined),
+  onRequestStart: vi.fn(),
+  onRequestSuccess: vi.fn(),
+  onRequestFailure: vi.fn(),
+};
+
+describe('createAiService', () => {
+  it('parses structured JSON responses from the configured primary provider', async () => {
+    const geminiGenerator = vi.fn(async () => '```json\n{"draftCards":[{"content":"hola"}]}\n```');
+    const service = createAiService({
+      privateEnv: {
+        GEMINI_API_KEY: 'test-gemini-key',
+      },
+      hooks: silentHooks,
+      providerGenerators: {
+        gemini: geminiGenerator,
+      },
+    });
+
+    const response = await service.generateStructured({
+      metadata: {
+        feature: 'card-entry',
+        operation: 'preprocess-note',
+        userId: 'user-1',
+        languageId: 'es',
+        noteId: 'note-1',
+      },
+      systemPrompt: 'system',
+      userPrompt: 'user',
+      responseSchema,
+    });
+
+    expect(response).toEqual({
+      draftCards: [{ content: 'hola' }],
+    });
+    expect(geminiGenerator).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the secondary provider when the primary one fails', async () => {
+    const geminiGenerator = vi.fn(async () => {
+      throw new Error('gemini unavailable');
+    });
+    const openAiGenerator = vi.fn(async () => '{"draftCards":[{"content":"fallback"}]}');
+    const service = createAiService({
+      privateEnv: {
+        GEMINI_API_KEY: 'test-gemini-key',
+        OPENAI_API_KEY: 'test-openai-key',
+      },
+      hooks: silentHooks,
+      providerGenerators: {
+        gemini: geminiGenerator,
+        openai: openAiGenerator,
+      },
+    });
+
+    const response = await service.generateStructured({
+      metadata: {
+        feature: 'card-entry',
+        operation: 'preprocess-note',
+        userId: 'user-1',
+        languageId: 'es',
+        noteId: 'note-1',
+      },
+      systemPrompt: 'system',
+      userPrompt: 'user',
+      responseSchema,
+    });
+
+    expect(response).toEqual({
+      draftCards: [{ content: 'fallback' }],
+    });
+    expect(geminiGenerator).toHaveBeenCalledTimes(1);
+    expect(openAiGenerator).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws a configuration error when no providers are configured', async () => {
+    const service = createAiService({
+      privateEnv: {},
+      hooks: silentHooks,
+    });
+
+    await expect(service.generateStructured({
+      metadata: {
+        feature: 'card-entry',
+        operation: 'preprocess-note',
+        userId: 'user-1',
+        languageId: 'es',
+        noteId: 'note-1',
+      },
+      systemPrompt: 'system',
+      userPrompt: 'user',
+      responseSchema,
+    })).rejects.toBeInstanceOf(AiServiceConfigurationError);
+  });
+});

--- a/apps/web/src/lib/server/ai-service.ts
+++ b/apps/web/src/lib/server/ai-service.ts
@@ -1,0 +1,315 @@
+import { z } from 'zod';
+
+export type AiProviderName = 'gemini' | 'openai';
+
+export type AiRequestMetadata = {
+  feature: 'card-entry';
+  operation: 'preprocess-note';
+  userId: string;
+  languageId: string;
+  noteId: string;
+};
+
+export type AiRequestHooks = {
+  enforceQuota: (metadata: AiRequestMetadata) => Promise<void> | void;
+  readCache: <T>(cacheKey: string) => Promise<T | null> | T | null;
+  writeCache: <T>(cacheKey: string, value: T) => Promise<void> | void;
+  onRequestStart: (input: { provider: AiProviderName; metadata: AiRequestMetadata; model: string }) => Promise<void> | void;
+  onRequestSuccess: (input: {
+    provider: AiProviderName;
+    metadata: AiRequestMetadata;
+    model: string;
+    rawTextLength: number;
+  }) => Promise<void> | void;
+  onRequestFailure: (input: {
+    provider: AiProviderName;
+    metadata: AiRequestMetadata;
+    model: string;
+    error: unknown;
+  }) => Promise<void> | void;
+};
+
+type AiProviderConfig = {
+  name: AiProviderName;
+  model: string;
+  apiKey: string;
+};
+
+type StructuredRequest<T> = {
+  metadata: AiRequestMetadata;
+  systemPrompt: string;
+  userPrompt: string;
+  responseSchema: z.ZodType<T>;
+  cacheKey?: string;
+};
+
+type ProviderRequest = {
+  config: AiProviderConfig;
+  systemPrompt: string;
+  userPrompt: string;
+};
+
+type ProviderGenerateJson = (request: ProviderRequest) => Promise<string>;
+
+const DEFAULT_HOOKS: AiRequestHooks = {
+  enforceQuota: () => undefined,
+  readCache: async () => null,
+  writeCache: async () => undefined,
+  onRequestStart: ({ provider, metadata, model }) => {
+    console.info(`[ai:${metadata.feature}] starting ${metadata.operation} via ${provider}:${model}`);
+  },
+  onRequestSuccess: ({ provider, metadata, model }) => {
+    console.info(`[ai:${metadata.feature}] completed ${metadata.operation} via ${provider}:${model}`);
+  },
+  onRequestFailure: ({ provider, metadata, model, error }) => {
+    console.error(`[ai:${metadata.feature}] failed ${metadata.operation} via ${provider}:${model}`, error);
+  },
+};
+
+export class AiServiceConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AiServiceConfigurationError';
+  }
+}
+
+export class AiServiceRequestError extends Error {
+  providerName: AiProviderName;
+  cause: unknown;
+
+  constructor(providerName: AiProviderName, message: string, cause?: unknown) {
+    super(message);
+    this.name = 'AiServiceRequestError';
+    this.providerName = providerName;
+    this.cause = cause;
+  }
+}
+
+function normalizeProviderOrder(primaryProvider: AiProviderName): AiProviderName[] {
+  return primaryProvider === 'openai' ? ['openai', 'gemini'] : ['gemini', 'openai'];
+}
+
+function getConfiguredProviders(privateEnv: Record<string, string | undefined>): AiProviderConfig[] {
+  const primaryProvider = privateEnv.STUDYPUCK_AI_PRIMARY_PROVIDER === 'openai' ? 'openai' : 'gemini';
+  const providerOrder = normalizeProviderOrder(primaryProvider);
+
+  const providerConfigs: Record<AiProviderName, AiProviderConfig | null> = {
+    gemini: privateEnv.GEMINI_API_KEY
+      ? {
+          name: 'gemini',
+          apiKey: privateEnv.GEMINI_API_KEY,
+          model: privateEnv.GEMINI_TEXT_MODEL || 'gemini-2.5-flash',
+        }
+      : null,
+    openai: privateEnv.OPENAI_API_KEY
+      ? {
+          name: 'openai',
+          apiKey: privateEnv.OPENAI_API_KEY,
+          model: privateEnv.OPENAI_TEXT_MODEL || 'gpt-4o-mini',
+        }
+      : null,
+  };
+
+  return providerOrder
+    .map((providerName) => providerConfigs[providerName])
+    .filter((provider): provider is AiProviderConfig => Boolean(provider));
+}
+
+function extractJsonText(rawText: string): string {
+  const trimmed = rawText.trim();
+
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    return trimmed;
+  }
+
+  const fencedMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+
+  if (fencedMatch?.[1]) {
+    return fencedMatch[1].trim();
+  }
+
+  const firstBraceIndex = trimmed.indexOf('{');
+  const lastBraceIndex = trimmed.lastIndexOf('}');
+
+  if (firstBraceIndex >= 0 && lastBraceIndex > firstBraceIndex) {
+    return trimmed.slice(firstBraceIndex, lastBraceIndex + 1);
+  }
+
+  throw new Error('The AI response did not contain valid JSON.');
+}
+
+async function parseStructuredResponse<T>(rawText: string, responseSchema: z.ZodType<T>): Promise<T> {
+  const parsedJson = JSON.parse(extractJsonText(rawText));
+  return responseSchema.parse(parsedJson);
+}
+
+async function callGemini(request: ProviderRequest): Promise<string> {
+  const response = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${request.config.model}:generateContent?key=${request.config.apiKey}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        systemInstruction: {
+          parts: [{ text: request.systemPrompt }],
+        },
+        contents: [
+          {
+            role: 'user',
+            parts: [{ text: request.userPrompt }],
+          },
+        ],
+        generationConfig: {
+          responseMimeType: 'application/json',
+        },
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(
+      `Gemini request failed with status ${response.status}${errorText ? `: ${errorText}` : ''}`
+    );
+  }
+
+  const body = await response.json();
+  const rawText = body.candidates?.[0]?.content?.parts
+    ?.map((part: { text?: string }) => part.text ?? '')
+    .join('')
+    .trim();
+
+  if (!rawText) {
+    throw new Error('Gemini returned an empty response.');
+  }
+
+  return rawText;
+}
+
+async function callOpenAi(request: ProviderRequest): Promise<string> {
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${request.config.apiKey}`,
+    },
+    body: JSON.stringify({
+      model: request.config.model,
+      response_format: {
+        type: 'json_object',
+      },
+      messages: [
+        {
+          role: 'system',
+          content: request.systemPrompt,
+        },
+        {
+          role: 'user',
+          content: request.userPrompt,
+        },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`OpenAI request failed with status ${response.status}`);
+  }
+
+  const body = await response.json();
+  const rawText = body.choices?.[0]?.message?.content?.trim();
+
+  if (!rawText) {
+    throw new Error('OpenAI returned an empty response.');
+  }
+
+  return rawText;
+}
+
+const DEFAULT_PROVIDER_GENERATORS: Record<AiProviderName, ProviderGenerateJson> = {
+  gemini: callGemini,
+  openai: callOpenAi,
+};
+
+export function createAiService(options: {
+  privateEnv: Record<string, string | undefined>;
+  hooks?: Partial<AiRequestHooks>;
+  providerGenerators?: Partial<Record<AiProviderName, ProviderGenerateJson>>;
+}) {
+  const providers = getConfiguredProviders(options.privateEnv);
+  const hooks = {
+    ...DEFAULT_HOOKS,
+    ...options.hooks,
+  };
+  const providerGenerators = {
+    ...DEFAULT_PROVIDER_GENERATORS,
+    ...options.providerGenerators,
+  };
+
+  return {
+    async generateStructured<T>(request: StructuredRequest<T>): Promise<T> {
+      if (providers.length === 0) {
+        throw new AiServiceConfigurationError(
+          'No AI text provider is configured. Set GEMINI_API_KEY or OPENAI_API_KEY.'
+        );
+      }
+
+      await hooks.enforceQuota(request.metadata);
+
+      if (request.cacheKey) {
+        const cached = await hooks.readCache<T>(request.cacheKey);
+
+        if (cached) {
+          return cached;
+        }
+      }
+
+      let lastError: unknown;
+
+      for (const provider of providers) {
+        try {
+          await hooks.onRequestStart({
+            provider: provider.name,
+            metadata: request.metadata,
+            model: provider.model,
+          });
+
+          const rawText = await providerGenerators[provider.name]({
+            config: provider,
+            systemPrompt: request.systemPrompt,
+            userPrompt: request.userPrompt,
+          });
+          const parsed = await parseStructuredResponse(rawText, request.responseSchema);
+
+          await hooks.onRequestSuccess({
+            provider: provider.name,
+            metadata: request.metadata,
+            model: provider.model,
+            rawTextLength: rawText.length,
+          });
+
+          if (request.cacheKey) {
+            await hooks.writeCache(request.cacheKey, parsed);
+          }
+
+          return parsed;
+        } catch (error) {
+          lastError = error;
+          await hooks.onRequestFailure({
+            provider: provider.name,
+            metadata: request.metadata,
+            model: provider.model,
+            error,
+          });
+        }
+      }
+
+      throw new AiServiceRequestError(
+        providers[0]!.name,
+        'All configured AI providers failed to return a valid response.',
+        lastError
+      );
+    },
+  };
+}

--- a/apps/web/src/lib/server/card-entry-ai.ts
+++ b/apps/web/src/lib/server/card-entry-ai.ts
@@ -1,0 +1,107 @@
+import {
+  finalizeInboxNoteAiProcessing,
+  getNoteWithDraftCards,
+  transitionInboxNoteAiState,
+  type InboxNoteAiState,
+} from '@studypuck/database';
+import { buildCardEntryPreprocessPrompt, cardEntryPreprocessResponseSchema } from '$lib/server/ai-prompts/card-entry.js';
+import { createAiService } from '$lib/server/ai-service.js';
+
+type DatabaseClient = {
+  [key: string]: unknown;
+};
+
+const TERMINAL_AI_STATES: InboxNoteAiState[] = ['complete', 'failed'];
+
+export async function ensureCardEntryNoteProcessingState(input: {
+  userId: string;
+  languageId: string;
+  noteId: string;
+  database: DatabaseClient;
+  privateEnv: Record<string, string | undefined>;
+}) {
+  const workspace = await getNoteWithDraftCards(
+    input.userId,
+    input.languageId,
+    input.noteId,
+    input.database as never
+  );
+
+  if (!workspace) {
+    return null;
+  }
+
+  if (workspace.note.state !== 'unprocessed' || TERMINAL_AI_STATES.includes(workspace.note.aiState as InboxNoteAiState)) {
+    return workspace;
+  }
+
+  if (workspace.note.aiState === 'processing') {
+    return workspace;
+  }
+
+  const claimed = await transitionInboxNoteAiState(
+    input.userId,
+    input.languageId,
+    input.noteId,
+    'queued',
+    'processing',
+    input.database as never
+  );
+
+  if (!claimed) {
+    return getNoteWithDraftCards(input.userId, input.languageId, input.noteId, input.database as never);
+  }
+
+  try {
+    const aiService = createAiService({
+      privateEnv: input.privateEnv,
+    });
+    const prompt = buildCardEntryPreprocessPrompt({
+      languageId: input.languageId,
+      noteContent: workspace.note.content,
+    });
+    const response = await aiService.generateStructured({
+      metadata: {
+        feature: 'card-entry',
+        operation: 'preprocess-note',
+        userId: input.userId,
+        languageId: input.languageId,
+        noteId: input.noteId,
+      },
+      systemPrompt: prompt.systemPrompt,
+      userPrompt: prompt.userPrompt,
+      responseSchema: cardEntryPreprocessResponseSchema,
+      cacheKey: `card-entry:${input.userId}:${input.languageId}:${input.noteId}:preprocess`,
+    });
+
+    return finalizeInboxNoteAiProcessing(
+      {
+        userId: input.userId,
+        languageId: input.languageId,
+        noteId: input.noteId,
+        draftCards: response.draftCards.map((draftCard) => ({
+          content: draftCard.content,
+          meaning: draftCard.meaning,
+          examples: draftCard.examples,
+          mnemonics: draftCard.mnemonics,
+          llmInstructions: draftCard.llmInstructions,
+          cardType: 'word',
+        })),
+      },
+      input.database as never
+    );
+  } catch (error) {
+    console.error('Card Entry AI preprocessing failed:', error);
+
+    await transitionInboxNoteAiState(
+      input.userId,
+      input.languageId,
+      input.noteId,
+      'processing',
+      'failed',
+      input.database as never
+    );
+
+    return getNoteWithDraftCards(input.userId, input.languageId, input.noteId, input.database as never);
+  }
+}

--- a/apps/web/src/lib/server/card-entry.ts
+++ b/apps/web/src/lib/server/card-entry.ts
@@ -6,7 +6,10 @@ import {
   getCardEntryCounts,
   getDb,
   getInboxNote,
+  getNoteWithDraftCards,
   listInboxNotes,
+  type InboxNoteAiState,
+  type InboxNoteState,
   type InboxSortOrder,
 } from '@studypuck/database';
 import type { Cookies } from '@sveltejs/kit';
@@ -51,9 +54,22 @@ export type CardEntryInboxData = {
 export type CardEntryNoteShellData = {
   noteId: string;
   content: string;
+  state: InboxNoteState;
+  aiState: InboxNoteAiState;
   createdAtIso: string;
   createdAtLabel: string;
   sourceLabel: string;
+  draftCards: CardEntryNoteDraftCardData[];
+};
+
+export type CardEntryNoteDraftCardData = {
+  cardId: string;
+  content: string;
+  meaning: string | null;
+  examples: string[];
+  mnemonics: string[];
+  llmInstructions: string | null;
+  linkedAtIso: string | null;
 };
 
 export function getCardEntrySortCookieName(languageId: string): string {
@@ -163,6 +179,28 @@ function mapInboxItem(
   };
 }
 
+function normalizeStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+}
+
+function mapDraftCard(
+  draftCard: NonNullable<Awaited<ReturnType<typeof getNoteWithDraftCards>>>['draftCards'][number]
+): CardEntryNoteDraftCardData {
+  return {
+    cardId: draftCard.cardId,
+    content: draftCard.content,
+    meaning: draftCard.meaning ?? null,
+    examples: normalizeStringList(draftCard.examples),
+    mnemonics: normalizeStringList(draftCard.mnemonics),
+    llmInstructions: draftCard.llmInstructions ?? null,
+    linkedAtIso: draftCard.linkedAt?.toISOString() ?? null,
+  };
+}
+
 async function assertUserHasLanguage(
   userId: string,
   languageId: string,
@@ -240,11 +278,13 @@ export async function loadCardEntryNoteShellData(
   noteId: string,
   database: DatabaseClient
 ): Promise<CardEntryNoteShellData> {
-  const note = await getInboxNote(userId, languageId, parseNoteId(noteId), database as never);
+  const workspace = await getNoteWithDraftCards(userId, languageId, parseNoteId(noteId), database as never);
 
-  if (!note) {
+  if (!workspace) {
     throw new CardEntryRequestError(404, 'Card Entry note not found.');
   }
+
+  const note = workspace.note;
 
   if (!note.createdAt) {
     throw new Error(`Inbox note ${note.noteId} is missing createdAt.`);
@@ -253,9 +293,12 @@ export async function loadCardEntryNoteShellData(
   return {
     noteId: note.noteId,
     content: note.content,
+    state: note.state as InboxNoteState,
+    aiState: note.aiState as InboxNoteAiState,
     createdAtIso: note.createdAt.toISOString(),
     createdAtLabel: formatCardEntryRelativeTime(note.createdAt),
     sourceLabel: formatCardEntrySourceLabel(note.sourceType),
+    draftCards: workspace.draftCards.map((draftCard) => mapDraftCard(draftCard)),
   };
 }
 

--- a/apps/web/src/routes/[lang]/card-entry/notes/[noteId]/+page.svelte
+++ b/apps/web/src/routes/[lang]/card-entry/notes/[noteId]/+page.svelte
@@ -1,30 +1,165 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { page } from '$app/stores';
+  import type { CardEntryNoteShellData } from '$lib/server/card-entry.js';
   import type { PageData } from './$types.js';
 
-  let { data } = $props<{ data: PageData }>();
+  export let data: PageData;
+
+  let note: CardEntryNoteShellData = data.note;
+  let isRefreshing = false;
+  let pollingError: string | null = null;
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function clearPollTimer() {
+    if (!pollTimer) {
+      return;
+    }
+
+    clearTimeout(pollTimer);
+    pollTimer = null;
+  }
+
+  function shouldPollAiState(currentNote: CardEntryNoteShellData) {
+    return currentNote.aiState === 'queued' || currentNote.aiState === 'processing';
+  }
+
+  async function refreshProcessingState() {
+    if (isRefreshing) {
+      return;
+    }
+
+    isRefreshing = true;
+
+    try {
+      const response = await fetch(`/${$page.params.lang}/card-entry/notes/${note.noteId}/processing`);
+
+      if (!response.ok) {
+        throw new Error(`Unexpected note processing status response: ${response.status}`);
+      }
+
+      note = await response.json();
+      pollingError = null;
+    } catch (error) {
+      console.error('Failed to refresh Card Entry note processing state:', error);
+      pollingError = 'The latest AI processing status could not be loaded right now.';
+    } finally {
+      isRefreshing = false;
+
+      if (shouldPollAiState(note)) {
+        pollTimer = setTimeout(() => {
+          void refreshProcessingState();
+        }, 2_000);
+      }
+    }
+  }
+
+  onMount(() => {
+    if (shouldPollAiState(note)) {
+      void refreshProcessingState();
+    }
+
+    return () => {
+      clearPollTimer();
+    };
+  });
 </script>
 
 <svelte:head>
-  <title>Process Note – StudyPuck</title>
+  <title>Note Processing – StudyPuck</title>
 </svelte:head>
 
 <section class="note-shell stack" style="--stack-space: var(--space-5)">
   <a class="note-shell__back" href={`/${$page.params.lang}/card-entry`}>← Back to inbox</a>
 
   <header class="note-shell__header stack" style="--stack-space: var(--space-3)">
-    <p class="note-shell__meta">{data.note.sourceLabel} · {data.note.createdAtLabel}</p>
-    <h1>Processing workspace is next</h1>
-    <p class="note-shell__content">{data.note.content}</p>
+    <p class="note-shell__meta">{note.sourceLabel} · {note.createdAtLabel}</p>
+    <h1>Note Processing</h1>
+    <p class="note-shell__content">{note.content}</p>
   </header>
 
-  <section class="note-shell__placeholder stack" style="--stack-space: var(--space-3)" aria-labelledby="note-shell-placeholder-title">
-    <h2 id="note-shell-placeholder-title">Temporary handoff page</h2>
-    <p>
-      This route is wired so the inbox’s Process action already lands in the right place. The full draft-card
-      workspace is still scheduled for issue 117.
-    </p>
-  </section>
+  {#if note.aiState === 'queued' || note.aiState === 'processing'}
+    <section class="note-shell__status note-shell__status--loading stack" style="--stack-space: var(--space-3)" aria-live="polite">
+      <h2>AI is preparing your cards…</h2>
+      <p>
+        {note.aiState === 'queued'
+          ? 'This note is queued for preprocessing.'
+          : 'Draft cards are being generated for this note now.'}
+      </p>
+      {#if pollingError}
+        <p class="note-shell__status-detail">{pollingError}</p>
+      {:else if isRefreshing}
+        <p class="note-shell__status-detail">Refreshing the latest processing state…</p>
+      {/if}
+    </section>
+  {:else if note.aiState === 'failed'}
+    <section class="note-shell__status note-shell__status--error stack" style="--stack-space: var(--space-3)" role="alert">
+      <h2>AI processing failed</h2>
+      <p>The note stays in Card Entry so it can still be finished manually as the workspace evolves.</p>
+      {#if pollingError}
+        <p class="note-shell__status-detail">{pollingError}</p>
+      {/if}
+    </section>
+  {/if}
+
+  {#if note.draftCards.length > 0}
+    <section class="draft-preview stack" style="--stack-space: var(--space-4)" aria-labelledby="draft-preview-title">
+      <div class="draft-preview__heading stack" style="--stack-space: var(--space-2)">
+        <h2 id="draft-preview-title">Draft cards</h2>
+        <p>The shared AI preprocessing pipeline has populated these draft fields for the upcoming inline editor.</p>
+      </div>
+
+      {#each note.draftCards as draftCard}
+        <article class="draft-preview__card stack" style="--stack-space: var(--space-3)">
+          <div class="stack" style="--stack-space: var(--space-2)">
+            <p class="draft-preview__label">Content</p>
+            <p class="draft-preview__value">{draftCard.content}</p>
+          </div>
+
+          {#if draftCard.meaning}
+            <div class="stack" style="--stack-space: var(--space-2)">
+              <p class="draft-preview__label">Meaning</p>
+              <p class="draft-preview__value">{draftCard.meaning}</p>
+            </div>
+          {/if}
+
+          {#if draftCard.examples.length > 0}
+            <div class="stack" style="--stack-space: var(--space-2)">
+              <p class="draft-preview__label">Examples</p>
+              <ul class="draft-preview__list">
+                {#each draftCard.examples as example}
+                  <li>{example}</li>
+                {/each}
+              </ul>
+            </div>
+          {/if}
+
+          {#if draftCard.mnemonics.length > 0}
+            <div class="stack" style="--stack-space: var(--space-2)">
+              <p class="draft-preview__label">Mnemonics</p>
+              <ul class="draft-preview__list">
+                {#each draftCard.mnemonics as mnemonic}
+                  <li>{mnemonic}</li>
+                {/each}
+              </ul>
+            </div>
+          {/if}
+
+          {#if draftCard.llmInstructions}
+            <div class="stack" style="--stack-space: var(--space-2)">
+              <p class="draft-preview__label">LLM instructions</p>
+              <p class="draft-preview__value">{draftCard.llmInstructions}</p>
+            </div>
+          {/if}
+        </article>
+      {/each}
+    </section>
+  {:else if note.aiState === 'complete'}
+    <section class="note-shell__status stack" style="--stack-space: var(--space-3)">
+      <h2>No draft cards were generated</h2>
+      <p>The note finished preprocessing without draft output, so it remains ready for manual follow-up.</p>
+    </section>
+  {/if}
 </section>
 
 <style>
@@ -34,8 +169,14 @@
 
   .note-shell__back,
   .note-shell__meta,
-  .note-shell__placeholder p,
-  .note-shell__content {
+  .note-shell__content,
+  .note-shell__status h2,
+  .note-shell__status p,
+  .draft-preview__heading h2,
+  .draft-preview__heading p,
+  .draft-preview__label,
+  .draft-preview__value,
+  .draft-preview__list {
     margin: 0;
   }
 
@@ -46,7 +187,8 @@
   }
 
   .note-shell__header,
-  .note-shell__placeholder {
+  .note-shell__status,
+  .draft-preview__card {
     padding: var(--space-5);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
@@ -54,7 +196,8 @@
     box-shadow: var(--shadow-sm);
   }
 
-  .note-shell__meta {
+  .note-shell__meta,
+  .draft-preview__label {
     color: var(--color-text-secondary);
     font-family: var(--font-ui);
     font-size: var(--font-size-caption);
@@ -62,14 +205,33 @@
     text-transform: uppercase;
   }
 
-  .note-shell__header h1,
-  .note-shell__placeholder h2 {
-    margin: 0;
-  }
-
   .note-shell__content {
     font-size: var(--font-size-h4);
     line-height: 1.5;
+  }
+
+  .note-shell__status--loading {
+    border-color: color-mix(in srgb, var(--color-primary) 40%, var(--color-border));
+  }
+
+  .note-shell__status--error {
+    border-color: color-mix(in srgb, var(--color-danger-text) 40%, var(--color-border));
+  }
+
+  .note-shell__status-detail {
+    color: var(--color-text-secondary);
+  }
+
+  .draft-preview__heading p {
+    color: var(--color-text-secondary);
+  }
+
+  .draft-preview__value {
+    line-height: 1.5;
+  }
+
+  .draft-preview__list {
+    padding-inline-start: 1.25rem;
   }
 
   .note-shell__back:focus-visible {

--- a/apps/web/src/routes/[lang]/card-entry/notes/[noteId]/processing/+server.ts
+++ b/apps/web/src/routes/[lang]/card-entry/notes/[noteId]/processing/+server.ts
@@ -1,0 +1,43 @@
+import { error, json, type RequestHandler } from '@sveltejs/kit';
+import { getDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import { ensureCardEntryNoteProcessingState } from '$lib/server/card-entry-ai.js';
+import { CardEntryRequestError, loadCardEntryNoteShellData } from '$lib/server/card-entry.js';
+
+export const GET: RequestHandler = async (event) => {
+  const session = await event.locals.auth();
+  const userId = session?.user?.id;
+  const languageId = event.params.lang;
+  const noteId = event.params.noteId;
+
+  if (!userId || !languageId || !noteId) {
+    throw error(401, 'You must be signed in to check this note.');
+  }
+
+  const database = getDb(env.DATABASE_URL);
+
+  try {
+    const workspace = await ensureCardEntryNoteProcessingState({
+      userId,
+      languageId,
+      noteId,
+      database,
+      privateEnv: env,
+    });
+
+    if (!workspace) {
+      throw error(404, 'Card Entry note not found.');
+    }
+
+    const note = await loadCardEntryNoteShellData(userId, languageId, noteId, database);
+
+    return json(note);
+  } catch (requestError) {
+    if (requestError instanceof CardEntryRequestError) {
+      throw error(requestError.status, requestError.message);
+    }
+
+    console.error('Failed to update Card Entry note processing state:', requestError);
+    throw error(500, 'The note processing status could not be refreshed right now.');
+  }
+};

--- a/apps/web/tests/e2e/card-entry.spec.ts
+++ b/apps/web/tests/e2e/card-entry.spec.ts
@@ -80,6 +80,7 @@ test('supports command-bar quick-add flow and process handoff route', async ({ p
   await drawerRow.getByRole('link', { name: 'Process →' }).click();
 
   await page.waitForURL(/\/es\/card-entry\/notes\//);
-  await expect(page.getByRole('heading', { name: 'Processing workspace is next' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Note Processing' })).toBeVisible();
   await expect(page.getByText('hola desde drawer')).toBeVisible();
+  await expect(page.getByText(/AI is preparing your cards…|AI processing failed/)).toBeVisible();
 });

--- a/docs/ops/adding-environment-variables.md
+++ b/docs/ops/adding-environment-variables.md
@@ -68,6 +68,14 @@ EXAMPLE_API_KEY=exec('node scripts/bitwarden-secret.mjs EXAMPLE_API_KEY')
 EXAMPLE_BASE_URL=
 ```
 
+### Example: optional Bitwarden-backed secret
+
+```env-spec
+# Optional fallback provider key.
+# @optional @sensitive @type=string
+EXAMPLE_OPTIONAL_SECRET=exec('node scripts/bitwarden-optional-secret.mjs EXAMPLE_OPTIONAL_SECRET')
+```
+
 ### Example: browser-safe public value
 
 ```env-spec
@@ -84,6 +92,12 @@ If the value is sensitive and should be available in local dev/Codespaces, wire 
 
 ```env-spec
 MY_SECRET=exec('node scripts/bitwarden-secret.mjs MY_SECRET')
+```
+
+If the secret is intentionally optional, use the optional helper so local env validation still passes when the Bitwarden field is absent:
+
+```env-spec
+OPTIONAL_SECRET=exec('node scripts/bitwarden-optional-secret.mjs OPTIONAL_SECRET')
 ```
 
 Then add the same custom field name to the approved Bitwarden item, normally:

--- a/packages/database/migrations/0007_repair_cards_schema.sql
+++ b/packages/database/migrations/0007_repair_cards_schema.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "cards" ADD COLUMN IF NOT EXISTS "deleted_at" timestamp with time zone;--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_cards_fulltext";--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_cards_fulltext_simple";--> statement-breakpoint
+CREATE INDEX "idx_cards_fulltext" ON "cards" USING gin (to_tsvector('english', "content" || ' ' || COALESCE("meaning", '') || ' ' || COALESCE("examples"::text, '') || ' ' || COALESCE("mnemonics"::text, '')));--> statement-breakpoint
+CREATE INDEX "idx_cards_fulltext_simple" ON "cards" USING gin (to_tsvector('simple', "content" || ' ' || COALESCE("meaning", '') || ' ' || COALESCE("examples"::text, '') || ' ' || COALESCE("mnemonics"::text, '')));

--- a/packages/database/migrations/meta/0007_snapshot.json
+++ b/packages/database/migrations/meta/0007_snapshot.json
@@ -1,0 +1,1819 @@
+{
+  "id": "f07d7350-3fd3-41dd-8af3-ee14fa94f26f",
+  "prevId": "8ef25aa3-96df-4314-8ebc-7eca5860e5ff",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.study_languages": {
+      "name": "study_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_name": {
+          "name": "language_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "cefr_level": {
+          "name": "cefr_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'A1'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "study_languages_user_id_language_id_pk": {
+          "name": "study_languages_user_id_language_id_pk",
+          "columns": [
+            "user_id",
+            "language_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.card_groups": {
+      "name": "card_groups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_card_groups_by_group": {
+          "name": "idx_card_groups_by_group",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_card_groups_by_card": {
+          "name": "idx_card_groups_by_card",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "card_groups_user_id_language_id_card_id_group_id_pk": {
+          "name": "card_groups_user_id_language_id_card_id_group_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "card_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cards": {
+      "name": "cards",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "card_type": {
+          "name": "card_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'word'"
+        },
+        "meaning": {
+          "name": "meaning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "examples": {
+          "name": "examples",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mnemonics": {
+          "name": "mnemonics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llm_instructions": {
+          "name": "llm_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_generated_at": {
+          "name": "embedding_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cards_status_type": {
+          "name": "idx_cards_status_type",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "card_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cards_status_updated": {
+          "name": "idx_cards_status_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cards_embedding_similarity": {
+          "name": "idx_cards_embedding_similarity",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "idx_cards_active_type": {
+          "name": "idx_cards_active_type",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "card_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cards_active_updated": {
+          "name": "idx_cards_active_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cards_fulltext": {
+          "name": "idx_cards_fulltext",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"content\" || ' ' || COALESCE(\"meaning\", '') || ' ' || COALESCE(\"examples\"::text, '') || ' ' || COALESCE(\"mnemonics\"::text, ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_cards_fulltext_simple": {
+          "name": "idx_cards_fulltext_simple",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', \"content\" || ' ' || COALESCE(\"meaning\", '') || ' ' || COALESCE(\"examples\"::text, '') || ' ' || COALESCE(\"mnemonics\"::text, ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "cards_user_id_language_id_card_id_pk": {
+          "name": "cards_user_id_language_id_card_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "card_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_generated_at": {
+          "name": "embedding_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_groups_embedding_similarity": {
+          "name": "idx_groups_embedding_similarity",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "groups_user_id_language_id_group_id_pk": {
+          "name": "groups_user_id_language_id_group_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.card_entry_daily_stats": {
+      "name": "card_entry_daily_stats",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes_captured": {
+          "name": "notes_captured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "notes_processed": {
+          "name": "notes_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "notes_deferred": {
+          "name": "notes_deferred",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "notes_deleted": {
+          "name": "notes_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "draft_cards_created": {
+          "name": "draft_cards_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_promoted_to_active": {
+          "name": "cards_promoted_to_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "groups_created": {
+          "name": "groups_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_card_entry_stats_date": {
+          "name": "idx_card_entry_stats_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "card_entry_daily_stats_user_id_language_id_date_pk": {
+          "name": "card_entry_daily_stats_user_id_language_id_date_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_notes": {
+      "name": "inbox_notes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unprocessed'"
+        },
+        "ai_state": {
+          "name": "ai_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'complete'"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'manual'"
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_inbox_state": {
+          "name": "idx_inbox_state",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbox_ai_state": {
+          "name": "idx_inbox_ai_state",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ai_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbox_source": {
+          "name": "idx_inbox_source",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inbox_notes_user_id_language_id_note_id_pk": {
+          "name": "inbox_notes_user_id_language_id_note_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "note_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_card_links": {
+      "name": "note_card_links",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_note_card_links_note": {
+          "name": "idx_note_card_links_note",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_note_card_links_card": {
+          "name": "idx_note_card_links_card",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "note_card_links_user_id_language_id_note_id_card_id_pk": {
+          "name": "note_card_links_user_id_language_id_note_id_card_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "note_id",
+            "card_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.card_review_daily_stats": {
+      "name": "card_review_daily_stats",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cards_reviewed": {
+          "name": "cards_reviewed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "total_review_time_minutes": {
+          "name": "total_review_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_rated_easy": {
+          "name": "cards_rated_easy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_rated_medium": {
+          "name": "cards_rated_medium",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_rated_hard": {
+          "name": "cards_rated_hard",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_snoozed": {
+          "name": "cards_snoozed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_disabled": {
+          "name": "cards_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_pinned_to_drills": {
+          "name": "cards_pinned_to_drills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_card_review_stats_date": {
+          "name": "idx_card_review_stats_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "card_review_daily_stats_user_id_language_id_date_pk": {
+          "name": "card_review_daily_stats_user_id_language_id_date_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.card_review_srs": {
+      "name": "card_review_srs",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_due": {
+          "name": "next_due",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "interval_days": {
+          "name": "interval_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "ease_factor": {
+          "name": "ease_factor",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2.5
+        },
+        "review_count": {
+          "name": "review_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_reviewed": {
+          "name": "last_reviewed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_card_review_srs_due": {
+          "name": "idx_card_review_srs_due",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_card_review_srs_interval": {
+          "name": "idx_card_review_srs_interval",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "interval_days",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "card_review_srs_user_id_language_id_card_id_pk": {
+          "name": "card_review_srs_user_id_language_id_card_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "card_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_drill_context": {
+      "name": "translation_drill_context",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "added_from": {
+          "name": "added_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "state_until": {
+          "name": "state_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cefr_override": {
+          "name": "cefr_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_translation_context_state": {
+          "name": "idx_translation_context_state",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_context_added": {
+          "name": "idx_translation_context_added",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "added_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_context_rotation": {
+          "name": "idx_translation_context_rotation",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_used",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "translation_drill_context_user_id_language_id_card_id_pk": {
+          "name": "translation_drill_context_user_id_language_id_card_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "card_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_drill_daily_stats": {
+      "name": "translation_drill_daily_stats",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sentences_translated": {
+          "name": "sentences_translated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "total_session_time_minutes": {
+          "name": "total_session_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_dismissed": {
+          "name": "cards_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_snoozed": {
+          "name": "cards_snoozed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_drawn": {
+          "name": "cards_drawn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "new_context_groups_added": {
+          "name": "new_context_groups_added",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_translation_drill_stats_date": {
+          "name": "idx_translation_drill_stats_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "translation_drill_daily_stats_user_id_language_id_date_pk": {
+          "name": "translation_drill_daily_stats_user_id_language_id_date_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_drill_draw_piles": {
+      "name": "translation_drill_draw_piles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "draw_pile_name": {
+          "name": "draw_pile_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pile_size_limit": {
+          "name": "pile_size_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_draw_piles_enabled": {
+          "name": "idx_draw_piles_enabled",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "translation_drill_draw_piles_user_id_language_id_group_id_pk": {
+          "name": "translation_drill_draw_piles_user_id_language_id_group_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_drill_srs": {
+      "name": "translation_drill_srs",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_due": {
+          "name": "next_due",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "interval_days": {
+          "name": "interval_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performance_score": {
+          "name": "performance_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_translation_drill_srs_due": {
+          "name": "idx_translation_drill_srs_due",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "translation_drill_srs_user_id_language_id_card_id_pk": {
+          "name": "translation_drill_srs_user_id_language_id_card_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "card_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1776140298106,
       "tag": "0006_absent_dark_phoenix",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1776486900000,
+      "tag": "0007_repair_cards_schema",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/card-entry.ts
+++ b/packages/database/src/card-entry.ts
@@ -76,6 +76,13 @@ export type CreateDraftCardFromNoteInput = Omit<
   cardId?: string;
 };
 
+export type GeneratedDraftCardInput = Omit<
+  CreateDraftCardFromNoteInput,
+  'userId' | 'languageId' | 'noteId' | 'cardId'
+> & {
+  cardId?: string;
+};
+
 /** Returns the global lazily-initialised db, importing index only when needed */
 async function globalDb(): Promise<AnyDb> {
   return (await import('./index.js')).db as AnyDb;
@@ -294,6 +301,99 @@ export async function updateInboxNoteAiState(
     .returning();
 
   return result[0] || null;
+}
+
+export async function transitionInboxNoteAiState(
+  userId: string,
+  languageId: string,
+  noteId: string,
+  currentAiState: InboxNoteAiState | InboxNoteAiState[],
+  nextAiState: InboxNoteAiState,
+  db?: AnyDb
+): Promise<InboxNote | null> {
+  const conn = db ?? await globalDb();
+  const currentStates = Array.isArray(currentAiState) ? currentAiState : [currentAiState];
+  const result = await conn
+    .update(inboxNotes)
+    .set({ aiState: nextAiState })
+    .where(and(
+      eq(inboxNotes.userId, userId),
+      eq(inboxNotes.languageId, languageId),
+      eq(inboxNotes.noteId, noteId),
+      currentStates.length === 1
+        ? eq(inboxNotes.aiState, currentStates[0])
+        : inArray(inboxNotes.aiState, currentStates)
+    ))
+    .returning();
+
+  return result[0] || null;
+}
+
+export async function finalizeInboxNoteAiProcessing(
+  input: {
+    userId: string;
+    languageId: string;
+    noteId: string;
+    draftCards: GeneratedDraftCardInput[];
+  },
+  db?: AnyDb
+): Promise<NoteWithDraftCards | null> {
+  return withTransaction(db, async (tx) => {
+    const workspace = await getNoteWithDraftCards(input.userId, input.languageId, input.noteId, tx);
+
+    if (!workspace) {
+      return null;
+    }
+
+    if (workspace.note.aiState !== 'processing') {
+      return workspace;
+    }
+
+    if (workspace.draftCards.length === 0) {
+      const now = new Date();
+
+      for (const draftCard of input.draftCards) {
+        const cardId = draftCard.cardId ?? createId('card');
+        const [createdCard] = await tx
+          .insert(cards)
+          .values({
+            ...draftCard,
+            userId: input.userId,
+            languageId: input.languageId,
+            cardId,
+            status: 'draft',
+            createdAt: now,
+            updatedAt: now,
+          })
+          .returning();
+
+        await tx.insert(noteCardLinks).values({
+          userId: input.userId,
+          languageId: input.languageId,
+          noteId: input.noteId,
+          cardId: createdCard!.cardId,
+          createdAt: now,
+        });
+      }
+
+      if (input.draftCards.length > 0) {
+        await incrementCardEntryDailyStats(input.userId, input.languageId, {
+          draftCardsCreated: input.draftCards.length,
+        }, tx);
+      }
+    }
+
+    await tx
+      .update(inboxNotes)
+      .set({ aiState: 'complete' })
+      .where(and(
+        eq(inboxNotes.userId, input.userId),
+        eq(inboxNotes.languageId, input.languageId),
+        eq(inboxNotes.noteId, input.noteId)
+      ));
+
+    return getNoteWithDraftCards(input.userId, input.languageId, input.noteId, tx);
+  });
 }
 
 export async function deferInboxNote(

--- a/packages/database/src/tests/card-entry.test.ts
+++ b/packages/database/src/tests/card-entry.test.ts
@@ -8,11 +8,13 @@ import {
   createInboxNote,
   deferInboxNote,
   deleteInboxNote,
+  finalizeInboxNoteAiProcessing,
   getCardEntryCounts,
   getDraftCardsForLanguage,
   getNoteWithDraftCards,
   listInboxNotes,
   signOffNote,
+  transitionInboxNoteAiState,
   updateInboxNoteAiState,
 } from '../card-entry.js';
 
@@ -257,5 +259,66 @@ describe('Card Entry database operations', () => {
 
     const [stats] = await db.select().from(cardEntryDailyStats);
     expect(stats.notesDeferred).toBe(1);
+  });
+
+  it('claims queued notes for preprocessing and finalizes generated draft cards idempotently', async () => {
+    await createInboxNote({
+      userId: TEST_USER.userId,
+      languageId: TEST_LANG.languageId,
+      noteId: 'note-ai-preprocess',
+      content: 'anotar cuando usar por si acaso',
+      sourceType: 'manual',
+    }, db);
+
+    const claimed = await transitionInboxNoteAiState(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      'note-ai-preprocess',
+      'queued',
+      'processing',
+      db
+    );
+
+    expect(claimed?.aiState).toBe('processing');
+
+    const finalized = await finalizeInboxNoteAiProcessing(
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        noteId: 'note-ai-preprocess',
+        draftCards: [
+          {
+            content: 'por si acaso',
+            meaning: 'just in case',
+            examples: ['Llevo agua por si acaso.'],
+            mnemonics: ['Think of taking something along just in case.'],
+          },
+        ],
+      },
+      db
+    );
+
+    expect(finalized?.note.aiState).toBe('complete');
+    expect(finalized?.draftCards).toHaveLength(1);
+    expect(finalized?.draftCards[0]?.content).toBe('por si acaso');
+
+    const finalizedAgain = await finalizeInboxNoteAiProcessing(
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        noteId: 'note-ai-preprocess',
+        draftCards: [
+          {
+            content: 'duplicate draft should not be created',
+          },
+        ],
+      },
+      db
+    );
+
+    expect(finalizedAgain?.draftCards).toHaveLength(1);
+
+    const counts = await getCardEntryCounts(TEST_USER.userId, TEST_LANG.languageId, db);
+    expect(counts.draftCardCount).toBe(1);
   });
 });

--- a/scripts/bitwarden-optional-secret.mjs
+++ b/scripts/bitwarden-optional-secret.mjs
@@ -1,0 +1,20 @@
+import { resolveSecretValue } from './studypuck-env.mjs';
+
+const key = process.argv[2];
+
+if (!key) {
+	throw new Error('Usage: node scripts/bitwarden-optional-secret.mjs <ENV_KEY>');
+}
+
+try {
+	process.stdout.write(resolveSecretValue(key));
+} catch (error) {
+	const message = error instanceof Error ? error.message : String(error);
+
+	if (message.includes(`missing a custom field named ${key}`)) {
+		process.stdout.write('');
+		process.exit(0);
+	}
+
+	throw error;
+}

--- a/scripts/run-with-bitwarden-env.mjs
+++ b/scripts/run-with-bitwarden-env.mjs
@@ -1,7 +1,7 @@
 import { execFileSync, execSync, spawn } from 'node:child_process';
 import { writeFileSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
-import { maskValue, resolveStudypuckEnv, requiredSecretKeys } from './studypuck-env.mjs';
+import { maskValue, optionalEnvKeys, optionalSecretKeys, resolveStudypuckEnv, requiredSecretKeys } from './studypuck-env.mjs';
 
 const args = process.argv.slice(2);
 const overrides = {};
@@ -199,7 +199,13 @@ if (writeDevVars) {
 			: 'http://127.0.0.1:8788';
 	}
 
-	const devVarsKeys = [...requiredSecretKeys, ...Object.keys(overrides), 'ORIGIN'];
+	const devVarsKeys = [
+		...requiredSecretKeys,
+		...optionalSecretKeys,
+		...optionalEnvKeys,
+		...Object.keys(overrides),
+		'ORIGIN',
+	];
 	const lines = devVarsKeys
 		.filter((k) => fallbackEnv[k])
 		.map((k) => `${k}="${fallbackEnv[k].replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`)

--- a/scripts/studypuck-env.mjs
+++ b/scripts/studypuck-env.mjs
@@ -11,9 +11,18 @@ export const requiredSecretKeys = [
 	'DATABASE_URL',
 ];
 
-const supportedSecretKeys = [...requiredSecretKeys, 'NEON_API_KEY'];
+export const optionalSecretKeys = ['NEON_API_KEY', 'GEMINI_API_KEY', 'OPENAI_API_KEY'];
 
-export const optionalEnvKeys = ['AUTH_URL', 'AUTH_REDIRECT_PROXY_URL', 'ORIGIN'];
+const supportedSecretKeys = [...requiredSecretKeys, ...optionalSecretKeys];
+
+export const optionalEnvKeys = [
+	'AUTH_URL',
+	'AUTH_REDIRECT_PROXY_URL',
+	'ORIGIN',
+	'STUDYPUCK_AI_PRIMARY_PROVIDER',
+	'GEMINI_TEXT_MODEL',
+	'OPENAI_TEXT_MODEL',
+];
 
 const defaultBitwardenItem = 'StudyPuck Dev';
 let cachedItem;
@@ -147,6 +156,26 @@ export const resolveStudypuckEnv = () => {
 
 	for (const key of requiredSecretKeys) {
 		resolved[key] = resolveSecretValue(key);
+	}
+
+	for (const key of optionalSecretKeys) {
+		if (process.env[key]) {
+			resolved[key] = process.env[key];
+			continue;
+		}
+
+		try {
+			resolved[key] = resolveSecretValue(key);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+
+			if (message.includes(`missing a custom field named ${key}`)) {
+				resolved[key] = '';
+				continue;
+			}
+
+			throw error;
+		}
 	}
 
 	for (const key of optionalEnvKeys) {


### PR DESCRIPTION
## Summary
- add a shared server-side AI boundary for Card Entry preprocessing and note polling
- wire Card Entry note processing UI, database finalization, tests, and secure optional AI secret handling
- add a forward repair migration for the skipped cards schema changes caused by non-monotonic Drizzle journal timestamps

## Validation
- pnpm turbo lint check-types build --filter=web
- local Card Entry note processing flow with Gemini completed successfully after applying the repair migration

## Production follow-up
- confirm production records the new migration in drizzle.__drizzle_migrations
- confirm public.cards includes deleted_at after deploy

Closes #119