### PR TITLE
Fix Card Entry transaction contract in Workers

### DIFF
--- a/apps/web/src/lib/server/card-entry-ai.ts
+++ b/apps/web/src/lib/server/card-entry-ai.ts
@@ -3,13 +3,10 @@ import {
   getNoteWithDraftCards,
   transitionInboxNoteAiState,
   type InboxNoteAiState,
+  type TransactionCapableDatabaseConnection,
 } from '@studypuck/database';
 import { buildCardEntryPreprocessPrompt, cardEntryPreprocessResponseSchema } from '$lib/server/ai-prompts/card-entry.js';
 import { createAiService } from '$lib/server/ai-service.js';
-
-type DatabaseClient = {
-  [key: string]: unknown;
-};
 
 const TERMINAL_AI_STATES: InboxNoteAiState[] = ['complete', 'failed'];
 
@@ -17,14 +14,14 @@ export async function ensureCardEntryNoteProcessingState(input: {
   userId: string;
   languageId: string;
   noteId: string;
-  database: DatabaseClient;
+  transactionDatabase: TransactionCapableDatabaseConnection;
   privateEnv: Record<string, string | undefined>;
 }) {
   const workspace = await getNoteWithDraftCards(
     input.userId,
     input.languageId,
     input.noteId,
-    input.database as never
+    input.transactionDatabase as never
   );
 
   if (!workspace) {
@@ -45,11 +42,11 @@ export async function ensureCardEntryNoteProcessingState(input: {
     input.noteId,
     'queued',
     'processing',
-    input.database as never
+    input.transactionDatabase as never
   );
 
   if (!claimed) {
-    return getNoteWithDraftCards(input.userId, input.languageId, input.noteId, input.database as never);
+    return getNoteWithDraftCards(input.userId, input.languageId, input.noteId, input.transactionDatabase as never);
   }
 
   try {
@@ -88,7 +85,7 @@ export async function ensureCardEntryNoteProcessingState(input: {
           cardType: 'word',
         })),
       },
-      input.database as never
+      input.transactionDatabase as never
     );
   } catch (error) {
     console.error('Card Entry AI preprocessing failed:', error);
@@ -99,9 +96,9 @@ export async function ensureCardEntryNoteProcessingState(input: {
       input.noteId,
       'processing',
       'failed',
-      input.database as never
+      input.transactionDatabase as never
     );
 
-    return getNoteWithDraftCards(input.userId, input.languageId, input.noteId, input.database as never);
+    return getNoteWithDraftCards(input.userId, input.languageId, input.noteId, input.transactionDatabase as never);
   }
 }

--- a/apps/web/src/routes/[lang]/card-entry/notes/[noteId]/processing/+server.ts
+++ b/apps/web/src/routes/[lang]/card-entry/notes/[noteId]/processing/+server.ts
@@ -1,5 +1,5 @@
 import { error, json, type RequestHandler } from '@sveltejs/kit';
-import { getDb } from '@studypuck/database';
+import { withTransactionDb } from '@studypuck/database';
 import { env } from '$env/dynamic/private';
 import { ensureCardEntryNoteProcessingState } from '$lib/server/card-entry-ai.js';
 import { CardEntryRequestError, loadCardEntryNoteShellData } from '$lib/server/card-entry.js';
@@ -13,23 +13,29 @@ export const GET: RequestHandler = async (event) => {
   if (!userId || !languageId || !noteId) {
     throw error(401, 'You must be signed in to check this note.');
   }
-
-  const database = getDb(env.DATABASE_URL);
+  
+  const databaseUrl = env.DATABASE_URL;
+  
+  if (!databaseUrl) {
+    throw error(500, 'The note processing service is not configured right now.');
+  }
 
   try {
-    const workspace = await ensureCardEntryNoteProcessingState({
-      userId,
-      languageId,
-      noteId,
-      database,
-      privateEnv: env,
+    const note = await withTransactionDb(databaseUrl, async (database) => {
+      const workspace = await ensureCardEntryNoteProcessingState({
+        userId,
+        languageId,
+        noteId,
+        transactionDatabase: database,
+        privateEnv: env,
+      });
+
+      if (!workspace) {
+        throw error(404, 'Card Entry note not found.');
+      }
+
+      return loadCardEntryNoteShellData(userId, languageId, noteId, database);
     });
-
-    if (!workspace) {
-      throw error(404, 'Card Entry note not found.');
-    }
-
-    const note = await loadCardEntryNoteShellData(userId, languageId, noteId, database);
 
     return json(note);
   } catch (requestError) {

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -5,6 +5,9 @@ import * as schema from './schema.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DatabaseConnection = any;
+export type TransactionCapableDatabaseConnection = DatabaseConnection & {
+  transaction: <T>(callback: (tx: DatabaseConnection) => Promise<T>) => Promise<T>;
+};
 type PostgresFactory = (
   databaseUrl: string,
   options?: {
@@ -105,13 +108,13 @@ export function getDb(databaseUrl?: string) {
  */
 export async function withTransactionDb<T>(
   databaseUrl: string,
-  callback: (db: DatabaseConnection) => Promise<T>
+  callback: (db: TransactionCapableDatabaseConnection) => Promise<T>
 ): Promise<T> {
   if (isNodeRuntime()) {
-    return callback(createNodeDatabaseConnection(databaseUrl));
+    return callback(createNodeDatabaseConnection(databaseUrl) as TransactionCapableDatabaseConnection);
   }
 
-  const db = createWorkerTransactionDatabaseConnection(databaseUrl);
+  const db = createWorkerTransactionDatabaseConnection(databaseUrl) as TransactionCapableDatabaseConnection;
   const pool = db.$client as Pool;
 
   try {


### PR DESCRIPTION
## Summary
- route Card Entry note processing through withTransactionDb instead of the runtime-dependent getDb path
- make the transaction requirement explicit by typing the Card Entry processing helper to require a transaction-capable DB connection
- keep simple read paths on getDb while ensuring multi-step mutation finalization uses a driver that supports transactions in Cloudflare Workers

## Validation
- pnpm turbo lint check-types build --filter=web

## Context
Production note processing failed after Gemini completed because the default Cloudflare Worker database client uses neon-http, which does not support Drizzle transactions. This change makes the transaction-capable path explicit in code.
