### PR TITLE
Implement Card Entry note processing workspace

### DIFF
--- a/apps/web/src/lib/card-entry/workspace.test.ts
+++ b/apps/web/src/lib/card-entry/workspace.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { getUnresolvedDuplicateWarnings, replaceDraftCardInNote } from './workspace.js';
+import type { CardEntryNoteShellData } from '$lib/server/card-entry.js';
+
+function createNoteFixture(): CardEntryNoteShellData {
+  return {
+    noteId: 'note-1',
+    content: 'Need a draft',
+    state: 'unprocessed',
+    aiState: 'complete',
+    createdAtIso: '2026-04-18T00:00:00.000Z',
+    createdAtLabel: 'Just now',
+    sourceLabel: 'Manual',
+    availableGroups: [
+      { groupId: 'group-a', groupName: 'Grammar' },
+      { groupId: 'group-b', groupName: 'Travel' },
+    ],
+    draftCards: [
+      {
+        cardId: 'card-1',
+        content: 'se me ocurrió',
+        meaning: null,
+        examples: ['Se me ocurrió una idea.'],
+        mnemonics: [],
+        llmInstructions: null,
+        linkedAtIso: null,
+        groups: [{ groupId: 'group-a', groupName: 'Grammar' }],
+        duplicateWarnings: [
+          {
+            warningId: 'warning-1',
+            title: 'Possible duplicate',
+            similarCardLabel: 'ocurrírsele a alguien',
+            dismissed: false,
+          },
+        ],
+      },
+      {
+        cardId: 'card-2',
+        content: '',
+        meaning: null,
+        examples: [],
+        mnemonics: [],
+        llmInstructions: null,
+        linkedAtIso: null,
+        groups: [],
+        duplicateWarnings: [
+          {
+            warningId: 'warning-2',
+            title: 'Possible duplicate',
+            similarCardLabel: 'tiempo transcurrido',
+            dismissed: true,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe('replaceDraftCardInNote', () => {
+  it('replaces the matching draft card and refreshes available groups', () => {
+    const note = createNoteFixture();
+    const updated = replaceDraftCardInNote(
+      note,
+      {
+        ...note.draftCards[0],
+        content: 'nuevo contenido',
+      },
+      [{ groupId: 'group-c', groupName: 'Idioms' }]
+    );
+
+    expect(updated.draftCards[0]?.content).toBe('nuevo contenido');
+    expect(updated.draftCards[1]?.content).toBe(note.draftCards[1]?.content);
+    expect(updated.availableGroups).toEqual([{ groupId: 'group-c', groupName: 'Idioms' }]);
+  });
+});
+
+describe('getUnresolvedDuplicateWarnings', () => {
+  it('flattens only unresolved warnings and falls back for blank card labels', () => {
+    const note = createNoteFixture();
+    const warnings = getUnresolvedDuplicateWarnings(note);
+
+    expect(warnings).toEqual([
+      {
+        cardId: 'card-1',
+        cardLabel: 'se me ocurrió',
+        warningId: 'warning-1',
+        title: 'Possible duplicate',
+        similarCardLabel: 'ocurrírsele a alguien',
+      },
+    ]);
+  });
+});

--- a/apps/web/src/lib/card-entry/workspace.ts
+++ b/apps/web/src/lib/card-entry/workspace.ts
@@ -1,0 +1,41 @@
+import type {
+  CardEntryGroupData,
+  CardEntryNoteDraftCardData,
+  CardEntryNoteShellData,
+} from '$lib/server/card-entry.js';
+
+export type UnresolvedDuplicateWarning = {
+  cardId: string;
+  cardLabel: string;
+  warningId: string;
+  title: string;
+  similarCardLabel: string;
+};
+
+export function replaceDraftCardInNote(
+  note: CardEntryNoteShellData,
+  updatedCard: CardEntryNoteDraftCardData,
+  availableGroups: CardEntryGroupData[]
+): CardEntryNoteShellData {
+  return {
+    ...note,
+    availableGroups,
+    draftCards: note.draftCards.map((draftCard) =>
+      draftCard.cardId === updatedCard.cardId ? updatedCard : draftCard
+    ),
+  };
+}
+
+export function getUnresolvedDuplicateWarnings(note: CardEntryNoteShellData): UnresolvedDuplicateWarning[] {
+  return note.draftCards.flatMap((draftCard) =>
+    draftCard.duplicateWarnings
+      .filter((warning) => !warning.dismissed)
+      .map((warning) => ({
+        cardId: draftCard.cardId,
+        cardLabel: draftCard.content.trim() || 'Untitled draft card',
+        warningId: warning.warningId,
+        title: warning.title,
+        similarCardLabel: warning.similarCardLabel,
+      }))
+  );
+}

--- a/apps/web/src/lib/components/card-entry/DraftCardEditor.svelte
+++ b/apps/web/src/lib/components/card-entry/DraftCardEditor.svelte
@@ -1,0 +1,796 @@
+<script lang="ts">
+  import { createEventDispatcher, onDestroy, tick } from 'svelte';
+  import type {
+    CardEntryGroupData,
+    CardEntryNoteDraftCardData,
+    CardEntryNoteShellData,
+  } from '$lib/server/card-entry.js';
+
+  type EditableListField = 'examples' | 'mnemonics';
+  type SaveState = 'idle' | 'saving' | 'saved' | 'error';
+
+  const dispatch = createEventDispatcher<{
+    updated: {
+      card: CardEntryNoteDraftCardData;
+      availableGroups: CardEntryGroupData[];
+    };
+    removed: {
+      note: CardEntryNoteShellData;
+    };
+  }>();
+
+  export let lang: string;
+  export let noteId: string;
+  export let card: CardEntryNoteDraftCardData;
+  export let availableGroups: CardEntryGroupData[] = [];
+  export let disabled = false;
+
+  let draft = structuredClone(card);
+  let previousCard = card;
+  let saveState: SaveState = 'idle';
+  let saveError: string | null = null;
+  let saveToken = 0;
+  let savedIndicatorTimer: ReturnType<typeof setTimeout> | null = null;
+  let groupQuery = '';
+  let groupMenuOpen = false;
+  let groupFieldElement: HTMLDivElement | null = null;
+  let groupSearchInput: HTMLInputElement | null = null;
+  let llmInstructionsOpen = Boolean(card.llmInstructions);
+  let removePending = false;
+
+  $: if (card !== previousCard) {
+    draft = structuredClone(card);
+    previousCard = card;
+    llmInstructionsOpen = Boolean(card.llmInstructions);
+  }
+
+  $: normalizedGroupQuery = groupQuery.trim().toLocaleLowerCase();
+  $: selectedGroupIds = new Set(draft.groups.map((group) => group.groupId));
+  $: filteredGroups = availableGroups.filter(
+    (group) =>
+      !selectedGroupIds.has(group.groupId) &&
+      group.groupName.toLocaleLowerCase().includes(normalizedGroupQuery)
+  );
+  $: canCreateGroup =
+    normalizedGroupQuery.length > 0 &&
+    !availableGroups.some((group) => group.groupName.trim().toLocaleLowerCase() === normalizedGroupQuery);
+  $: signpostLabel =
+    saveState === 'saving'
+      ? 'Saving...'
+      : saveState === 'saved'
+        ? 'Saved ✓'
+        : saveState === 'error'
+          ? 'Save failed'
+          : '';
+
+  function clearSavedIndicatorTimer() {
+    if (!savedIndicatorTimer) {
+      return;
+    }
+
+    clearTimeout(savedIndicatorTimer);
+    savedIndicatorTimer = null;
+  }
+
+  function scheduleSavedIndicatorReset() {
+    clearSavedIndicatorTimer();
+    savedIndicatorTimer = setTimeout(() => {
+      saveState = 'idle';
+    }, 2_000);
+  }
+
+  function normalizeList(values: string[]) {
+    return values.map((value) => value.trim()).filter(Boolean);
+  }
+
+  function closeGroupMenu() {
+    groupMenuOpen = false;
+    groupQuery = '';
+  }
+
+  async function openGroupMenu() {
+    if (disabled) {
+      return;
+    }
+
+    groupMenuOpen = true;
+    await tick();
+    groupSearchInput?.focus();
+  }
+
+  function handleGroupFieldFocusOut(event: FocusEvent) {
+    const nextFocused = event.relatedTarget;
+
+    if (!(nextFocused instanceof Node) || !groupFieldElement?.contains(nextFocused)) {
+      closeGroupMenu();
+    }
+  }
+
+  function handleGroupSearchKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeGroupMenu();
+    }
+  }
+
+  function buildPayload() {
+    return {
+      content: draft.content,
+      meaning: draft.meaning ?? '',
+      examples: normalizeList(draft.examples),
+      mnemonics: normalizeList(draft.mnemonics),
+      llmInstructions: draft.llmInstructions ?? '',
+      groups: draft.groups.map((group) => ({
+        groupId: group.groupId?.trim() ? group.groupId : null,
+        groupName: group.groupName,
+      })),
+    };
+  }
+
+  async function persistDraft() {
+    if (disabled) {
+      return;
+    }
+
+    clearSavedIndicatorTimer();
+    saveState = 'saving';
+    saveError = null;
+
+    const currentSaveToken = ++saveToken;
+
+    try {
+      const response = await fetch(`/${lang}/card-entry/notes/${noteId}/draft-cards/${card.cardId}`, {
+        method: 'PATCH',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(buildPayload()),
+      });
+
+      const data = (await response.json().catch(() => null)) as
+        | {
+            card?: CardEntryNoteDraftCardData;
+            availableGroups?: CardEntryGroupData[];
+            message?: string;
+          }
+        | null;
+
+      if (!response.ok || !data?.card || !data.availableGroups) {
+        throw new Error(data?.message ?? 'The draft card could not be saved right now.');
+      }
+
+      if (currentSaveToken !== saveToken) {
+        return;
+      }
+
+      draft = data.card;
+      saveState = 'saved';
+      dispatch('updated', {
+        card: data.card,
+        availableGroups: data.availableGroups,
+      });
+      scheduleSavedIndicatorReset();
+    } catch (error) {
+      if (currentSaveToken !== saveToken) {
+        return;
+      }
+
+      saveState = 'error';
+      saveError = error instanceof Error ? error.message : 'The draft card could not be saved right now.';
+    }
+  }
+
+  function updateListValue(field: EditableListField, index: number, value: string) {
+    const nextValues = [...draft[field]];
+    nextValues[index] = value;
+    draft = {
+      ...draft,
+      [field]: nextValues,
+    };
+  }
+
+  function addListValue(field: EditableListField) {
+    draft = {
+      ...draft,
+      [field]: [...draft[field], ''],
+    };
+  }
+
+  async function removeListValue(field: EditableListField, index: number) {
+    draft = {
+      ...draft,
+      [field]: draft[field].filter((_, currentIndex) => currentIndex !== index),
+    };
+
+    await persistDraft();
+  }
+
+  async function toggleGroup(group: CardEntryGroupData) {
+    if (disabled) {
+      return;
+    }
+
+    draft = {
+      ...draft,
+      groups: [...draft.groups, group].sort((left, right) => left.groupName.localeCompare(right.groupName)),
+    };
+
+    closeGroupMenu();
+    await persistDraft();
+  }
+
+  async function createGroupFromQuery() {
+    if (disabled || !canCreateGroup) {
+      return;
+    }
+
+    draft = {
+      ...draft,
+      groups: [
+        ...draft.groups,
+        {
+          groupId: '',
+          groupName: groupQuery.trim(),
+        },
+      ],
+    };
+
+    closeGroupMenu();
+    await persistDraft();
+  }
+
+  async function removeGroup(groupId: string) {
+    if (disabled) {
+      return;
+    }
+
+    draft = {
+      ...draft,
+      groups: draft.groups.filter((group) => group.groupId !== groupId),
+    };
+
+    await persistDraft();
+  }
+
+  async function removeDraftCard() {
+    if (disabled || removePending) {
+      return;
+    }
+
+    removePending = true;
+
+    try {
+      const response = await fetch(`/${lang}/card-entry/notes/${noteId}/draft-cards/${card.cardId}`, {
+        method: 'DELETE',
+      });
+
+      const data = (await response.json().catch(() => null)) as
+        | (CardEntryNoteShellData & {
+            message?: string;
+          })
+        | null;
+
+      if (!response.ok || !data?.noteId) {
+        throw new Error(data?.message ?? 'The draft card could not be removed right now.');
+      }
+
+      dispatch('removed', {
+        note: data,
+      });
+    } catch (error) {
+      saveState = 'error';
+      saveError = error instanceof Error ? error.message : 'The draft card could not be removed right now.';
+    } finally {
+      removePending = false;
+    }
+  }
+
+  onDestroy(() => {
+    clearSavedIndicatorTimer();
+  });
+</script>
+
+<article class="draft-card stack" style="--stack-space: var(--space-4)">
+  <header class="draft-card__header cluster">
+    <div class="stack" style="--stack-space: var(--space-1)">
+      <p class="draft-card__eyebrow">Draft card</p>
+    </div>
+
+    <div class="draft-card__status-wrap stack" style="--stack-space: var(--space-1)">
+      <p class={`draft-card__status draft-card__status--${saveState}`} aria-live="polite">
+        {signpostLabel || ' '}
+      </p>
+      {#if saveError}
+        <p class="draft-card__error">{saveError}</p>
+      {/if}
+    </div>
+  </header>
+
+  <label class="draft-card__field stack" style="--stack-space: var(--space-2)">
+    <span class="draft-card__label">Content</span>
+    <textarea
+      class="draft-card__textarea"
+      rows="3"
+      bind:value={draft.content}
+      placeholder="Card content..."
+      disabled={disabled}
+      on:blur={() => void persistDraft()}
+    ></textarea>
+  </label>
+
+  <label class="draft-card__field stack" style="--stack-space: var(--space-2)">
+    <span class="draft-card__label">Meaning</span>
+    <textarea
+      class="draft-card__textarea"
+      rows="3"
+      value={draft.meaning ?? ''}
+      placeholder="Meaning..."
+      disabled={disabled}
+      on:input={(event) => {
+        draft = {
+          ...draft,
+          meaning: event.currentTarget.value,
+        };
+      }}
+      on:blur={() => void persistDraft()}
+    ></textarea>
+  </label>
+
+  <div
+    class="draft-card__field stack"
+    style="--stack-space: var(--space-2)"
+    bind:this={groupFieldElement}
+    on:focusout={handleGroupFieldFocusOut}
+  >
+    <div class="cluster draft-card__field-head">
+      <span class="draft-card__label">Groups</span>
+      <button
+        type="button"
+        class="draft-card__group-trigger"
+        disabled={disabled}
+        aria-expanded={groupMenuOpen}
+        on:click={() => void (groupMenuOpen ? closeGroupMenu() : openGroupMenu())}
+      >
+        + Add group
+      </button>
+    </div>
+
+    <div class="draft-card__group-chips cluster">
+      {#if draft.groups.length === 0}
+        <p class="draft-card__empty-inline">No groups yet.</p>
+      {:else}
+        {#each draft.groups as group}
+          <button
+            type="button"
+            class="draft-card__group-chip"
+            disabled={disabled}
+            on:click={() => void removeGroup(group.groupId)}
+          >
+            {group.groupName}
+            <span aria-hidden="true">✕</span>
+          </button>
+        {/each}
+      {/if}
+    </div>
+
+    {#if groupMenuOpen}
+      <div class="draft-card__group-menu stack" style="--stack-space: var(--space-2)">
+        <input
+          type="text"
+          class="draft-card__group-search"
+          bind:this={groupSearchInput}
+          bind:value={groupQuery}
+          placeholder="Search groups..."
+          disabled={disabled}
+          on:keydown={handleGroupSearchKeydown}
+        />
+
+        <div class="draft-card__group-options stack" style="--stack-space: var(--space-1)">
+          {#if filteredGroups.length === 0 && !canCreateGroup}
+            <p class="draft-card__empty-inline">No matching groups.</p>
+          {/if}
+
+          {#each filteredGroups as group}
+            <button
+              type="button"
+              class="draft-card__group-option"
+              disabled={disabled}
+              on:click={() => void toggleGroup(group)}
+            >
+              <span>{group.groupName}</span>
+            </button>
+          {/each}
+
+          {#if canCreateGroup}
+            <button
+              type="button"
+              class="draft-card__create-group"
+              disabled={disabled}
+              on:click={() => void createGroupFromQuery()}
+            >
+              + Create "{groupQuery.trim()}"
+            </button>
+          {/if}
+        </div>
+      </div>
+    {/if}
+  </div>
+
+  <div class="draft-card__field stack" style="--stack-space: var(--space-2)">
+    <div class="cluster draft-card__field-head">
+      <span class="draft-card__label">Example sentences</span>
+      <button type="button" class="draft-card__list-button" disabled={disabled} on:click={() => addListValue('examples')}>
+        + Add
+      </button>
+    </div>
+
+    <div class="stack" style="--stack-space: var(--space-2)">
+      {#if draft.examples.length === 0}
+        <p class="draft-card__empty-inline">No example sentences yet.</p>
+      {/if}
+
+      {#each draft.examples as example, index}
+        <div class="draft-card__list-row">
+          <textarea
+            class="draft-card__list-input"
+            rows="3"
+            value={example}
+            placeholder="Example sentence..."
+            disabled={disabled}
+            on:input={(event) => updateListValue('examples', index, event.currentTarget.value)}
+            on:blur={() => void persistDraft()}
+          ></textarea>
+          <button
+            type="button"
+            class="draft-card__list-remove"
+            disabled={disabled}
+            aria-label={`Remove example sentence ${index + 1}`}
+            on:click={() => void removeListValue('examples', index)}
+          >
+            ✕
+          </button>
+        </div>
+      {/each}
+    </div>
+  </div>
+
+  <div class="draft-card__field stack" style="--stack-space: var(--space-2)">
+    <div class="cluster draft-card__field-head">
+      <span class="draft-card__label">Mnemonics</span>
+      <button type="button" class="draft-card__list-button" disabled={disabled} on:click={() => addListValue('mnemonics')}>
+        + Add
+      </button>
+    </div>
+
+    <div class="stack" style="--stack-space: var(--space-2)">
+      {#if draft.mnemonics.length === 0}
+        <p class="draft-card__empty-inline">No mnemonics yet.</p>
+      {/if}
+
+      {#each draft.mnemonics as mnemonic, index}
+        <div class="draft-card__list-row">
+          <textarea
+            class="draft-card__list-input"
+            rows="4"
+            value={mnemonic}
+            placeholder="Mnemonic..."
+            disabled={disabled}
+            on:input={(event) => updateListValue('mnemonics', index, event.currentTarget.value)}
+            on:blur={() => void persistDraft()}
+          ></textarea>
+          <button
+            type="button"
+            class="draft-card__list-remove"
+            disabled={disabled}
+            aria-label={`Remove mnemonic ${index + 1}`}
+            on:click={() => void removeListValue('mnemonics', index)}
+          >
+            ✕
+          </button>
+        </div>
+      {/each}
+    </div>
+  </div>
+
+  <details class="draft-card__details" bind:open={llmInstructionsOpen}>
+    <summary>Special instructions for practicing this card</summary>
+    <label class="stack" style="--stack-space: var(--space-2)">
+      <span class="visually-hidden">Special instructions for practicing this card</span>
+      <textarea
+        class="draft-card__textarea"
+        rows="4"
+        value={draft.llmInstructions ?? ''}
+        placeholder="Optional: tell StudyPuck what to focus on, avoid, or reinforce, when it is quizzing you on this card."
+        disabled={disabled}
+        on:input={(event) => {
+          draft = {
+            ...draft,
+            llmInstructions: event.currentTarget.value,
+          };
+        }}
+        on:blur={() => void persistDraft()}
+      ></textarea>
+    </label>
+  </details>
+
+  {#if draft.duplicateWarnings.length > 0}
+    <div class="stack" style="--stack-space: var(--space-2)">
+      {#each draft.duplicateWarnings as warning}
+        <section class="draft-card__warning" role="alert">
+          <p class="draft-card__warning-title">Possible duplicate: {warning.title}</p>
+          <p class="draft-card__warning-copy">Similar to: {warning.similarCardLabel}</p>
+        </section>
+      {/each}
+    </div>
+  {/if}
+
+  <footer class="draft-card__footer">
+    <button
+      type="button"
+      class="draft-card__remove"
+      disabled={disabled || removePending}
+      on:click={() => void removeDraftCard()}
+    >
+      {removePending ? 'Removing draft card...' : 'Remove this draft card'}
+    </button>
+  </footer>
+</article>
+
+<style>
+  .draft-card {
+    padding: var(--space-5);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .draft-card__header,
+  .draft-card__field-head,
+  .draft-card__group-chips,
+  .draft-card__status-wrap {
+    align-items: start;
+  }
+
+  .draft-card__header,
+  .draft-card__field-head {
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  .draft-card__eyebrow,
+  .draft-card__meaning,
+  .draft-card__label,
+  .draft-card__status,
+  .draft-card__error,
+  .draft-card__warning-title,
+  .draft-card__warning-copy,
+  .draft-card__empty-inline {
+    margin: 0;
+  }
+
+  .draft-card__eyebrow,
+  .draft-card__label {
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-caption);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .draft-card__meaning,
+  .draft-card__empty-inline {
+    color: var(--color-text-secondary);
+  }
+
+  .draft-card__status {
+    min-inline-size: 5rem;
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+    text-align: right;
+  }
+
+  .draft-card__status--saving {
+    color: var(--color-text-secondary);
+  }
+
+  .draft-card__status--saved {
+    color: var(--color-success-text);
+  }
+
+  .draft-card__status--error,
+  .draft-card__error {
+    color: var(--color-error-text);
+  }
+
+  .draft-card__error {
+    font-size: var(--font-size-small);
+    text-align: right;
+  }
+
+  .draft-card__textarea,
+  .draft-card__group-search,
+  .draft-card__list-input {
+    inline-size: 100%;
+    padding: var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-raised);
+    color: var(--color-text-primary);
+    font: inherit;
+  }
+
+  .draft-card__textarea {
+    resize: vertical;
+    min-block-size: 6rem;
+  }
+
+  .draft-card__group-trigger,
+  .draft-card__list-button,
+  .draft-card__create-group,
+  .draft-card__remove {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-subtle);
+    color: var(--color-text-primary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-ui);
+    padding: var(--space-2) var(--space-3);
+  }
+
+  .draft-card__group-menu {
+    padding: var(--space-3);
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-subtle);
+  }
+
+  .draft-card__group-option {
+    display: flex;
+    inline-size: 100%;
+    justify-content: space-between;
+    align-items: center;
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text-primary);
+    font-family: var(--font-ui);
+  }
+
+  .draft-card__group-chip {
+    display: inline-flex;
+    gap: var(--space-2);
+    align-items: center;
+    border: 1px solid color-mix(in srgb, var(--color-primary) 35%, var(--color-border));
+    border-radius: var(--radius-pill, 999px);
+    background: var(--color-primary-subtle);
+    color: var(--color-primary-text);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+    padding: var(--space-1) var(--space-3);
+  }
+
+  .draft-card__group-option:hover:not(:disabled) {
+    border-color: color-mix(in srgb, var(--color-primary) 35%, var(--color-border));
+    background: var(--color-primary-subtle);
+  }
+
+  .draft-card__list-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: var(--space-2);
+    align-items: start;
+  }
+
+  .draft-card__list-input {
+    min-block-size: 5.5rem;
+    overflow-y: auto;
+    overflow-x: hidden;
+    resize: vertical;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .draft-card__list-remove {
+    inline-size: 2.5rem;
+    block-size: 2.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-subtle);
+    color: var(--color-text-primary);
+  }
+
+  .draft-card__details {
+    padding: var(--space-3);
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-subtle);
+  }
+
+  .draft-card__details summary {
+    cursor: pointer;
+    font-family: var(--font-ui);
+    font-size: var(--font-size-ui);
+    font-weight: 600;
+  }
+
+  .draft-card__details[open] summary {
+    margin-block-end: var(--space-3);
+  }
+
+  .draft-card__warning {
+    padding: var(--space-3);
+    border: 1px solid var(--color-warning-border);
+    border-radius: var(--radius-md);
+    background: var(--color-warning-bg);
+  }
+
+  .draft-card__warning-title {
+    color: var(--color-warning-text);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-ui);
+    font-weight: 600;
+  }
+
+  .draft-card__warning-copy {
+    color: var(--color-warning-text);
+    font-size: var(--font-size-small);
+  }
+
+  .draft-card__footer {
+    display: flex;
+    justify-content: end;
+  }
+
+  .draft-card__remove {
+    border-color: color-mix(in srgb, var(--color-error-text) 35%, var(--color-border));
+    color: var(--color-error-text);
+  }
+
+  .draft-card__textarea:focus-visible,
+  .draft-card__group-search:focus-visible,
+  .draft-card__group-option:focus-visible,
+  .draft-card__list-input:focus-visible,
+  .draft-card__group-trigger:focus-visible,
+  .draft-card__list-button:focus-visible,
+  .draft-card__create-group:focus-visible,
+  .draft-card__group-chip:focus-visible,
+  .draft-card__list-remove:focus-visible,
+  .draft-card__remove:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  button:disabled,
+  input:disabled,
+  textarea:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
+
+  @media (max-width: 40rem) {
+    .draft-card {
+      padding: var(--space-4);
+    }
+
+    .draft-card__header,
+    .draft-card__field-head {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    .draft-card__status,
+    .draft-card__error {
+      text-align: left;
+    }
+
+    .draft-card__footer {
+      justify-content: stretch;
+    }
+
+    .draft-card__remove {
+      inline-size: 100%;
+    }
+  }
+</style>

--- a/apps/web/src/lib/schemas/card-entry.ts
+++ b/apps/web/src/lib/schemas/card-entry.ts
@@ -14,3 +14,32 @@ export const createCardEntryNoteSchema = z.object({
   languageId: z.string().trim().min(1, 'A language is required.'),
   content: cardEntryNoteContentSchema,
 });
+
+const editableCardTextSchema = z.string().trim().max(4_000, 'Card text must be 4,000 characters or fewer.');
+const editableCardListItemSchema = z.string().trim().max(1_000, 'List items must be 1,000 characters or fewer.');
+export const editableGroupNameSchema = z
+  .string()
+  .trim()
+  .min(1, 'Group names cannot be empty.')
+  .max(80, 'Group names must be 80 characters or fewer.');
+
+export const editableCardOptionalTextSchema = editableCardTextSchema.transform((value) => value || null);
+
+export const editableCardListSchema = z
+  .array(editableCardListItemSchema)
+  .max(20, 'No more than 20 items are allowed.')
+  .transform((items) => items.filter(Boolean));
+
+export const editableCardGroupSelectionSchema = z.object({
+  groupId: z.string().trim().min(1).nullable().optional(),
+  groupName: editableGroupNameSchema,
+});
+
+export const cardEntryDraftCardUpdateSchema = z.object({
+  content: editableCardTextSchema,
+  meaning: editableCardOptionalTextSchema,
+  examples: editableCardListSchema,
+  mnemonics: editableCardListSchema,
+  llmInstructions: editableCardOptionalTextSchema,
+  groups: z.array(editableCardGroupSelectionSchema).max(20, 'No more than 20 groups are allowed.'),
+});

--- a/apps/web/src/lib/server/card-entry.ts
+++ b/apps/web/src/lib/server/card-entry.ts
@@ -1,25 +1,42 @@
 import {
+  addCardToGroup,
+  createDraftCardFromNote,
+  createGroup,
   createInboxNote,
   deleteInboxNote,
   deferInboxNote,
   getActiveUserLanguages,
   getCardEntryCounts,
+  getCardGroups,
+  getCardGroupsForCards,
   getDb,
+  getGroups,
   getInboxNote,
   getNoteWithDraftCards,
   listInboxNotes,
+  removeCardFromGroup,
+  signOffNote,
+  updateCard,
+  type Group,
   type InboxNoteAiState,
   type InboxNoteState,
   type InboxSortOrder,
 } from '@studypuck/database';
+import { and, eq } from 'drizzle-orm';
 import type { Cookies } from '@sveltejs/kit';
+import { cards, noteCardLinks } from '@studypuck/database';
 import {
+  cardEntryDraftCardUpdateSchema,
   cardEntryNoteContentSchema,
   cardEntryNoteIdSchema,
+  editableCardOptionalTextSchema,
+  editableGroupNameSchema,
   inboxSortOrderSchema,
 } from '$lib/schemas/card-entry.js';
 
 type DatabaseClient = ReturnType<typeof getDb>;
+type CardEntryDraftCardUpdate = typeof cardEntryDraftCardUpdateSchema._output;
+type EditableOptionalCardText = typeof editableCardOptionalTextSchema._output;
 
 const CARD_ENTRY_SORT_COOKIE_PREFIX = 'card-entry-inbox-sort';
 
@@ -51,15 +68,16 @@ export type CardEntryInboxData = {
   unprocessedNoteCount: number;
 };
 
-export type CardEntryNoteShellData = {
-  noteId: string;
-  content: string;
-  state: InboxNoteState;
-  aiState: InboxNoteAiState;
-  createdAtIso: string;
-  createdAtLabel: string;
-  sourceLabel: string;
-  draftCards: CardEntryNoteDraftCardData[];
+export type CardEntryGroupData = {
+  groupId: string;
+  groupName: string;
+};
+
+export type CardEntryDuplicateWarningData = {
+  warningId: string;
+  title: string;
+  similarCardLabel: string;
+  dismissed: boolean;
 };
 
 export type CardEntryNoteDraftCardData = {
@@ -70,6 +88,20 @@ export type CardEntryNoteDraftCardData = {
   mnemonics: string[];
   llmInstructions: string | null;
   linkedAtIso: string | null;
+  groups: CardEntryGroupData[];
+  duplicateWarnings: CardEntryDuplicateWarningData[];
+};
+
+export type CardEntryNoteShellData = {
+  noteId: string;
+  content: string;
+  state: InboxNoteState;
+  aiState: InboxNoteAiState;
+  createdAtIso: string;
+  createdAtLabel: string;
+  sourceLabel: string;
+  draftCards: CardEntryNoteDraftCardData[];
+  availableGroups: CardEntryGroupData[];
 };
 
 export function getCardEntrySortCookieName(languageId: string): string {
@@ -187,8 +219,26 @@ function normalizeStringList(value: unknown): string[] {
   return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
 }
 
+function mapGroup(group: Pick<Group, 'groupId' | 'groupName'>): CardEntryGroupData {
+  return {
+    groupId: group.groupId,
+    groupName: group.groupName,
+  };
+}
+
+function parseOptionalText(value: unknown): EditableOptionalCardText {
+  const parsed = editableCardOptionalTextSchema.safeParse(typeof value === 'string' ? value : '');
+
+  if (!parsed.success) {
+    throw new CardEntryRequestError(400, parsed.error.issues[0]?.message ?? 'Card text is invalid.');
+  }
+
+  return parsed.data;
+}
+
 function mapDraftCard(
-  draftCard: NonNullable<Awaited<ReturnType<typeof getNoteWithDraftCards>>>['draftCards'][number]
+  draftCard: NonNullable<Awaited<ReturnType<typeof getNoteWithDraftCards>>>['draftCards'][number],
+  groups: CardEntryGroupData[]
 ): CardEntryNoteDraftCardData {
   return {
     cardId: draftCard.cardId,
@@ -196,8 +246,10 @@ function mapDraftCard(
     meaning: draftCard.meaning ?? null,
     examples: normalizeStringList(draftCard.examples),
     mnemonics: normalizeStringList(draftCard.mnemonics),
-    llmInstructions: draftCard.llmInstructions ?? null,
+    llmInstructions: parseOptionalText(draftCard.llmInstructions ?? ''),
     linkedAtIso: draftCard.linkedAt?.toISOString() ?? null,
+    groups,
+    duplicateWarnings: [],
   };
 }
 
@@ -224,14 +276,203 @@ function parseNoteContent(content: unknown): string {
   return parsed.data;
 }
 
-function parseNoteId(noteId: unknown): string {
-  const parsed = cardEntryNoteIdSchema.safeParse(typeof noteId === 'string' ? noteId : '');
+function parseEntityId(value: unknown, label: string): string {
+  const parsed = cardEntryNoteIdSchema.safeParse(typeof value === 'string' ? value : '');
 
   if (!parsed.success) {
-    throw new CardEntryRequestError(400, parsed.error.issues[0]?.message ?? 'Note identifier is invalid.');
+    throw new CardEntryRequestError(400, parsed.error.issues[0]?.message ?? `${label} identifier is invalid.`);
   }
 
   return parsed.data;
+}
+
+function parseNoteId(noteId: unknown): string {
+  return parseEntityId(noteId, 'Note');
+}
+
+function parseCardId(cardId: unknown): string {
+  return parseEntityId(cardId, 'Card');
+}
+
+function parseDraftCardUpdate(input: unknown): CardEntryDraftCardUpdate {
+  const parsed = cardEntryDraftCardUpdateSchema.safeParse(input);
+
+  if (!parsed.success) {
+    throw new CardEntryRequestError(400, parsed.error.issues[0]?.message ?? 'Draft card update is invalid.');
+  }
+
+  return parsed.data;
+}
+
+function createGroupId(): string {
+  return `group-${globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`}`;
+}
+
+async function loadDraftCardGroupsMap(
+  userId: string,
+  languageId: string,
+  cardIds: string[],
+  database: DatabaseClient
+) {
+  return getCardGroupsForCards(userId, languageId, cardIds, database as never);
+}
+
+async function mapWorkspaceDraftCards(
+  userId: string,
+  languageId: string,
+  workspace: NonNullable<Awaited<ReturnType<typeof getNoteWithDraftCards>>>,
+  database: DatabaseClient
+): Promise<CardEntryNoteDraftCardData[]> {
+  const cardIds = workspace.draftCards.map((draftCard) => draftCard.cardId);
+  const draftCardGroups = await loadDraftCardGroupsMap(userId, languageId, cardIds, database);
+
+  return workspace.draftCards.map((draftCard) =>
+    mapDraftCard(draftCard, (draftCardGroups.get(draftCard.cardId) ?? []).map((group) => mapGroup(group)))
+  );
+}
+
+async function loadWorkspace(
+  userId: string,
+  languageId: string,
+  noteId: string,
+  database: DatabaseClient
+) {
+  const workspace = await getNoteWithDraftCards(userId, languageId, noteId, database as never);
+
+  if (!workspace) {
+    throw new CardEntryRequestError(404, 'Card Entry note not found.');
+  }
+
+  return workspace;
+}
+
+async function assertDraftCardInWorkspace(
+  userId: string,
+  languageId: string,
+  noteId: string,
+  cardId: string,
+  database: DatabaseClient
+) {
+  const workspace = await loadWorkspace(userId, languageId, noteId, database);
+  const draftCard = workspace.draftCards.find((card) => card.cardId === cardId);
+
+  if (!draftCard) {
+    throw new CardEntryRequestError(404, 'Draft card not found for this note.');
+  }
+
+  return {
+    workspace,
+    draftCard,
+  };
+}
+
+async function resolveGroupSelections(
+  userId: string,
+  languageId: string,
+  selections: CardEntryDraftCardUpdate['groups'],
+  database: DatabaseClient
+): Promise<CardEntryGroupData[]> {
+  const existingGroups = await getGroups(userId, languageId, database as never);
+  const groupsById = new Map(existingGroups.map((group) => [group.groupId, group]));
+  const groupsByNormalizedName = new Map(
+    existingGroups.map((group) => [group.groupName.trim().toLocaleLowerCase(), group])
+  );
+  const resolvedGroups = new Map<string, CardEntryGroupData>();
+
+  for (const selection of selections) {
+    const normalizedName = selection.groupName.trim().toLocaleLowerCase();
+    const explicitGroupId = selection.groupId?.trim() || null;
+
+    if (explicitGroupId) {
+      const explicitGroup = groupsById.get(explicitGroupId);
+
+      if (!explicitGroup) {
+        throw new CardEntryRequestError(404, 'One of the selected groups no longer exists.');
+      }
+
+      resolvedGroups.set(explicitGroup.groupId, mapGroup(explicitGroup));
+      continue;
+    }
+
+    const existingGroup = groupsByNormalizedName.get(normalizedName);
+
+    if (existingGroup) {
+      resolvedGroups.set(existingGroup.groupId, mapGroup(existingGroup));
+      continue;
+    }
+
+    const parsedGroupName = editableGroupNameSchema.safeParse(selection.groupName);
+
+    if (!parsedGroupName.success) {
+      throw new CardEntryRequestError(
+        400,
+        parsedGroupName.error.issues[0]?.message ?? 'Group name is invalid.'
+      );
+    }
+
+    const createdGroup = await createGroup(
+      {
+        userId,
+        languageId,
+        groupId: createGroupId(),
+        groupName: parsedGroupName.data,
+      },
+      database as never
+    );
+
+    groupsById.set(createdGroup.groupId, createdGroup);
+    groupsByNormalizedName.set(createdGroup.groupName.trim().toLocaleLowerCase(), createdGroup);
+    resolvedGroups.set(createdGroup.groupId, mapGroup(createdGroup));
+  }
+
+  return Array.from(resolvedGroups.values()).sort((left, right) => left.groupName.localeCompare(right.groupName));
+}
+
+async function syncDraftCardGroups(
+  userId: string,
+  languageId: string,
+  cardId: string,
+  nextGroups: CardEntryGroupData[],
+  database: DatabaseClient
+) {
+  const currentGroups = await getCardGroups(userId, languageId, cardId, database as never);
+  const currentGroupIds = new Set(currentGroups.map((group) => group.groupId));
+  const nextGroupIds = new Set(nextGroups.map((group) => group.groupId));
+
+  for (const group of nextGroups) {
+    if (!currentGroupIds.has(group.groupId)) {
+      await addCardToGroup(
+        {
+          userId,
+          languageId,
+          cardId,
+          groupId: group.groupId,
+        },
+        database as never
+      );
+    }
+  }
+
+  for (const group of currentGroups) {
+    if (!nextGroupIds.has(group.groupId)) {
+      await removeCardFromGroup(userId, languageId, cardId, group.groupId, database as never);
+    }
+  }
+
+  return nextGroups;
+}
+
+async function loadDraftCardData(
+  userId: string,
+  languageId: string,
+  noteId: string,
+  cardId: string,
+  database: DatabaseClient
+): Promise<CardEntryNoteDraftCardData> {
+  const { draftCard } = await assertDraftCardInWorkspace(userId, languageId, noteId, cardId, database);
+  const draftCardGroups = await getCardGroups(userId, languageId, cardId, database as never);
+
+  return mapDraftCard(draftCard, draftCardGroups.map((group) => mapGroup(group)));
 }
 
 export async function loadCardEntryShellData(
@@ -278,13 +519,12 @@ export async function loadCardEntryNoteShellData(
   noteId: string,
   database: DatabaseClient
 ): Promise<CardEntryNoteShellData> {
-  const workspace = await getNoteWithDraftCards(userId, languageId, parseNoteId(noteId), database as never);
-
-  if (!workspace) {
-    throw new CardEntryRequestError(404, 'Card Entry note not found.');
-  }
-
+  const workspace = await loadWorkspace(userId, languageId, parseNoteId(noteId), database);
   const note = workspace.note;
+  const [draftCards, availableGroups] = await Promise.all([
+    mapWorkspaceDraftCards(userId, languageId, workspace, database),
+    getGroups(userId, languageId, database as never),
+  ]);
 
   if (!note.createdAt) {
     throw new Error(`Inbox note ${note.noteId} is missing createdAt.`);
@@ -298,7 +538,8 @@ export async function loadCardEntryNoteShellData(
     createdAtIso: note.createdAt.toISOString(),
     createdAtLabel: formatCardEntryRelativeTime(note.createdAt),
     sourceLabel: formatCardEntrySourceLabel(note.sourceType),
-    draftCards: workspace.draftCards.map((draftCard) => mapDraftCard(draftCard)),
+    draftCards,
+    availableGroups: availableGroups.map((group) => mapGroup(group)),
   };
 }
 
@@ -349,4 +590,158 @@ export async function deleteCardEntryNoteForLanguage(
   }
 
   return deletedNote;
+}
+
+export async function signOffCardEntryNoteForLanguage(
+  userId: string,
+  languageId: string,
+  noteId: unknown,
+  database: DatabaseClient
+) {
+  try {
+    return await signOffNote(userId, languageId, parseNoteId(noteId), database as never);
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message.startsWith('Inbox note not found:')) {
+        throw new CardEntryRequestError(404, 'Card Entry note not found.');
+      }
+
+      if (error.message.includes('has no linked')) {
+        throw new CardEntryRequestError(400, 'This note has no draft cards to sign off yet.');
+      }
+    }
+
+    throw error;
+  }
+}
+
+export async function createCardEntryDraftCardForLanguage(
+  userId: string,
+  languageId: string,
+  noteId: unknown,
+  database: DatabaseClient
+) {
+  const parsedNoteId = parseNoteId(noteId);
+  const note = await getInboxNote(userId, languageId, parsedNoteId, database as never);
+
+  if (!note) {
+    throw new CardEntryRequestError(404, 'Card Entry note not found.');
+  }
+
+  await createDraftCardFromNote(
+    {
+      userId,
+      languageId,
+      noteId: parsedNoteId,
+      content: '',
+      examples: [],
+      mnemonics: [],
+      llmInstructions: null,
+    },
+    database as never
+  );
+
+  return loadCardEntryNoteShellData(userId, languageId, parsedNoteId, database);
+}
+
+export async function updateCardEntryDraftCardForLanguage(
+  userId: string,
+  languageId: string,
+  noteId: unknown,
+  cardId: unknown,
+  input: unknown,
+  database: DatabaseClient
+) {
+  const parsedNoteId = parseNoteId(noteId);
+  const parsedCardId = parseCardId(cardId);
+  const parsedInput = parseDraftCardUpdate(input);
+
+  await assertDraftCardInWorkspace(userId, languageId, parsedNoteId, parsedCardId, database);
+  const resolvedGroups = await resolveGroupSelections(
+    userId,
+    languageId,
+    parsedInput.groups,
+    database
+  );
+
+  const updatedCard = await updateCard(
+    userId,
+    languageId,
+    parsedCardId,
+    {
+      content: parsedInput.content,
+      meaning: parsedInput.meaning,
+      examples: parsedInput.examples,
+      mnemonics: parsedInput.mnemonics,
+      llmInstructions: parsedInput.llmInstructions,
+    },
+    database as never
+  );
+
+  if (!updatedCard) {
+    throw new CardEntryRequestError(404, 'Draft card not found for this note.');
+  }
+
+  await syncDraftCardGroups(userId, languageId, parsedCardId, resolvedGroups, database);
+
+  const [card, availableGroups] = await Promise.all([
+    loadDraftCardData(userId, languageId, parsedNoteId, parsedCardId, database),
+    getGroups(userId, languageId, database as never),
+  ]);
+
+  return {
+    card,
+    availableGroups: availableGroups.map((group) => mapGroup(group)),
+  };
+}
+
+export async function removeCardEntryDraftCardForLanguage(
+  userId: string,
+  languageId: string,
+  noteId: unknown,
+  cardId: unknown,
+  database: DatabaseClient
+) {
+  const parsedNoteId = parseNoteId(noteId);
+  const parsedCardId = parseCardId(cardId);
+
+  await assertDraftCardInWorkspace(userId, languageId, parsedNoteId, parsedCardId, database);
+
+  await database
+    .delete(noteCardLinks)
+    .where(and(
+      eq(noteCardLinks.userId, userId),
+      eq(noteCardLinks.languageId, languageId),
+      eq(noteCardLinks.noteId, parsedNoteId),
+      eq(noteCardLinks.cardId, parsedCardId)
+    ));
+
+  const remainingLinks = await database
+    .select({ noteId: noteCardLinks.noteId })
+    .from(noteCardLinks)
+    .where(and(
+      eq(noteCardLinks.userId, userId),
+      eq(noteCardLinks.languageId, languageId),
+      eq(noteCardLinks.cardId, parsedCardId)
+    ))
+    .limit(1);
+
+  if (remainingLinks.length === 0) {
+    const now = new Date();
+    await database
+      .update(cards)
+      .set({
+        status: 'deleted',
+        deletedAt: now,
+        updatedAt: now,
+      })
+      .where(and(
+        eq(cards.userId, userId),
+        eq(cards.languageId, languageId),
+        eq(cards.cardId, parsedCardId),
+        eq(cards.status, 'draft')
+      ));
+  }
+
+  return loadCardEntryNoteShellData(userId, languageId, parsedNoteId, database);
 }

--- a/apps/web/src/routes/[lang]/card-entry/notes/[noteId]/+page.server.ts
+++ b/apps/web/src/routes/[lang]/card-entry/notes/[noteId]/+page.server.ts
@@ -1,7 +1,13 @@
-import { error, type ServerLoad } from '@sveltejs/kit';
-import { getDb } from '@studypuck/database';
+import { error, fail, redirect, type Actions, type ServerLoad } from '@sveltejs/kit';
+import { getDb, withTransactionDb } from '@studypuck/database';
 import { env } from '$env/dynamic/private';
-import { CardEntryRequestError, loadCardEntryNoteShellData } from '$lib/server/card-entry.js';
+import {
+  CardEntryRequestError,
+  deferCardEntryNoteForLanguage,
+  deleteCardEntryNoteForLanguage,
+  loadCardEntryNoteShellData,
+  signOffCardEntryNoteForLanguage,
+} from '$lib/server/card-entry.js';
 
 export const load: ServerLoad = async (event) => {
   const { session } = await event.parent();
@@ -31,4 +37,135 @@ export const load: ServerLoad = async (event) => {
     console.error('Failed to load Card Entry note shell:', requestError);
     throw error(500, 'The note could not be loaded right now.');
   }
+};
+
+export const actions: Actions = {
+  deferNote: async (event) => {
+    const session = await event.locals.auth();
+    const languageCode = event.params.lang;
+    const noteId = event.params.noteId;
+    const userId = session?.user?.id;
+
+    if (!userId || !languageCode || !noteId) {
+      throw redirect(303, '/');
+    }
+
+    const databaseUrl = env.DATABASE_URL;
+
+    if (!databaseUrl) {
+      return fail(500, {
+        operation: 'defer-note' as const,
+        errorMessage: 'The note service is not configured right now.',
+      });
+    }
+
+    try {
+      await withTransactionDb(
+        databaseUrl,
+        (database) => deferCardEntryNoteForLanguage(userId, languageCode, noteId, database as never)
+      );
+    } catch (requestError) {
+      if (requestError instanceof CardEntryRequestError) {
+        return fail(requestError.status, {
+          operation: 'defer-note' as const,
+          errorMessage: requestError.message,
+        });
+      }
+
+      console.error('Failed to defer Card Entry note from workspace:', requestError);
+
+      return fail(500, {
+        operation: 'defer-note' as const,
+        errorMessage: 'The note could not be deferred right now.',
+      });
+    }
+
+    throw redirect(303, `/${languageCode}/card-entry`);
+  },
+
+  deleteNote: async (event) => {
+    const session = await event.locals.auth();
+    const languageCode = event.params.lang;
+    const noteId = event.params.noteId;
+    const userId = session?.user?.id;
+
+    if (!userId || !languageCode || !noteId) {
+      throw redirect(303, '/');
+    }
+
+    const databaseUrl = env.DATABASE_URL;
+
+    if (!databaseUrl) {
+      return fail(500, {
+        operation: 'delete-note' as const,
+        errorMessage: 'The note service is not configured right now.',
+      });
+    }
+
+    try {
+      await withTransactionDb(
+        databaseUrl,
+        (database) => deleteCardEntryNoteForLanguage(userId, languageCode, noteId, database as never)
+      );
+    } catch (requestError) {
+      if (requestError instanceof CardEntryRequestError) {
+        return fail(requestError.status, {
+          operation: 'delete-note' as const,
+          errorMessage: requestError.message,
+        });
+      }
+
+      console.error('Failed to delete Card Entry note from workspace:', requestError);
+
+      return fail(500, {
+        operation: 'delete-note' as const,
+        errorMessage: 'The note could not be deleted right now.',
+      });
+    }
+
+    throw redirect(303, `/${languageCode}/card-entry`);
+  },
+
+  signOffNote: async (event) => {
+    const session = await event.locals.auth();
+    const languageCode = event.params.lang;
+    const noteId = event.params.noteId;
+    const userId = session?.user?.id;
+
+    if (!userId || !languageCode || !noteId) {
+      throw redirect(303, '/');
+    }
+
+    const databaseUrl = env.DATABASE_URL;
+
+    if (!databaseUrl) {
+      return fail(500, {
+        operation: 'sign-off-note' as const,
+        errorMessage: 'The note service is not configured right now.',
+      });
+    }
+
+    try {
+      await withTransactionDb(
+        databaseUrl,
+        (database) => signOffCardEntryNoteForLanguage(userId, languageCode, noteId, database as never)
+      );
+    } catch (requestError) {
+      if (requestError instanceof CardEntryRequestError) {
+        return fail(requestError.status, {
+          operation: 'sign-off-note' as const,
+          errorMessage: requestError.message,
+        });
+      }
+
+      console.error('Failed to sign off Card Entry note:', requestError);
+
+      return fail(500, {
+        operation: 'sign-off-note' as const,
+        errorMessage: 'The note could not be signed off right now.',
+      });
+    }
+
+    throw redirect(303, `/${languageCode}/card-entry`);
+  },
 };

--- a/apps/web/src/routes/[lang]/card-entry/notes/[noteId]/+page.svelte
+++ b/apps/web/src/routes/[lang]/card-entry/notes/[noteId]/+page.svelte
@@ -1,15 +1,36 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import type { ActionData, PageData } from './$types.js';
   import { page } from '$app/stores';
+  import { onMount } from 'svelte';
+  import DraftCardEditor from '$lib/components/card-entry/DraftCardEditor.svelte';
+  import { getUnresolvedDuplicateWarnings, replaceDraftCardInNote } from '$lib/card-entry/workspace.js';
   import type { CardEntryNoteShellData } from '$lib/server/card-entry.js';
-  import type { PageData } from './$types.js';
 
   export let data: PageData;
+  export let form: ActionData;
 
   let note: CardEntryNoteShellData = data.note;
   let isRefreshing = false;
   let pollingError: string | null = null;
+  let workspaceError: string | null = null;
+  let addCardPending = false;
   let pollTimer: ReturnType<typeof setTimeout> | null = null;
+  let showDuplicateDialog = false;
+  let signOffForm: HTMLFormElement | null = null;
+
+  $: currentLang = $page.params.lang ?? '';
+  $: actionError = (form as { errorMessage?: string } | null | undefined)?.errorMessage ?? null;
+  $: unresolvedDuplicateWarnings = getUnresolvedDuplicateWarnings(note);
+  $: signOffDisabled =
+    note.draftCards.length === 0 || note.aiState === 'queued' || note.aiState === 'processing';
+  $: signOffLabel =
+    note.draftCards.length === 0
+      ? 'Sign off unavailable — add at least one draft card'
+      : note.aiState === 'queued' || note.aiState === 'processing'
+        ? 'Sign off unavailable while AI is still processing'
+        : `Sign off — Promote all to active (${note.draftCards.length} ${
+            note.draftCards.length === 1 ? 'card' : 'cards'
+          }) →`;
 
   function clearPollTimer() {
     if (!pollTimer) {
@@ -32,7 +53,7 @@
     isRefreshing = true;
 
     try {
-      const response = await fetch(`/${$page.params.lang}/card-entry/notes/${note.noteId}/processing`);
+      const response = await fetch(`/${currentLang}/card-entry/notes/${note.noteId}/processing`);
 
       if (!response.ok) {
         throw new Error(`Unexpected note processing status response: ${response.status}`);
@@ -54,6 +75,69 @@
     }
   }
 
+  async function addDraftCard() {
+    if (addCardPending) {
+      return;
+    }
+
+    addCardPending = true;
+    workspaceError = null;
+
+    try {
+      const response = await fetch(`/${currentLang}/card-entry/notes/${note.noteId}/draft-cards`, {
+        method: 'POST',
+      });
+
+      const updatedNote = (await response.json().catch(() => null)) as
+        | (CardEntryNoteShellData & { message?: string })
+        | null;
+
+      if (!response.ok || !updatedNote?.noteId) {
+        throw new Error(updatedNote?.message ?? 'A draft card could not be created right now.');
+      }
+
+      note = updatedNote;
+    } catch (error) {
+      workspaceError = error instanceof Error ? error.message : 'A draft card could not be created right now.';
+    } finally {
+      addCardPending = false;
+    }
+  }
+
+  function handleDraftCardUpdated(event: CustomEvent<{ card: CardEntryNoteShellData['draftCards'][number]; availableGroups: CardEntryNoteShellData['availableGroups'] }>) {
+    note = replaceDraftCardInNote(note, event.detail.card, event.detail.availableGroups);
+    workspaceError = null;
+  }
+
+  function handleDraftCardRemoved(event: CustomEvent<{ note: CardEntryNoteShellData }>) {
+    note = event.detail.note;
+    workspaceError = null;
+  }
+
+  function handleSignOffClick(event: MouseEvent) {
+    if (signOffDisabled || unresolvedDuplicateWarnings.length === 0) {
+      return;
+    }
+
+    event.preventDefault();
+    showDuplicateDialog = true;
+  }
+
+  function closeDuplicateDialog() {
+    showDuplicateDialog = false;
+  }
+
+  function submitSignOffAnyway() {
+    showDuplicateDialog = false;
+    signOffForm?.requestSubmit();
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape' && showDuplicateDialog) {
+      closeDuplicateDialog();
+    }
+  }
+
   onMount(() => {
     if (shouldPollAiState(note)) {
       void refreshProcessingState();
@@ -65,130 +149,184 @@
   });
 </script>
 
+<svelte:window on:keydown={handleKeydown} />
+
 <svelte:head>
   <title>Note Processing – StudyPuck</title>
 </svelte:head>
 
-<section class="note-shell stack" style="--stack-space: var(--space-5)">
-  <a class="note-shell__back" href={`/${$page.params.lang}/card-entry`}>← Back to inbox</a>
+<section class="note-workspace stack" style="--stack-space: var(--space-4)">
+  <a class="note-workspace__back" href={`/${$page.params.lang}/card-entry`}>← Back to inbox</a>
 
-  <header class="note-shell__header stack" style="--stack-space: var(--space-3)">
-    <p class="note-shell__meta">{note.sourceLabel} · {note.createdAtLabel}</p>
-    <h1>Note Processing</h1>
-    <p class="note-shell__content">{note.content}</p>
+  {#if actionError || workspaceError}
+    <section class="note-workspace__alert" role="alert">
+      <h2>Action failed</h2>
+      <p>{actionError ?? workspaceError}</p>
+    </section>
+  {/if}
+
+  <header class="note-workspace__header stack" style="--stack-space: var(--space-3)">
+    <div class="note-workspace__header-top cluster">
+      <div class="stack" style="--stack-space: var(--space-1)">
+        <p class="note-workspace__meta">{note.sourceLabel} · {note.createdAtLabel}</p>
+        <h1>Note Processing</h1>
+      </div>
+
+      <div class="note-workspace__actions cluster">
+        <form method="POST" action="?/deferNote">
+          <button type="submit" class="note-workspace__action">Defer</button>
+        </form>
+        <form method="POST" action="?/deleteNote">
+          <button type="submit" class="note-workspace__action note-workspace__action--danger">Delete</button>
+        </form>
+      </div>
+    </div>
+
+    <p class="note-workspace__content">{note.content}</p>
   </header>
 
   {#if note.aiState === 'queued' || note.aiState === 'processing'}
-    <section class="note-shell__status note-shell__status--loading stack" style="--stack-space: var(--space-3)" aria-live="polite">
+    <section class="note-workspace__status note-workspace__status--loading stack" style="--stack-space: var(--space-2)" aria-live="polite">
       <h2>AI is preparing your cards…</h2>
       <p>
         {note.aiState === 'queued'
           ? 'This note is queued for preprocessing.'
-          : 'Draft cards are being generated for this note now.'}
+          : 'Draft cards are still being generated for this note.'}
       </p>
       {#if pollingError}
-        <p class="note-shell__status-detail">{pollingError}</p>
+        <p class="note-workspace__status-detail">{pollingError}</p>
       {:else if isRefreshing}
-        <p class="note-shell__status-detail">Refreshing the latest processing state…</p>
+        <p class="note-workspace__status-detail">Refreshing the latest processing state…</p>
       {/if}
     </section>
   {:else if note.aiState === 'failed'}
-    <section class="note-shell__status note-shell__status--error stack" style="--stack-space: var(--space-3)" role="alert">
+    <section class="note-workspace__status note-workspace__status--error stack" style="--stack-space: var(--space-2)" role="alert">
       <h2>AI processing failed</h2>
-      <p>The note stays in Card Entry so it can still be finished manually as the workspace evolves.</p>
+      <p>You can keep working here manually and add draft cards yourself.</p>
       {#if pollingError}
-        <p class="note-shell__status-detail">{pollingError}</p>
+        <p class="note-workspace__status-detail">{pollingError}</p>
       {/if}
     </section>
   {/if}
 
-  {#if note.draftCards.length > 0}
-    <section class="draft-preview stack" style="--stack-space: var(--space-4)" aria-labelledby="draft-preview-title">
-      <div class="draft-preview__heading stack" style="--stack-space: var(--space-2)">
-        <h2 id="draft-preview-title">Draft cards</h2>
-        <p>The shared AI preprocessing pipeline has populated these draft fields for the upcoming inline editor.</p>
-      </div>
+  <section class="note-workspace__drafts stack" style="--stack-space: var(--space-4)" aria-labelledby="draft-panels-title">
+    <div class="stack" style="--stack-space: var(--space-1)">
+      <h2 id="draft-panels-title">Draft cards</h2>
+      <p class="note-workspace__supporting">
+        Edit each linked draft inline. Fields save automatically when focus leaves them.
+      </p>
+    </div>
 
-      {#each note.draftCards as draftCard}
-        <article class="draft-preview__card stack" style="--stack-space: var(--space-3)">
-          <div class="stack" style="--stack-space: var(--space-2)">
-            <p class="draft-preview__label">Content</p>
-            <p class="draft-preview__value">{draftCard.content}</p>
+    {#if note.draftCards.length === 0}
+      <section class="note-workspace__empty">
+        <h3>No draft cards yet</h3>
+        <p>
+          {note.aiState === 'queued' || note.aiState === 'processing'
+            ? 'AI is still working, but you can start a manual draft now.'
+            : 'Add a draft card to start shaping this note into active cards.'}
+        </p>
+      </section>
+    {:else}
+      {#each note.draftCards as draftCard (draftCard.cardId)}
+        <DraftCardEditor
+          lang={currentLang}
+          noteId={note.noteId}
+          card={draftCard}
+          availableGroups={note.availableGroups}
+          on:updated={handleDraftCardUpdated}
+          on:removed={handleDraftCardRemoved}
+        />
+      {/each}
+    {/if}
+
+    <button
+      type="button"
+      class="note-workspace__add-card"
+      disabled={addCardPending}
+      on:click={() => void addDraftCard()}
+    >
+      {addCardPending ? 'Adding draft card...' : '+ Add another card'}
+    </button>
+  </section>
+
+  <div class="note-workspace__signoff">
+    <form method="POST" action="?/signOffNote" bind:this={signOffForm}>
+      <button
+        type="submit"
+        class="note-workspace__signoff-button"
+        disabled={signOffDisabled}
+        aria-disabled={signOffDisabled}
+        on:click={handleSignOffClick}
+      >
+        {signOffLabel}
+      </button>
+    </form>
+  </div>
+
+  {#if showDuplicateDialog}
+    <div class="note-workspace__dialog-backdrop">
+      <div class="note-workspace__dialog" role="alertdialog" aria-modal="true" aria-labelledby="duplicate-dialog-title">
+        <div class="stack" style="--stack-space: var(--space-3)">
+          <div class="stack" style="--stack-space: var(--space-1)">
+            <h2 id="duplicate-dialog-title">Duplicate warnings</h2>
+            <p>These draft cards still have possible duplicates.</p>
           </div>
 
-          {#if draftCard.meaning}
-            <div class="stack" style="--stack-space: var(--space-2)">
-              <p class="draft-preview__label">Meaning</p>
-              <p class="draft-preview__value">{draftCard.meaning}</p>
-            </div>
-          {/if}
+          <div class="stack" style="--stack-space: var(--space-2)">
+            {#each unresolvedDuplicateWarnings as warning}
+              <section class="note-workspace__dialog-warning">
+                <p class="note-workspace__dialog-card">{warning.cardLabel}</p>
+                <p class="note-workspace__dialog-copy">{warning.similarCardLabel}</p>
+              </section>
+            {/each}
+          </div>
 
-          {#if draftCard.examples.length > 0}
-            <div class="stack" style="--stack-space: var(--space-2)">
-              <p class="draft-preview__label">Examples</p>
-              <ul class="draft-preview__list">
-                {#each draftCard.examples as example}
-                  <li>{example}</li>
-                {/each}
-              </ul>
-            </div>
-          {/if}
-
-          {#if draftCard.mnemonics.length > 0}
-            <div class="stack" style="--stack-space: var(--space-2)">
-              <p class="draft-preview__label">Mnemonics</p>
-              <ul class="draft-preview__list">
-                {#each draftCard.mnemonics as mnemonic}
-                  <li>{mnemonic}</li>
-                {/each}
-              </ul>
-            </div>
-          {/if}
-
-          {#if draftCard.llmInstructions}
-            <div class="stack" style="--stack-space: var(--space-2)">
-              <p class="draft-preview__label">LLM instructions</p>
-              <p class="draft-preview__value">{draftCard.llmInstructions}</p>
-            </div>
-          {/if}
-        </article>
-      {/each}
-    </section>
-  {:else if note.aiState === 'complete'}
-    <section class="note-shell__status stack" style="--stack-space: var(--space-3)">
-      <h2>No draft cards were generated</h2>
-      <p>The note finished preprocessing without draft output, so it remains ready for manual follow-up.</p>
-    </section>
+          <div class="note-workspace__dialog-actions cluster">
+            <button type="button" class="note-workspace__dialog-button note-workspace__dialog-button--primary" on:click={submitSignOffAnyway}>
+              Promote anyway
+            </button>
+            <button type="button" class="note-workspace__dialog-button" on:click={closeDuplicateDialog}>
+              Go back
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   {/if}
 </section>
 
 <style>
-  .note-shell {
-    padding: calc(var(--shell-header-height) + var(--space-5)) var(--space-4) calc(var(--space-7) + 4.5rem);
+  .note-workspace {
+    padding: calc(var(--shell-header-height) + var(--space-5)) var(--space-4) calc(var(--space-8) + 5rem);
   }
 
-  .note-shell__back,
-  .note-shell__meta,
-  .note-shell__content,
-  .note-shell__status h2,
-  .note-shell__status p,
-  .draft-preview__heading h2,
-  .draft-preview__heading p,
-  .draft-preview__label,
-  .draft-preview__value,
-  .draft-preview__list {
+  .note-workspace__back,
+  .note-workspace__meta,
+  .note-workspace__content,
+  .note-workspace__supporting,
+  .note-workspace__empty h3,
+  .note-workspace__empty p,
+  .note-workspace__status h2,
+  .note-workspace__status p,
+  .note-workspace__alert h2,
+  .note-workspace__alert p,
+  .note-workspace__dialog h2,
+  .note-workspace__dialog p,
+  .note-workspace__dialog-card,
+  .note-workspace__dialog-copy {
     margin: 0;
   }
 
-  .note-shell__back {
+  .note-workspace__back {
     color: var(--color-primary-text);
     font-family: var(--font-ui);
     text-decoration: none;
   }
 
-  .note-shell__header,
-  .note-shell__status,
-  .draft-preview__card {
+  .note-workspace__header,
+  .note-workspace__status,
+  .note-workspace__empty,
+  .note-workspace__alert {
     padding: var(--space-5);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
@@ -196,8 +334,20 @@
     box-shadow: var(--shadow-sm);
   }
 
-  .note-shell__meta,
-  .draft-preview__label {
+  .note-workspace__header {
+    position: sticky;
+    inset-block-start: calc(var(--shell-header-height) + var(--space-3));
+    z-index: 2;
+  }
+
+  .note-workspace__header-top,
+  .note-workspace__actions,
+  .note-workspace__dialog-actions {
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  .note-workspace__meta {
     color: var(--color-text-secondary);
     font-family: var(--font-ui);
     font-size: var(--font-size-caption);
@@ -205,50 +355,152 @@
     text-transform: uppercase;
   }
 
-  .note-shell__content {
+  .note-workspace__content {
+    max-inline-size: var(--measure-body);
     font-size: var(--font-size-h4);
-    line-height: 1.5;
+    line-height: var(--leading-body);
   }
 
-  .note-shell__status--loading {
-    border-color: color-mix(in srgb, var(--color-primary) 40%, var(--color-border));
-  }
-
-  .note-shell__status--error {
-    border-color: color-mix(in srgb, var(--color-danger-text) 40%, var(--color-border));
-  }
-
-  .note-shell__status-detail {
+  .note-workspace__supporting,
+  .note-workspace__status-detail,
+  .note-workspace__empty p,
+  .note-workspace__dialog-copy {
     color: var(--color-text-secondary);
   }
 
-  .draft-preview__heading p {
-    color: var(--color-text-secondary);
+  .note-workspace__status--loading {
+    border-color: color-mix(in srgb, var(--color-primary) 35%, var(--color-border));
   }
 
-  .draft-preview__value {
-    line-height: 1.5;
+  .note-workspace__status--error,
+  .note-workspace__alert {
+    border-color: color-mix(in srgb, var(--color-error-text) 35%, var(--color-border));
   }
 
-  .draft-preview__list {
-    padding-inline-start: 1.25rem;
+  .note-workspace__drafts {
+    padding-block-end: var(--space-3);
   }
 
-  .note-shell__back:focus-visible {
+  .note-workspace__add-card,
+  .note-workspace__action,
+  .note-workspace__signoff-button,
+  .note-workspace__dialog-button {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-subtle);
+    color: var(--color-text-primary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-ui);
+    padding: var(--space-2) var(--space-4);
+  }
+
+  .note-workspace__add-card {
+    inline-size: fit-content;
+  }
+
+  .note-workspace__action--danger {
+    color: var(--color-error-text);
+    border-color: color-mix(in srgb, var(--color-error-text) 35%, var(--color-border));
+  }
+
+  .note-workspace__signoff {
+    position: sticky;
+    inset-block-end: var(--space-3);
+    z-index: 3;
+  }
+
+  .note-workspace__signoff-button {
+    inline-size: min(100%, 44rem);
+    padding: var(--space-4) var(--space-5);
+    border-color: color-mix(in srgb, var(--color-primary) 35%, var(--color-border));
+    background: var(--color-surface-raised);
+    box-shadow: var(--shadow-sm);
+    color: var(--color-primary-text);
+    font-weight: 600;
+  }
+
+  .note-workspace__signoff-button:disabled {
+    color: var(--color-text-disabled);
+    border-color: var(--color-border);
+  }
+
+  .note-workspace__dialog-backdrop {
+    position: fixed;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    padding: var(--space-4);
+    background: color-mix(in srgb, var(--color-background) 20%, transparent);
+    backdrop-filter: blur(2px);
+    z-index: 10;
+  }
+
+  .note-workspace__dialog {
+    inline-size: min(100%, 34rem);
+    padding: var(--space-5);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface-raised);
+    box-shadow: var(--shadow-md);
+  }
+
+  .note-workspace__dialog-warning {
+    padding: var(--space-3);
+    border: 1px solid var(--color-warning-border);
+    border-radius: var(--radius-md);
+    background: var(--color-warning-bg);
+  }
+
+  .note-workspace__dialog-card {
+    color: var(--color-warning-text);
+    font-family: var(--font-ui);
+    font-weight: 600;
+  }
+
+  .note-workspace__dialog-copy {
+    color: var(--color-warning-text);
+  }
+
+  .note-workspace__dialog-button--primary {
+    color: var(--color-primary-text);
+    border-color: color-mix(in srgb, var(--color-primary) 35%, var(--color-border));
+  }
+
+  .note-workspace__back:focus-visible,
+  .note-workspace__add-card:focus-visible,
+  .note-workspace__action:focus-visible,
+  .note-workspace__signoff-button:focus-visible,
+  .note-workspace__dialog-button:focus-visible {
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
   }
 
   @media (min-width: 64rem) {
-    .note-shell {
+    .note-workspace {
       padding-inline: calc(var(--shell-sidebar-width) + var(--space-6)) var(--space-6);
-      padding-block-end: calc(var(--space-7) + 5rem);
     }
   }
 
-  @media (max-width: 63.99rem) {
-    .note-shell {
+  @media (max-width: 48rem) {
+    .note-workspace {
       padding-inline: var(--space-3);
+      padding-block-end: calc(var(--space-8) + 6rem);
+    }
+
+    .note-workspace__header-top,
+    .note-workspace__actions,
+    .note-workspace__dialog-actions {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .note-workspace__signoff-button {
+      inline-size: 100%;
+    }
+
+    .note-workspace__dialog {
+      align-self: end;
+      inline-size: 100%;
     }
   }
 </style>

--- a/apps/web/src/routes/[lang]/card-entry/notes/[noteId]/draft-cards/+server.ts
+++ b/apps/web/src/routes/[lang]/card-entry/notes/[noteId]/draft-cards/+server.ts
@@ -1,0 +1,37 @@
+import { error, json, type RequestHandler } from '@sveltejs/kit';
+import { withTransactionDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import { CardEntryRequestError, createCardEntryDraftCardForLanguage } from '$lib/server/card-entry.js';
+
+export const POST: RequestHandler = async (event) => {
+  const session = await event.locals.auth();
+  const userId = session?.user?.id;
+  const languageId = event.params.lang;
+  const noteId = event.params.noteId;
+
+  if (!userId || !languageId || !noteId) {
+    throw error(401, 'You must be signed in to edit this note.');
+  }
+
+  const databaseUrl = env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    throw error(500, 'The draft card service is not configured right now.');
+  }
+
+  try {
+    const note = await withTransactionDb(
+      databaseUrl,
+      (database) => createCardEntryDraftCardForLanguage(userId, languageId, noteId, database as never)
+    );
+
+    return json(note);
+  } catch (requestError) {
+    if (requestError instanceof CardEntryRequestError) {
+      throw error(requestError.status, requestError.message);
+    }
+
+    console.error('Failed to create Card Entry draft card:', requestError);
+    throw error(500, 'The draft card could not be created right now.');
+  }
+};

--- a/apps/web/src/routes/[lang]/card-entry/notes/[noteId]/draft-cards/[cardId]/+server.ts
+++ b/apps/web/src/routes/[lang]/card-entry/notes/[noteId]/draft-cards/[cardId]/+server.ts
@@ -1,0 +1,94 @@
+import { error, json, type RequestHandler } from '@sveltejs/kit';
+import { withTransactionDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import {
+  CardEntryRequestError,
+  removeCardEntryDraftCardForLanguage,
+  updateCardEntryDraftCardForLanguage,
+} from '$lib/server/card-entry.js';
+
+export const PATCH: RequestHandler = async (event) => {
+  const session = await event.locals.auth();
+  const userId = session?.user?.id;
+  const params = event.params as {
+    lang?: string;
+    noteId?: string;
+    cardId?: string;
+  };
+  const languageId = params.lang;
+  const noteId = params.noteId;
+  const cardId = params.cardId;
+
+  if (!userId || !languageId || !noteId || !cardId) {
+    throw error(401, 'You must be signed in to edit this draft card.');
+  }
+
+  const databaseUrl = env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    throw error(500, 'The draft card service is not configured right now.');
+  }
+
+  let body: unknown;
+
+  try {
+    body = await event.request.json();
+  } catch {
+    throw error(400, 'The draft card update payload must be valid JSON.');
+  }
+
+  try {
+    const result = await withTransactionDb(
+      databaseUrl,
+      (database) => updateCardEntryDraftCardForLanguage(userId, languageId, noteId, cardId, body, database as never)
+    );
+
+    return json(result);
+  } catch (requestError) {
+    if (requestError instanceof CardEntryRequestError) {
+      throw error(requestError.status, requestError.message);
+    }
+
+    console.error('Failed to update Card Entry draft card:', requestError);
+    throw error(500, 'The draft card could not be updated right now.');
+  }
+};
+
+export const DELETE: RequestHandler = async (event) => {
+  const session = await event.locals.auth();
+  const userId = session?.user?.id;
+  const params = event.params as {
+    lang?: string;
+    noteId?: string;
+    cardId?: string;
+  };
+  const languageId = params.lang;
+  const noteId = params.noteId;
+  const cardId = params.cardId;
+
+  if (!userId || !languageId || !noteId || !cardId) {
+    throw error(401, 'You must be signed in to edit this draft card.');
+  }
+
+  const databaseUrl = env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    throw error(500, 'The draft card service is not configured right now.');
+  }
+
+  try {
+    const note = await withTransactionDb(
+      databaseUrl,
+      (database) => removeCardEntryDraftCardForLanguage(userId, languageId, noteId, cardId, database as never)
+    );
+
+    return json(note);
+  } catch (requestError) {
+    if (requestError instanceof CardEntryRequestError) {
+      throw error(requestError.status, requestError.message);
+    }
+
+    console.error('Failed to remove Card Entry draft card:', requestError);
+    throw error(500, 'The draft card could not be removed right now.');
+  }
+};

--- a/docs/requirements/functionality/card-library-and-groups.md
+++ b/docs/requirements/functionality/card-library-and-groups.md
@@ -92,7 +92,7 @@ The Card Detail drawer is a **shared component** accessible from multiple surfac
 | **Groups** | Group membership (multi-select) |
 | **Example sentences** | Zero or more; ordered list |
 | **Mnemonics** | Zero or more personal memory aids |
-| **LLM instructions** | Optional AI guidance for Translation Drills |
+| **LLM instructions** | Optional AI guidance for Translation Drills, labeled in the UI as `Special instructions for practicing this card` with helper text clarifying that StudyPuck should focus on, avoid, or reinforce specific quiz behavior for the card |
 
 ### Actions Available from the Drawer
 

--- a/docs/requirements/functionality/cards.md
+++ b/docs/requirements/functionality/cards.md
@@ -31,7 +31,7 @@ Unlike traditional flashcards, StudyPuck cards are structured as study prompts r
 - **Status lifecycle**: Cards progress from 'draft' (private review) to 'active' (available across applications); soft-deleting a card sets status to 'deleted' and records a `deleted_at` timestamp, removing it from all active surfaces while preserving SRS history
 - **Multiple example sentences**: Demonstrate usage in context during review
 - **Mnemonic prompts**: Personal memory encoding reminders for how you decided to remember a word or concept
-- **LLM instructions**: Optional guidance for how the AI should use this card when generating translation sentences
+- **LLM instructions**: Optional guidance for how the AI should use this card when generating translation sentences; surfaced in the UI as `Special instructions for practicing this card`
 - **Variable length**: Can range from a few words to full paragraph prompts
 
 ## Organization

--- a/docs/ux/storyboards/card-entry.md
+++ b/docs/ux/storyboards/card-entry.md
@@ -308,10 +308,11 @@ Each panel contains:
 | Field | Type | Detail |
 |---|---|---|
 | Content | Multi-line textarea | The card's primary content. Placeholder: "Card content…" |
-| Groups | Multi-select token input | Selected groups shown as pills. `[+ Add group]` opens the group picker dropdown. Inline group creation: `+ Create "[typed text]"` at the bottom of dropdown — see [card-library-and-groups.md](./card-library-and-groups.md) |
-| Example sentences | Ordered list of text inputs | Each item has a `✕` remove button. `[ + Add ]` button adds a new blank row. |
-| Mnemonics | Ordered list of text inputs | Same add/remove pattern as example sentences. |
-| LLM instructions | Collapsible textarea | Collapsed by default ("▸ LLM instructions"). Expanding reveals a textarea for per-card instructions to the AI. |
+| Meaning | Multi-line textarea | Editable meaning/translation field. Placeholder: "Meaning…" |
+| Groups | Multi-select token input | Selected groups shown as pills. `[+ Add group]` opens a dropdown containing only groups not already associated with the card. Leaving the group-search area closes the dropdown. Inline group creation: `+ Create "[typed text]"` at the bottom of dropdown — see [card-library-and-groups.md](./card-library-and-groups.md) |
+| Example sentences | Ordered list of multi-line textareas | Each item wraps text, starts slightly taller than a single line, and scrolls vertically if needed. Each item has a `✕` remove button. `[ + Add ]` button adds a new blank row. |
+| Mnemonics | Ordered list of multi-line textareas | Same add/remove pattern as example sentences, with wrapping text and vertical scrolling for longer notes. |
+| LLM instructions | Collapsible textarea | Collapsed by default ("▸ Special instructions for practicing this card"). Expanding reveals helper text: `Optional: tell StudyPuck what to focus on, avoid, or reinforce, when it is quizzing you on this card.` |
 
 **AI suggestions (inline below the relevant field — Decision 12):**
 

--- a/docs/ux/storyboards/card-library-and-groups.md
+++ b/docs/ux/storyboards/card-library-and-groups.md
@@ -289,30 +289,31 @@ If a save request fails (network error, server error), the indicator changes to 
 #### Groups (Multi-Select with Inline Creation)
 
 - **Visual:** A token input field — selected groups appear as removable pills (e.g., `Greetings ✕`). An inline `+ Add group` trigger opens the group picker dropdown below the field.
-- **Dropdown behavior:** On click/focus, a dropdown list opens showing all groups for the active language, sorted alphabetically. Already-assigned groups appear checked at the top (and can be unchecked to remove). Unassigned groups are listed below.
+- **Dropdown behavior:** On click/focus, a dropdown list opens showing only groups for the active language that are **not already assigned** to the card, sorted alphabetically. Choosing a group adds it to the card as a pill. When focus leaves the group-search area, the dropdown closes.
 - **Live search within dropdown:** Typing in the field filters the dropdown list in real time.
 - **Inline group creation:** If the typed text does not match any existing group, a `+ Create "[typed text]"` option appears as the last item in the dropdown. Selecting it immediately creates the group (name only; description is empty by default) and adds it to this card. The new group pill appears in the field.
 - **Save behavior:** Each addition or removal of a group tag saves immediately (not on drawer blur — the change is atomic and discrete).
-- **Keyboard:** Arrow keys navigate the dropdown; Enter selects; Escape closes the dropdown.
+- **Keyboard:** Typing filters the list in real time; Escape closes the dropdown.
 
 #### Example Sentences
 
-- **Visual:** A numbered, ordered list of text inputs. Each item has a `✕` remove button on the right. A `+ Add Example` button appears below the list (or inline after the last item).
+- **Visual:** A numbered, ordered list of multi-line text areas. Each item wraps text, starts slightly taller than a single line, and can scroll vertically if the content grows long. Each item has a `✕` remove button on the right. A `+ Add Example` button appears below the list (or inline after the last item).
 - **Placeholder for empty item:** `Type an example sentence…`
 - **Behavior:** Items save on blur. Order is preserved (drag-to-reorder is deferred to a future iteration). Removing an item is immediate (no confirmation); the list re-numbers.
 - **Empty state:** If no examples exist, only the `+ Add Example` button is shown.
 
 #### Mnemonics
 
-- **Visual:** Same pattern as Example Sentences but without ordered numbering. Each mnemonic is a text area (multi-line), not a single-line input.
+- **Visual:** Same pattern as Example Sentences but without ordered numbering. Each mnemonic is a multi-line text area with wrapping text and vertical scrolling for longer notes.
 - **Placeholder:** `Type a mnemonic…`
 - **Behavior:** Add/remove, saves on blur. No ordering.
 - **Empty state:** `+ Add Mnemonic` button.
 
 #### LLM Instructions
 
-- **Visual:** A multi-line text area, collapsed by default behind a disclosure toggle (`▸ LLM Instructions`). Clicking the toggle expands the field.
-- **Placeholder:** `Custom instructions for the LLM when this card is in context…`
+- **Visual:** A multi-line text area, collapsed by default behind a disclosure toggle (`▸ Special instructions for practicing this card`). Clicking the toggle expands the field.
+- **Helper text:** `Optional: tell StudyPuck what to focus on, avoid, or reinforce, when it is quizzing you on this card.`
+- **Placeholder:** `Optional instructions for how StudyPuck should quiz you on this card...`
 - **Behavior:** Saves on blur. The expanded/collapsed state persists only for the current drawer session (not persisted globally).
 - **Rationale for disclosure:** Most users will rarely set LLM instructions; hiding it by default reduces cognitive load without removing the capability.
 

--- a/packages/database/src/cards.ts
+++ b/packages/database/src/cards.ts
@@ -1,4 +1,5 @@
-import { eq, and, sql, desc } from 'drizzle-orm';
+import { eq, and, sql, desc, inArray } from 'drizzle-orm';
+import type { PgDatabase } from 'drizzle-orm/pg-core';
 import { db } from './index.js';
 import { cards, groups, cardGroups, type Card, type NewCard, type Group, type NewGroup, type CardGroup, type NewCardGroup } from './schema.js';
 
@@ -6,6 +7,13 @@ import { cards, groups, cardGroups, type Card, type NewCard, type Group, type Ne
  * Card and Group database operations
  * Handles CRUD operations for study content
  */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyDb = PgDatabase<any, any, any>;
+
+function getConn(database?: AnyDb) {
+  return database ?? (db as AnyDb);
+}
 
 // === Card Operations ===
 
@@ -79,9 +87,10 @@ export async function updateCard(
   userId: string, 
   languageId: string, 
   cardId: string, 
-  updates: Partial<Omit<NewCard, 'userId' | 'languageId' | 'cardId'>>
+  updates: Partial<Omit<NewCard, 'userId' | 'languageId' | 'cardId'>>,
+  database?: AnyDb
 ): Promise<Card | null> {
-  const result = await db
+  const result = await getConn(database)
     .update(cards)
     .set({
       ...updates,
@@ -187,8 +196,8 @@ export async function findSimilarCards(
 /**
  * Get all groups for a user+language
  */
-export async function getGroups(userId: string, languageId: string): Promise<Group[]> {
-  return await db
+export async function getGroups(userId: string, languageId: string, database?: AnyDb): Promise<Group[]> {
+  return await getConn(database)
     .select()
     .from(groups)
     .where(and(
@@ -201,8 +210,8 @@ export async function getGroups(userId: string, languageId: string): Promise<Gro
 /**
  * Get a specific group by ID
  */
-export async function getGroup(userId: string, languageId: string, groupId: string): Promise<Group | null> {
-  const result = await db
+export async function getGroup(userId: string, languageId: string, groupId: string, database?: AnyDb): Promise<Group | null> {
+  const result = await getConn(database)
     .select()
     .from(groups)
     .where(and(
@@ -218,8 +227,8 @@ export async function getGroup(userId: string, languageId: string, groupId: stri
 /**
  * Create a new group
  */
-export async function createGroup(groupData: NewGroup): Promise<Group> {
-  const result = await db
+export async function createGroup(groupData: NewGroup, database?: AnyDb): Promise<Group> {
+  const result = await getConn(database)
     .insert(groups)
     .values({
       ...groupData,
@@ -237,9 +246,10 @@ export async function updateGroup(
   userId: string, 
   languageId: string, 
   groupId: string, 
-  updates: Partial<Omit<NewGroup, 'userId' | 'languageId' | 'groupId'>>
+  updates: Partial<Omit<NewGroup, 'userId' | 'languageId' | 'groupId'>>,
+  database?: AnyDb
 ): Promise<Group | null> {
-  const result = await db
+  const result = await getConn(database)
     .update(groups)
     .set(updates)
     .where(and(
@@ -295,8 +305,8 @@ export async function findSimilarGroups(
 /**
  * Add a card to a group
  */
-export async function addCardToGroup(cardGroupData: NewCardGroup): Promise<CardGroup> {
-  const result = await db
+export async function addCardToGroup(cardGroupData: NewCardGroup, database?: AnyDb): Promise<CardGroup> {
+  const result = await getConn(database)
     .insert(cardGroups)
     .values({
       ...cardGroupData,
@@ -314,9 +324,10 @@ export async function removeCardFromGroup(
   userId: string, 
   languageId: string, 
   cardId: string, 
-  groupId: string
+  groupId: string,
+  database?: AnyDb
 ): Promise<void> {
-  await db
+  await getConn(database)
     .delete(cardGroups)
     .where(and(
       eq(cardGroups.userId, userId),
@@ -370,8 +381,8 @@ export async function getCardsInGroup(userId: string, languageId: string, groupI
 /**
  * Get all groups for a specific card
  */
-export async function getCardGroups(userId: string, languageId: string, cardId: string): Promise<Group[]> {
-  const result = await db
+export async function getCardGroups(userId: string, languageId: string, cardId: string, database?: AnyDb): Promise<Group[]> {
+  const result = await getConn(database)
     .select({
       userId: groups.userId,
       languageId: groups.languageId,
@@ -398,4 +409,63 @@ export async function getCardGroups(userId: string, languageId: string, cardId: 
     .orderBy(groups.groupName);
   
   return result;
+}
+
+export async function getCardGroupsForCards(
+  userId: string,
+  languageId: string,
+  cardIds: string[],
+  database?: AnyDb
+): Promise<Map<string, Group[]>> {
+  const groupsByCardId = new Map<string, Group[]>();
+
+  if (cardIds.length === 0) {
+    return groupsByCardId;
+  }
+
+  const rows = await getConn(database)
+    .select({
+      cardId: cardGroups.cardId,
+      userId: groups.userId,
+      languageId: groups.languageId,
+      groupId: groups.groupId,
+      groupName: groups.groupName,
+      description: groups.description,
+      embedding: groups.embedding,
+      embeddingModel: groups.embeddingModel,
+      embeddingGeneratedAt: groups.embeddingGeneratedAt,
+      createdAt: groups.createdAt,
+      metadata: groups.metadata,
+    })
+    .from(cardGroups)
+    .innerJoin(groups, and(
+      eq(groups.userId, cardGroups.userId),
+      eq(groups.languageId, cardGroups.languageId),
+      eq(groups.groupId, cardGroups.groupId)
+    ))
+    .where(and(
+      eq(cardGroups.userId, userId),
+      eq(cardGroups.languageId, languageId),
+      inArray(cardGroups.cardId, cardIds)
+    ))
+    .orderBy(cardGroups.cardId, groups.groupName);
+
+  for (const row of rows) {
+    const existingGroups = groupsByCardId.get(row.cardId) ?? [];
+    existingGroups.push({
+      userId: row.userId,
+      languageId: row.languageId,
+      groupId: row.groupId,
+      groupName: row.groupName,
+      description: row.description,
+      embedding: row.embedding,
+      embeddingModel: row.embeddingModel,
+      embeddingGeneratedAt: row.embeddingGeneratedAt,
+      createdAt: row.createdAt,
+      metadata: row.metadata,
+    });
+    groupsByCardId.set(row.cardId, existingGroups);
+  }
+
+  return groupsByCardId;
 }


### PR DESCRIPTION
## Summary
- turn the note processing route into an editable Card Entry workspace with sticky note actions and sign-off flow
- add draft-card APIs and reusable editor logic for content, meaning, groups, examples, mnemonics, and practice instructions
- align the Card Entry and Card Library docs with the implemented editor behavior and UX refinements

Closes #117