### PR TITLE
Fix development branch sync reset

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,7 +114,9 @@ jobs:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
         run: |
           echo "📋 Syncing development branch to production state..."
-          npx neonctl branches reset development --parent
+          PRESERVE_NAME=development-preserved-$(date +%Y%m%d_%H%M%S)
+          npx neonctl branches reset development --parent --preserve-under-name "$PRESERVE_NAME"
+          echo "ℹ️ Previous development state preserved as: $PRESERVE_NAME"
           echo "✅ Development branch synced to production state"
       
       # Rollback on failure


### PR DESCRIPTION
## Summary
- update the production deploy workflow to reset the Neon development branch with an explicit preserve-under-name value
- preserve the prior development branch state under a timestamped name before resetting to production
- avoid the ambiguous Neon CLI failure that blocked the final sync step even though production deploy itself succeeded

## Context
The production deploy completed successfully, but the workflow failed in the final \
px neonctl branches reset development --parent\ step with: \Branch has children, preserve_under_name is required\. This change makes the reset behavior explicit.
