### PR TITLE
Add Card Entry drafts view

### DIFF
--- a/apps/web/src/lib/card-entry/drafts.test.ts
+++ b/apps/web/src/lib/card-entry/drafts.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { filterDraftCards, formatDraftGroupFilterLabel } from './drafts.js';
+import type { CardEntryDraftListItemData } from '$lib/server/card-entry.js';
+
+const items: CardEntryDraftListItemData[] = [
+  {
+    cardId: 'card-1',
+    content: 'Relative time expression',
+    meaning: 'after a while',
+    updatedAtIso: '2026-04-18T00:00:00.000Z',
+    updatedAtLabel: '2h ago',
+    groups: [{ groupId: 'group-grammar', groupName: 'Grammar' }],
+    sourceNotes: [
+      {
+        noteId: 'note-1',
+        content: 'Saw a great example sentence in the textbook',
+        state: 'unprocessed',
+        createdAtIso: '2026-04-18T00:00:00.000Z',
+        linkedAtIso: '2026-04-18T00:00:00.000Z',
+      },
+    ],
+  },
+  {
+    cardId: 'card-2',
+    content: 'Particle distinction',
+    meaning: 'contrast marker',
+    updatedAtIso: '2026-04-17T00:00:00.000Z',
+    updatedAtLabel: '1d ago',
+    groups: [{ groupId: 'group-particles', groupName: 'Particles' }],
+    sourceNotes: [
+      {
+        noteId: 'note-2',
+        content: 'Need to review particles',
+        state: 'unprocessed',
+        createdAtIso: '2026-04-17T00:00:00.000Z',
+        linkedAtIso: '2026-04-17T00:00:00.000Z',
+      },
+    ],
+  },
+];
+
+describe('filterDraftCards', () => {
+  it('matches search against content, meaning, and source note content', () => {
+    expect(filterDraftCards(items, 'textbook', [])).toEqual([items[0]]);
+    expect(filterDraftCards(items, 'contrast', [])).toEqual([items[1]]);
+  });
+
+  it('applies OR logic across selected group filters', () => {
+    expect(filterDraftCards(items, '', ['group-grammar'])).toEqual([items[0]]);
+    expect(filterDraftCards(items, '', ['group-grammar', 'group-particles'])).toEqual(items);
+  });
+});
+
+describe('formatDraftGroupFilterLabel', () => {
+  it('formats the group filter label for default, single, and multi-select states', () => {
+    expect(formatDraftGroupFilterLabel([])).toBe('All groups');
+    expect(formatDraftGroupFilterLabel(['Grammar'])).toBe('Group: Grammar');
+    expect(formatDraftGroupFilterLabel(['Grammar', 'Particles'])).toBe('Groups: 2');
+  });
+});

--- a/apps/web/src/lib/card-entry/drafts.ts
+++ b/apps/web/src/lib/card-entry/drafts.ts
@@ -1,0 +1,40 @@
+import type { CardEntryDraftListItemData } from '$lib/server/card-entry.js';
+
+export function filterDraftCards(
+  items: CardEntryDraftListItemData[],
+  searchQuery: string,
+  selectedGroupIds: string[]
+): CardEntryDraftListItemData[] {
+  const normalizedSearchQuery = searchQuery.trim().toLocaleLowerCase();
+  const selectedGroupIdSet = new Set(selectedGroupIds);
+
+  return items.filter((item) => {
+    const matchesSearch =
+      normalizedSearchQuery.length === 0 ||
+      item.content.toLocaleLowerCase().includes(normalizedSearchQuery) ||
+      (item.meaning?.toLocaleLowerCase().includes(normalizedSearchQuery) ?? false) ||
+      item.sourceNotes.some((sourceNote) => sourceNote.content.toLocaleLowerCase().includes(normalizedSearchQuery));
+
+    if (!matchesSearch) {
+      return false;
+    }
+
+    if (selectedGroupIdSet.size === 0) {
+      return true;
+    }
+
+    return item.groups.some((group) => selectedGroupIdSet.has(group.groupId));
+  });
+}
+
+export function formatDraftGroupFilterLabel(selectedGroupNames: string[]): string {
+  if (selectedGroupNames.length === 0) {
+    return 'All groups';
+  }
+
+  if (selectedGroupNames.length === 1) {
+    return `Group: ${selectedGroupNames[0]}`;
+  }
+
+  return `Groups: ${selectedGroupNames.length}`;
+}

--- a/apps/web/src/lib/components/card-list/CardListBulkActionBar.svelte
+++ b/apps/web/src/lib/components/card-list/CardListBulkActionBar.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+
+  const dispatch = createEventDispatcher<{
+    primary: void;
+    secondary: void;
+    clear: void;
+  }>();
+
+  export let selectedCount = 0;
+  export let itemLabelSingular = 'card';
+  export let itemLabelPlural = 'cards';
+  export let primaryActionLabel = 'Primary';
+  export let primaryActionPendingLabel = 'Working...';
+  export let secondaryActionLabel = 'Secondary';
+  export let secondaryActionPendingLabel = 'Working...';
+  export let clearLabel = 'Deselect all';
+  export let disabled = false;
+  export let pendingAction: 'primary' | 'secondary' | null = null;
+</script>
+
+<section class="card-list-bulk-bar cluster" aria-live="polite">
+  <p>{selectedCount} {selectedCount === 1 ? itemLabelSingular : itemLabelPlural} selected</p>
+
+  <div class="card-list-bulk-bar__actions cluster">
+    <button type="button" class="card-list-bulk-bar__button" disabled={disabled} on:click={() => dispatch('primary')}>
+      {pendingAction === 'primary' ? primaryActionPendingLabel : primaryActionLabel}
+    </button>
+    <button
+      type="button"
+      class="card-list-bulk-bar__button card-list-bulk-bar__button--danger"
+      disabled={disabled}
+      on:click={() => dispatch('secondary')}
+    >
+      {pendingAction === 'secondary' ? secondaryActionPendingLabel : secondaryActionLabel}
+    </button>
+    <button type="button" class="card-list-bulk-bar__link" on:click={() => dispatch('clear')}>{clearLabel}</button>
+  </div>
+</section>
+
+<style>
+  .card-list-bulk-bar,
+  .card-list-bulk-bar__actions {
+    align-items: center;
+    gap: var(--space-3);
+  }
+
+  .card-list-bulk-bar {
+    justify-content: space-between;
+    padding: 0.85rem 1rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .card-list-bulk-bar p {
+    margin: 0;
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+  }
+
+  .card-list-bulk-bar__button,
+  .card-list-bulk-bar__link {
+    border: 0;
+    background: none;
+    color: inherit;
+    font: inherit;
+  }
+
+  .card-list-bulk-bar__button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.55rem 0.9rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text-primary);
+    cursor: pointer;
+    text-decoration: none;
+    font-family: var(--font-ui);
+  }
+
+  .card-list-bulk-bar__button:first-child {
+    border-color: var(--color-primary);
+    background: var(--color-primary);
+    color: var(--color-text-inverse);
+  }
+
+  .card-list-bulk-bar__button--danger {
+    color: var(--color-danger-text);
+    border-color: color-mix(in srgb, var(--color-danger-border) 60%, var(--color-border));
+    background: var(--color-surface);
+  }
+
+  .card-list-bulk-bar__link {
+    padding: 0;
+    text-decoration: underline;
+    cursor: pointer;
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+  }
+
+  .card-list-bulk-bar__button:focus-visible,
+  .card-list-bulk-bar__link:focus-visible {
+    outline: 3px solid color-mix(in srgb, var(--color-primary-text) 35%, transparent);
+    outline-offset: 2px;
+  }
+
+  @media (max-width: 640px) {
+    .card-list-bulk-bar {
+      align-items: start;
+      flex-direction: column;
+    }
+
+    .card-list-bulk-bar__actions {
+      inline-size: 100%;
+      flex-wrap: wrap;
+    }
+  }
+</style>

--- a/apps/web/src/lib/components/card-list/CardListColumns.svelte
+++ b/apps/web/src/lib/components/card-list/CardListColumns.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  export let labels: string[] = [];
+  export let rowTemplate = 'auto minmax(0, 1.9fr) minmax(10rem, 1fr) minmax(4rem, 0.5fr) auto';
+</script>
+
+<div class="card-list-columns" aria-hidden="true" style={`--card-list-row-template: ${rowTemplate}`}>
+  {#if labels[0]}
+    <span>{labels[0]}</span>
+  {/if}
+  {#if labels[1]}
+    <span>{labels[1]}</span>
+  {/if}
+  {#if labels[2]}
+    <span>{labels[2]}</span>
+  {/if}
+</div>
+
+<style>
+  .card-list-columns {
+    display: grid;
+    grid-template-columns: var(--card-list-row-template);
+    gap: var(--space-3);
+    padding: 0 var(--space-4) var(--space-2);
+    color: var(--color-text-muted);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-caption);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .card-list-columns span:first-child {
+    grid-column: 2;
+  }
+
+  @media (max-width: 900px) {
+    .card-list-columns {
+      display: none;
+    }
+  }
+</style>

--- a/apps/web/src/lib/components/card-list/CardListFilterBar.svelte
+++ b/apps/web/src/lib/components/card-list/CardListFilterBar.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+  type CardListGroupOption = {
+    groupId: string;
+    groupName: string;
+  };
+
+  export let availableGroups: CardListGroupOption[] = [];
+  export let searchLabel = 'Search';
+  export let searchPlaceholder = 'Search...';
+  export let searchQuery = '';
+  export let groupFilterLabel = 'All groups';
+  export let selectedGroupIds: string[] = [];
+  export let clearGroupLabel = 'Clear group filters';
+
+  function toggleGroup(groupId: string) {
+    if (selectedGroupIds.includes(groupId)) {
+      selectedGroupIds = selectedGroupIds.filter((existingGroupId) => existingGroupId !== groupId);
+      return;
+    }
+
+    selectedGroupIds = [...selectedGroupIds, groupId];
+  }
+
+  function clearGroupFilters() {
+    selectedGroupIds = [];
+  }
+</script>
+
+<section class="card-list-filter-bar">
+  <label class="card-list-filter-bar__search">
+    <span class="card-list-filter-bar__label">{searchLabel}</span>
+    <input
+      bind:value={searchQuery}
+      class="card-list-filter-bar__search-input"
+      type="search"
+      placeholder={searchPlaceholder}
+      autocomplete="off"
+    />
+  </label>
+
+  <details class="card-list-filter-bar__groups">
+    <summary class="card-list-filter-bar__groups-summary">
+      {groupFilterLabel}
+      <span aria-hidden="true">▾</span>
+    </summary>
+
+    <div class="card-list-filter-bar__groups-menu stack" style="--stack-space: var(--space-2)">
+      <button type="button" class="card-list-filter-bar__clear" on:click={clearGroupFilters}>
+        {clearGroupLabel}
+      </button>
+
+      {#each availableGroups as group}
+        <label class="card-list-filter-bar__group-option">
+          <input
+            type="checkbox"
+            checked={selectedGroupIds.includes(group.groupId)}
+            on:change={() => toggleGroup(group.groupId)}
+          />
+          <span>{group.groupName}</span>
+        </label>
+      {/each}
+    </div>
+  </details>
+</section>
+
+<style>
+  .card-list-filter-bar {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: var(--space-3);
+  }
+
+  .card-list-filter-bar__search {
+    display: grid;
+    gap: var(--space-1);
+  }
+
+  .card-list-filter-bar__label {
+    margin: 0;
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-caption);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .card-list-filter-bar__search-input,
+  .card-list-filter-bar__groups-summary {
+    min-block-size: 2.75rem;
+    padding: 0.7rem 0.95rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text-primary);
+    font-family: var(--font-ui);
+    transition:
+      border-color var(--duration-fast) var(--ease-standard),
+      box-shadow var(--duration-fast) var(--ease-standard);
+  }
+
+  .card-list-filter-bar__search-input {
+    inline-size: 100%;
+  }
+
+  .card-list-filter-bar__groups {
+    position: relative;
+  }
+
+  .card-list-filter-bar__groups[open] .card-list-filter-bar__groups-summary {
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
+  }
+
+  .card-list-filter-bar__groups-summary {
+    display: inline-flex;
+    min-inline-size: 10.5rem;
+    align-items: center;
+    justify-content: space-between;
+    cursor: pointer;
+    list-style: none;
+  }
+
+  .card-list-filter-bar__groups-summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .card-list-filter-bar__groups-menu {
+    position: absolute;
+    z-index: 2;
+    inset-inline-end: 0;
+    inline-size: min(18rem, 80vw);
+    margin-block-start: -1px;
+    padding: var(--space-3);
+    border: 1px solid var(--color-border);
+    border-start-start-radius: var(--radius-md);
+    border-start-end-radius: 0;
+    border-end-start-radius: var(--radius-lg);
+    border-end-end-radius: var(--radius-lg);
+    background: var(--color-surface);
+    box-shadow: var(--shadow-md);
+  }
+
+  .card-list-filter-bar__clear {
+    justify-self: start;
+    padding: 0;
+    border: 0;
+    background: none;
+    color: var(--color-text-secondary);
+    font: inherit;
+    font-family: var(--font-ui);
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .card-list-filter-bar__group-option {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    color: inherit;
+    font-family: var(--font-ui);
+  }
+
+  .card-list-filter-bar__search-input:focus-visible,
+  .card-list-filter-bar__groups-summary:focus-visible,
+  .card-list-filter-bar__clear:focus-visible {
+    outline: none;
+    border-color: color-mix(in srgb, var(--color-primary-text) 45%, var(--color-border));
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary-text) 18%, transparent);
+  }
+
+  @media (max-width: 900px) {
+    .card-list-filter-bar {
+      grid-template-columns: 1fr;
+    }
+
+    .card-list-filter-bar__groups-summary {
+      inline-size: 100%;
+    }
+  }
+</style>

--- a/apps/web/src/lib/components/card-list/CardListRow.svelte
+++ b/apps/web/src/lib/components/card-list/CardListRow.svelte
@@ -1,0 +1,184 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+
+  const dispatch = createEventDispatcher<{
+    toggleSelection: void;
+  }>();
+
+  export let selected = false;
+  export let checkboxLabel = 'Select card';
+  export let rowTemplate = '1rem minmax(0, 2.25fr) minmax(9rem, 1fr) auto auto';
+</script>
+
+<article class:selected class="card-list-row">
+  <div class="card-list-row__track" style={`--card-list-row-template: ${rowTemplate}`}>
+    <label class="card-list-row__checkbox">
+      <input type="checkbox" checked={selected} on:change={() => dispatch('toggleSelection')} />
+      <span class="sr-only">{checkboxLabel}</span>
+    </label>
+
+    <div class="card-list-row__content">
+      <slot name="content" />
+    </div>
+
+    <div class="card-list-row__groups">
+      <slot name="groups" />
+    </div>
+
+    <div class="card-list-row__updated">
+      <slot name="updated" />
+    </div>
+
+    <div class="card-list-row__actions" aria-label="Row actions">
+      <slot name="actions" />
+    </div>
+  </div>
+</article>
+
+<style>
+  .card-list-row {
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+    transition:
+      border-color var(--duration-fast) var(--ease-standard),
+      background var(--duration-fast) var(--ease-standard),
+      box-shadow var(--duration-fast) var(--ease-standard);
+  }
+
+  .card-list-row.selected {
+    border-color: color-mix(in srgb, var(--color-primary-text) 45%, var(--color-border));
+    background: color-mix(in srgb, var(--color-primary-subtle) 12%, var(--color-surface));
+  }
+
+  .card-list-row:hover,
+  .card-list-row:focus-within {
+    border-color: var(--color-border);
+    background: color-mix(in srgb, var(--color-surface-raised) 45%, var(--color-surface));
+  }
+
+  .card-list-row__track {
+    display: grid;
+    grid-template-columns: var(--card-list-row-template);
+    gap: var(--space-3);
+    align-items: start;
+    padding: var(--space-4);
+  }
+
+  .card-list-row__checkbox {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    align-self: center;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--duration-fast) var(--ease-standard);
+  }
+
+  .card-list-row__checkbox input {
+    margin: 0;
+  }
+
+  .card-list-row:hover .card-list-row__checkbox,
+  .card-list-row:focus-within .card-list-row__checkbox,
+  .card-list-row.selected .card-list-row__checkbox {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .card-list-row__content,
+  .card-list-row__groups,
+  .card-list-row__updated {
+    min-inline-size: 0;
+  }
+
+  .card-list-row__actions {
+    display: flex;
+    align-items: center;
+    justify-self: end;
+    gap: var(--space-3);
+    padding-inline-start: var(--space-3);
+    border-inline-start: 1px solid var(--color-border-subtle);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--duration-fast) var(--ease-standard);
+    white-space: nowrap;
+  }
+
+  .card-list-row:hover .card-list-row__actions,
+  .card-list-row:focus-within .card-list-row__actions,
+  .card-list-row.selected .card-list-row__actions {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .card-list-row :global(.card-list-action) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: 0;
+    background: none;
+    color: var(--color-text-secondary);
+    font: inherit;
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  .card-list-row :global(.card-list-action--promote) {
+    color: var(--color-primary-text);
+    font-weight: 600;
+  }
+
+  .card-list-row :global(.card-list-action--danger) {
+    color: var(--color-danger-text);
+  }
+
+  .card-list-row :global(.card-list-action:hover) {
+    text-decoration: underline;
+  }
+
+  .card-list-row :global(a:focus-visible),
+  .card-list-row :global(button:focus-visible),
+  .card-list-row input:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary-text) 18%, transparent);
+    border-radius: var(--radius-sm);
+  }
+
+  @media (max-width: 900px) {
+    .card-list-row__track {
+      grid-template-columns: 1.25rem minmax(0, 1fr);
+      align-items: start;
+    }
+
+    .card-list-row__checkbox {
+      justify-content: start;
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .card-list-row__content {
+      grid-column: 2;
+    }
+
+    .card-list-row__groups,
+    .card-list-row__updated,
+    .card-list-row__actions {
+      grid-column: 2;
+      margin-inline-start: 0;
+    }
+
+    .card-list-row__actions {
+      justify-self: start;
+      gap: var(--space-2);
+      padding-inline-start: 0;
+      border-inline-start: 0;
+      opacity: 1;
+      pointer-events: auto;
+      flex-wrap: wrap;
+    }
+  }
+</style>

--- a/apps/web/src/lib/components/card-list/CardListStatusBadge.svelte
+++ b/apps/web/src/lib/components/card-list/CardListStatusBadge.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  export let label = '';
+  export let tone: 'draft' | 'active' | 'neutral' = 'neutral';
+</script>
+
+<span class={`card-list-status-badge card-list-status-badge--${tone}`}>{label}</span>
+
+<style>
+  .card-list-status-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.15rem 0.45rem;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-caption);
+    letter-spacing: 0.04em;
+  }
+
+  .card-list-status-badge--draft {
+    background: var(--color-warning-bg);
+    color: var(--color-warning-text);
+    border-color: var(--color-warning-border);
+  }
+
+  .card-list-status-badge--active {
+    background: var(--color-primary-subtle);
+    color: var(--color-primary-text);
+    border-color: color-mix(in srgb, var(--color-primary-text) 30%, transparent);
+  }
+
+  .card-list-status-badge--neutral {
+    background: var(--color-surface);
+    color: var(--color-text-secondary);
+    border-color: var(--color-border-subtle);
+  }
+</style>

--- a/apps/web/src/lib/components/card-list/CardListTagChip.svelte
+++ b/apps/web/src/lib/components/card-list/CardListTagChip.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  export let label = '';
+</script>
+
+<span class="card-list-tag-chip">{label}</span>
+
+<style>
+  .card-list-tag-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.15rem 0.45rem;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface-subtle);
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-caption);
+  }
+</style>

--- a/apps/web/src/lib/server/card-entry.ts
+++ b/apps/web/src/lib/server/card-entry.ts
@@ -3,6 +3,7 @@ import {
   createDraftCardFromNote,
   createGroup,
   createInboxNote,
+  deleteDraftCards,
   deleteInboxNote,
   deferInboxNote,
   getActiveUserLanguages,
@@ -10,10 +11,12 @@ import {
   getCardGroups,
   getCardGroupsForCards,
   getDb,
+  getDraftCardsForLanguage,
   getGroups,
   getInboxNote,
   getNoteWithDraftCards,
   listInboxNotes,
+  promoteDraftCards,
   removeCardFromGroup,
   signOffNote,
   updateCard,
@@ -102,6 +105,30 @@ export type CardEntryNoteShellData = {
   sourceLabel: string;
   draftCards: CardEntryNoteDraftCardData[];
   availableGroups: CardEntryGroupData[];
+};
+
+export type CardEntryDraftSourceNoteData = {
+  noteId: string;
+  content: string;
+  state: InboxNoteState;
+  createdAtIso: string | null;
+  linkedAtIso: string | null;
+};
+
+export type CardEntryDraftListItemData = {
+  cardId: string;
+  content: string;
+  meaning: string | null;
+  updatedAtIso: string | null;
+  updatedAtLabel: string;
+  groups: CardEntryGroupData[];
+  sourceNotes: CardEntryDraftSourceNoteData[];
+};
+
+export type CardEntryDraftsData = {
+  items: CardEntryDraftListItemData[];
+  availableGroups: CardEntryGroupData[];
+  draftCardCount: number;
 };
 
 export function getCardEntrySortCookieName(languageId: string): string {
@@ -314,6 +341,10 @@ async function loadDraftCardGroupsMap(
   cardIds: string[],
   database: DatabaseClient
 ) {
+  if (cardIds.length === 0) {
+    return new Map();
+  }
+
   return getCardGroupsForCards(userId, languageId, cardIds, database as never);
 }
 
@@ -327,8 +358,37 @@ async function mapWorkspaceDraftCards(
   const draftCardGroups = await loadDraftCardGroupsMap(userId, languageId, cardIds, database);
 
   return workspace.draftCards.map((draftCard) =>
-    mapDraftCard(draftCard, (draftCardGroups.get(draftCard.cardId) ?? []).map((group) => mapGroup(group)))
+    mapDraftCard(
+      draftCard,
+      (draftCardGroups.get(draftCard.cardId) ?? []).map((group: Group) => mapGroup(group))
+    )
   );
+}
+
+async function mapDraftCardsWithSources(
+  userId: string,
+  languageId: string,
+  draftCards: Awaited<ReturnType<typeof getDraftCardsForLanguage>>,
+  database: DatabaseClient
+): Promise<CardEntryDraftListItemData[]> {
+  const cardIds = draftCards.map((draftCard) => draftCard.cardId);
+  const draftCardGroups = await loadDraftCardGroupsMap(userId, languageId, cardIds, database);
+
+  return draftCards.map((draftCard) => ({
+    cardId: draftCard.cardId,
+    content: draftCard.content,
+    meaning: parseOptionalText(draftCard.meaning ?? ''),
+    updatedAtIso: draftCard.updatedAt?.toISOString() ?? null,
+    updatedAtLabel: draftCard.updatedAt ? formatCardEntryRelativeTime(draftCard.updatedAt) : 'Just now',
+    groups: (draftCardGroups.get(draftCard.cardId) ?? []).map((group: Group) => mapGroup(group)),
+    sourceNotes: draftCard.sourceNotes.map((sourceNote) => ({
+      noteId: sourceNote.noteId,
+      content: sourceNote.content,
+      state: sourceNote.state as InboxNoteState,
+      createdAtIso: sourceNote.createdAt?.toISOString() ?? null,
+      linkedAtIso: sourceNote.linkedAt?.toISOString() ?? null,
+    })),
+  }));
 }
 
 async function loadWorkspace(
@@ -543,6 +603,23 @@ export async function loadCardEntryNoteShellData(
   };
 }
 
+export async function loadCardEntryDraftsData(
+  userId: string,
+  languageId: string,
+  database: DatabaseClient
+): Promise<CardEntryDraftsData> {
+  const [draftCards, availableGroups] = await Promise.all([
+    getDraftCardsForLanguage(userId, languageId, database as never),
+    getGroups(userId, languageId, database as never),
+  ]);
+
+  return {
+    items: await mapDraftCardsWithSources(userId, languageId, draftCards, database),
+    availableGroups: availableGroups.map((group) => mapGroup(group)),
+    draftCardCount: draftCards.length,
+  };
+}
+
 export async function createCardEntryNoteForLanguage(
   userId: string,
   languageId: string,
@@ -604,6 +681,10 @@ export async function signOffCardEntryNoteForLanguage(
     if (error instanceof Error) {
       if (error.message.startsWith('Inbox note not found:')) {
         throw new CardEntryRequestError(404, 'Card Entry note not found.');
+      }
+
+      if (error.message.includes('requires at least one group before promotion')) {
+        throw new CardEntryRequestError(400, 'Every draft card needs at least one group before it can become active.');
       }
 
       if (error.message.includes('has no linked')) {
@@ -744,4 +825,58 @@ export async function removeCardEntryDraftCardForLanguage(
   }
 
   return loadCardEntryNoteShellData(userId, languageId, parsedNoteId, database);
+}
+
+function parseCardIds(cardIds: unknown): string[] {
+  if (!Array.isArray(cardIds)) {
+    throw new CardEntryRequestError(400, 'At least one draft card must be selected.');
+  }
+
+  const parsedCardIds = [...new Set(cardIds.map((cardId) => parseCardId(cardId)))];
+
+  if (parsedCardIds.length === 0) {
+    throw new CardEntryRequestError(400, 'At least one draft card must be selected.');
+  }
+
+  return parsedCardIds;
+}
+
+export async function promoteCardEntryDraftsForLanguage(
+  userId: string,
+  languageId: string,
+  cardIds: unknown,
+  database: DatabaseClient
+) {
+  try {
+    return await promoteDraftCards(userId, languageId, parseCardIds(cardIds), database as never);
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message.startsWith('Draft card not found:')) {
+        throw new CardEntryRequestError(404, 'One of the selected draft cards no longer exists.');
+      }
+
+      if (error.message.includes('requires at least one group before promotion')) {
+        throw new CardEntryRequestError(400, 'Every promoted draft needs at least one group before it can become active.');
+      }
+    }
+
+    throw error;
+  }
+}
+
+export async function deleteCardEntryDraftsForLanguage(
+  userId: string,
+  languageId: string,
+  cardIds: unknown,
+  database: DatabaseClient
+) {
+  try {
+    return await deleteDraftCards(userId, languageId, parseCardIds(cardIds), database as never);
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('Draft card not found:')) {
+      throw new CardEntryRequestError(404, 'One of the selected draft cards no longer exists.');
+    }
+
+    throw error;
+  }
 }

--- a/apps/web/src/routes/[lang]/card-entry/+page.svelte
+++ b/apps/web/src/routes/[lang]/card-entry/+page.svelte
@@ -92,14 +92,17 @@
       <p class="card-entry-header__copy">Capture rough notes quickly, then come back for a calmer pass through the backlog.</p>
     </div>
 
-    <a
-      class="card-entry-sort"
-      href={`/${$page.params.lang}/card-entry?sort=${nextSort}`}
-      aria-label={`Switch sort order. Currently ${sortLabel}.`}
-    >
-      {sortLabel}
-      <span aria-hidden="true">▾</span>
-    </a>
+    <div class="card-entry-header__actions cluster">
+      <a class="card-entry-link" href={`/${$page.params.lang}/card-entry/drafts`}>View drafts</a>
+      <a
+        class="card-entry-sort"
+        href={`/${$page.params.lang}/card-entry?sort=${nextSort}`}
+        aria-label={`Switch sort order. Currently ${sortLabel}.`}
+      >
+        {sortLabel}
+        <span aria-hidden="true">▾</span>
+      </a>
+    </div>
   </header>
 
   <form
@@ -219,6 +222,7 @@
 
   .card-entry-header,
   .card-entry-header__title,
+  .card-entry-header__actions,
   .card-entry-sort,
   .note-row__meta {
     align-items: center;
@@ -227,6 +231,10 @@
 
   .card-entry-header {
     justify-content: space-between;
+  }
+
+  .card-entry-header__actions {
+    justify-content: flex-end;
   }
 
   .card-entry-header__eyebrow {
@@ -257,6 +265,7 @@
   }
 
   .card-entry-count,
+  .card-entry-link,
   .card-entry-sort {
     border-radius: 999px;
     font-family: var(--font-ui);
@@ -274,8 +283,10 @@
     font-weight: 700;
   }
 
+  .card-entry-link,
   .card-entry-sort {
     display: inline-flex;
+    align-items: center;
     justify-content: center;
     min-block-size: 2.75rem;
     padding-inline: var(--space-4);
@@ -439,6 +450,7 @@
   }
 
   .card-entry-sort:focus-visible,
+  .card-entry-link:focus-visible,
   .quick-capture__input:focus-visible,
   .quick-capture__submit:focus-visible,
   .note-row:focus-visible,
@@ -488,6 +500,10 @@
     .card-entry-header {
       align-items: stretch;
       flex-direction: column;
+    }
+
+    .card-entry-header__actions {
+      justify-content: flex-start;
     }
 
     .quick-capture__controls {

--- a/apps/web/src/routes/[lang]/card-entry/drafts/+page.server.ts
+++ b/apps/web/src/routes/[lang]/card-entry/drafts/+page.server.ts
@@ -1,0 +1,37 @@
+import { redirect, type ServerLoad } from '@sveltejs/kit';
+import { getDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import { loadCardEntryDraftsData } from '$lib/server/card-entry.js';
+
+export const load: ServerLoad = async (event) => {
+  const { session } = await event.parent();
+  const languageCode = event.params.lang;
+
+  if (!languageCode) {
+    throw redirect(303, '/');
+  }
+
+  if (!session?.user?.id) {
+    throw redirect(303, '/');
+  }
+
+  const database = getDb(env.DATABASE_URL);
+
+  try {
+    return {
+      drafts: await loadCardEntryDraftsData(session.user.id, languageCode, database),
+      loadError: null,
+    };
+  } catch (loadError) {
+    console.error('Failed to load Card Entry drafts:', loadError);
+
+    return {
+      drafts: {
+        items: [],
+        availableGroups: [],
+        draftCardCount: 0,
+      },
+      loadError: 'The Drafts view could not be loaded right now.',
+    };
+  }
+};

--- a/apps/web/src/routes/[lang]/card-entry/drafts/+page.svelte
+++ b/apps/web/src/routes/[lang]/card-entry/drafts/+page.svelte
@@ -1,0 +1,582 @@
+<script lang="ts">
+  import { invalidateAll } from '$app/navigation';
+  import { page } from '$app/stores';
+  import { filterDraftCards, formatDraftGroupFilterLabel } from '$lib/card-entry/drafts.js';
+  import CardListBulkActionBar from '$lib/components/card-list/CardListBulkActionBar.svelte';
+  import CardListColumns from '$lib/components/card-list/CardListColumns.svelte';
+  import CardListFilterBar from '$lib/components/card-list/CardListFilterBar.svelte';
+  import CardListRow from '$lib/components/card-list/CardListRow.svelte';
+  import CardListStatusBadge from '$lib/components/card-list/CardListStatusBadge.svelte';
+  import CardListTagChip from '$lib/components/card-list/CardListTagChip.svelte';
+  import type { CardEntryDraftListItemData, CardEntryDraftsData } from '$lib/server/card-entry.js';
+
+  export let data: {
+    drafts: CardEntryDraftsData;
+    loadError: string | null;
+  };
+
+  type DraftAction = 'promote' | 'delete';
+  type ActionFeedback = {
+    kind: 'missing-groups' | 'error';
+    message: string;
+    cardIds: string[];
+  };
+
+  let searchQuery = '';
+  let selectedGroupIds: string[] = [];
+  let selectedCardIds: string[] = [];
+  let actionFeedback: ActionFeedback | null = null;
+  let isRefreshing = false;
+  let pendingAction: { action: DraftAction; cardIds: string[] } | null = null;
+
+  $: currentLang = $page.params.lang ?? '';
+  $: drafts = data.drafts;
+  $: filteredItems = filterDraftCards(drafts.items, searchQuery, selectedGroupIds);
+  $: selectedGroupNames = drafts.availableGroups
+    .filter((group: CardEntryDraftsData['availableGroups'][number]) => selectedGroupIds.includes(group.groupId))
+    .map((group: CardEntryDraftsData['availableGroups'][number]) => group.groupName);
+  $: groupFilterLabel = formatDraftGroupFilterLabel(selectedGroupNames);
+  $: isSelectMode = selectedCardIds.length > 0;
+  $: cardsMissingGroupsForPromotion = new Set(
+    actionFeedback?.kind === 'missing-groups' ? actionFeedback.cardIds : []
+  );
+
+  function getPrimarySourceNote(item: CardEntryDraftListItemData) {
+    return item.sourceNotes[0] ?? null;
+  }
+
+  function getSourcePreview(item: CardEntryDraftListItemData) {
+    const primarySourceNote = getPrimarySourceNote(item);
+
+    if (!primarySourceNote) {
+      return 'No source note linked';
+    }
+
+    if (item.sourceNotes.length === 1) {
+      return primarySourceNote.content;
+    }
+
+    return `${primarySourceNote.content} +${item.sourceNotes.length - 1} more`;
+  }
+
+  function getSelectedCardIdsForAction(cardIds?: string[]) {
+    if (cardIds && cardIds.length > 0) {
+      return cardIds;
+    }
+
+    return selectedCardIds;
+  }
+
+  function clearFilters() {
+    searchQuery = '';
+    selectedGroupIds = [];
+  }
+
+  function toggleSelection(cardId: string) {
+    if (selectedCardIds.includes(cardId)) {
+      selectedCardIds = selectedCardIds.filter((selectedCardId) => selectedCardId !== cardId);
+      return;
+    }
+
+    selectedCardIds = [...selectedCardIds, cardId];
+  }
+
+  function clearSelection() {
+    selectedCardIds = [];
+  }
+
+  function dismissActionFeedback() {
+    actionFeedback = null;
+  }
+
+  function isPending(cardId: string, action: DraftAction) {
+    return pendingAction?.action === action && pendingAction.cardIds.includes(cardId);
+  }
+
+  function buildActionFeedback(action: DraftAction, cardIds: string[], message: string): ActionFeedback {
+    const missingGroupCardIds =
+      action === 'promote'
+        ? cardIds.filter((cardId) => {
+            const card = drafts.items.find((item) => item.cardId === cardId);
+            return (card?.groups.length ?? 0) === 0;
+          })
+        : [];
+
+    if (missingGroupCardIds.length > 0 && message.toLocaleLowerCase().includes('group')) {
+      return {
+        kind: 'missing-groups',
+        message,
+        cardIds: missingGroupCardIds,
+      };
+    }
+
+    return {
+      kind: 'error',
+      message,
+      cardIds,
+    };
+  }
+
+  async function applyDraftAction(action: DraftAction, requestedCardIds?: string[]) {
+    const cardIds = getSelectedCardIdsForAction(requestedCardIds);
+
+    if (cardIds.length === 0 || !currentLang) {
+      return;
+    }
+
+    pendingAction = { action, cardIds };
+    actionFeedback = null;
+
+    try {
+      const response = await fetch(`/${currentLang}/card-entry/drafts/actions`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          action,
+          cardIds,
+        }),
+      });
+
+      const responseBody = (await response.json().catch(() => null)) as { message?: string } | null;
+
+      if (!response.ok) {
+        throw new Error(responseBody?.message ?? 'The draft action could not be completed right now.');
+      }
+
+      selectedCardIds = selectedCardIds.filter((cardId) => !cardIds.includes(cardId));
+      isRefreshing = true;
+      await invalidateAll();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'The draft action could not be completed right now.';
+      actionFeedback = buildActionFeedback(action, cardIds, message);
+    } finally {
+      isRefreshing = false;
+      pendingAction = null;
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>Drafts – StudyPuck</title>
+</svelte:head>
+
+<section class="drafts-page stack" style="--stack-space: var(--space-5)">
+  <header class="drafts-header cluster">
+    <div class="stack" style="--stack-space: var(--space-2)">
+      <p class="drafts-header__eyebrow">Card Entry</p>
+      <div class="drafts-header__title cluster">
+        <h1>Drafts</h1>
+        <span class="drafts-count" aria-label={`${drafts.draftCardCount} draft cards`}>
+          {drafts.draftCardCount}
+        </span>
+      </div>
+      <p class="drafts-header__copy">Review draft cards across the whole language, then promote or delete them in batches.</p>
+    </div>
+
+    <div class="drafts-header__links cluster">
+      <a class="drafts-header__link" href={`/${currentLang}/card-entry`}>← Back to inbox</a>
+    </div>
+  </header>
+
+  {#if data.loadError}
+    <section class="drafts-state drafts-state--error" role="alert">
+      <h2>Drafts are unavailable</h2>
+      <p>{data.loadError}</p>
+    </section>
+  {:else}
+    <CardListFilterBar
+      bind:searchQuery
+      bind:selectedGroupIds
+      availableGroups={drafts.availableGroups}
+      searchLabel="Search drafts"
+      searchPlaceholder="Search drafts..."
+      groupFilterLabel={groupFilterLabel}
+      clearGroupLabel="Clear group filters"
+    />
+
+    {#if isSelectMode}
+      <CardListBulkActionBar
+        selectedCount={selectedCardIds.length}
+        itemLabelSingular="draft"
+        itemLabelPlural="drafts"
+        primaryActionLabel="Promote selected"
+        primaryActionPendingLabel="Promoting..."
+        secondaryActionLabel="Delete"
+        secondaryActionPendingLabel="Deleting..."
+        disabled={pendingAction !== null}
+        pendingAction={pendingAction?.action === 'promote' && pendingAction.cardIds.length === selectedCardIds.length
+          ? 'primary'
+          : pendingAction?.action === 'delete' && pendingAction.cardIds.length === selectedCardIds.length
+            ? 'secondary'
+            : null}
+        on:primary={() => void applyDraftAction('promote')}
+        on:secondary={() => void applyDraftAction('delete')}
+        on:clear={clearSelection}
+      />
+    {/if}
+
+    {#if actionFeedback}
+      <section class="drafts-feedback drafts-feedback--error" role="status" aria-live="polite">
+        <div class="drafts-feedback__body stack" style="--stack-space: var(--space-1)">
+          <p class="drafts-feedback__title">
+            {actionFeedback.kind === 'missing-groups' ? 'Add a group before promoting' : 'Action failed'}
+          </p>
+          <p>{actionFeedback.message}</p>
+        </div>
+
+        <button type="button" class="drafts-feedback__dismiss" on:click={dismissActionFeedback}>Dismiss</button>
+      </section>
+    {/if}
+
+    {#if isRefreshing}
+      <section class="drafts-state" aria-live="polite">
+        <h2>Refreshing drafts…</h2>
+        <p>Updating the list and card-entry counts.</p>
+      </section>
+    {:else if drafts.items.length === 0}
+      <section class="drafts-state drafts-state--empty">
+        <div class="drafts-state__icon" aria-hidden="true">📝</div>
+        <h2>No draft cards yet</h2>
+        <p>Process a note in Card Entry to generate or create your first draft cards.</p>
+        <a class="drafts-state__cta" href={`/${currentLang}/card-entry`}>Go to Card Entry</a>
+      </section>
+    {:else if filteredItems.length === 0}
+      <section class="drafts-state drafts-state--empty">
+        <div class="drafts-state__icon" aria-hidden="true">🔎</div>
+        <h2>No drafts match your filters</h2>
+        <p>Try adjusting the search or clearing the active group filters.</p>
+        <button type="button" class="drafts-state__cta" on:click={clearFilters}>Clear filters</button>
+      </section>
+    {:else}
+      <section class="drafts-list stack" style="--stack-space: var(--space-3)">
+        <CardListColumns labels={['Content / Source', 'Groups', 'Updated']} />
+
+        {#each filteredItems as item (item.cardId)}
+          {@const primarySourceNote = getPrimarySourceNote(item)}
+          <CardListRow
+            selected={selectedCardIds.includes(item.cardId)}
+            checkboxLabel="Select draft card"
+            on:toggleSelection={() => toggleSelection(item.cardId)}
+          >
+              <a
+                slot="content"
+                class="draft-row__content-link stack"
+                style="--stack-space: var(--space-1)"
+                href={primarySourceNote ? `/${currentLang}/card-entry/notes/${primarySourceNote.noteId}` : '#'}
+              >
+                <div class="draft-row__heading cluster">
+                  <CardListStatusBadge label="Draft" tone="draft" />
+                  <h2>{item.content}</h2>
+                </div>
+
+                {#if item.meaning}
+                  <p class="draft-row__meaning">{item.meaning}</p>
+                {/if}
+
+                <p class="draft-row__source">Source: {getSourcePreview(item)}</p>
+              </a>
+
+              <div slot="groups" class="draft-row__groups">
+                {#if item.groups.length === 0}
+                  {#if cardsMissingGroupsForPromotion.has(item.cardId)}
+                    <span class="draft-row__groups-warning">Needs a group before promotion</span>
+                  {:else}
+                    <span class="draft-row__groups-empty">No groups yet</span>
+                  {/if}
+                {:else}
+                  {#each item.groups as group}
+                    <CardListTagChip label={group.groupName} />
+                  {/each}
+                {/if}
+              </div>
+
+              <span slot="updated" class="draft-row__updated-label">{item.updatedAtLabel}</span>
+
+              <div slot="actions">
+                <button
+                  type="button"
+                  class="card-list-action card-list-action--promote"
+                  disabled={pendingAction !== null}
+                  on:click|stopPropagation={() => void applyDraftAction('promote', [item.cardId])}
+                >
+                  {isPending(item.cardId, 'promote') ? 'Promoting…' : 'Promote'}
+                </button>
+                <a
+                  class="card-list-action"
+                  href={primarySourceNote ? `/${currentLang}/card-entry/notes/${primarySourceNote.noteId}` : '#'}
+                >
+                  Edit
+                </a>
+                <button
+                  type="button"
+                  class="card-list-action card-list-action--danger"
+                  disabled={pendingAction !== null}
+                  on:click|stopPropagation={() => void applyDraftAction('delete', [item.cardId])}
+                >
+                  {isPending(item.cardId, 'delete') ? 'Deleting…' : 'Delete'}
+                </button>
+              </div>
+          </CardListRow>
+        {/each}
+      </section>
+    {/if}
+  {/if}
+</section>
+
+<style>
+  .drafts-page {
+    padding: calc(var(--shell-header-height) + var(--space-5)) var(--space-4) calc(var(--space-7) + 4.5rem);
+  }
+
+  .drafts-header,
+  .drafts-header__title,
+  .drafts-header__links,
+  .draft-row__heading {
+    align-items: center;
+    gap: var(--space-3);
+  }
+
+  .drafts-header {
+    justify-content: space-between;
+  }
+
+  .drafts-header__eyebrow,
+  .drafts-header__link {
+    margin: 0;
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-caption);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .drafts-header__title h1,
+  .drafts-header__copy,
+  .drafts-state h2,
+  .drafts-state p,
+  .draft-row__heading h2,
+  .draft-row__meaning,
+  .draft-row__source {
+    margin: 0;
+  }
+
+  .drafts-header__title h1 {
+    font-size: var(--font-size-h2);
+  }
+
+  .drafts-header__copy {
+    max-inline-size: 44rem;
+    color: var(--color-text-secondary);
+  }
+
+  .drafts-count,
+  .drafts-state {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+  }
+
+  .drafts-count {
+    display: inline-flex;
+    min-inline-size: 2.25rem;
+    justify-content: center;
+    padding: 0.1rem 0.45rem;
+    border-radius: var(--radius-sm);
+    background: var(--color-primary-subtle);
+    color: var(--color-primary-text);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-caption);
+  }
+
+  .drafts-header__link {
+    display: inline-flex;
+    align-items: center;
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+    text-decoration: none;
+  }
+
+  .drafts-state__cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.55rem 0.9rem;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    cursor: pointer;
+    text-decoration: none;
+    color: var(--color-text-primary);
+    font-family: var(--font-ui);
+  }
+
+  .drafts-feedback {
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+    gap: var(--space-4);
+    padding: var(--space-3) var(--space-4);
+    border: 1px solid color-mix(in srgb, var(--color-error-border) 65%, var(--color-border));
+    border-radius: var(--radius-lg);
+    background: color-mix(in srgb, var(--color-error-bg) 18%, var(--color-surface));
+  }
+
+  .drafts-feedback__title,
+  .drafts-feedback__body p {
+    margin: 0;
+  }
+
+  .drafts-feedback__title {
+    color: var(--color-error-text);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+    font-weight: 600;
+    letter-spacing: 0.02em;
+  }
+
+  .drafts-feedback__dismiss {
+    padding: 0;
+    border: 0;
+    background: none;
+    color: var(--color-text-secondary);
+    font: inherit;
+    font-family: var(--font-ui);
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .drafts-state {
+    padding: var(--space-5);
+    text-align: center;
+    box-shadow: var(--shadow-sm);
+  }
+
+  .drafts-state--error {
+    background: color-mix(in srgb, var(--color-danger-text) 8%, var(--color-surface-raised));
+  }
+
+  .drafts-state__icon {
+    margin-block-end: var(--space-3);
+    font-size: 2rem;
+  }
+
+  .drafts-list {
+    overflow: clip;
+  }
+
+  .draft-row__content-link {
+    display: grid;
+    min-inline-size: 0;
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .draft-row__heading {
+    align-items: start;
+    gap: var(--space-2);
+  }
+
+  .draft-row__heading h2,
+  .draft-row__meaning,
+  .draft-row__source {
+    overflow-wrap: anywhere;
+  }
+
+  .draft-row__heading h2 {
+    display: -webkit-box;
+    overflow: hidden;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    font-size: var(--font-size-h4);
+    line-height: var(--leading-heading);
+  }
+
+  .draft-row__meaning,
+  .draft-row__source,
+  .draft-row__updated-label,
+  .draft-row__groups-empty {
+    color: var(--color-text-secondary);
+  }
+
+  .draft-row__meaning {
+    display: -webkit-box;
+    overflow: hidden;
+    line-clamp: 1;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+    color: var(--color-text-secondary);
+    line-height: 1.45;
+  }
+
+  .draft-row__source {
+    display: -webkit-box;
+    overflow: hidden;
+    line-clamp: 1;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+    color: var(--color-text-muted);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+    line-height: 1.4;
+  }
+
+  .draft-row__groups {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    padding-block-start: 0.15rem;
+  }
+
+  .draft-row__groups-empty,
+  .draft-row__updated-label {
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+  }
+
+  .draft-row__groups-warning {
+    color: var(--color-error-text);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+    line-height: 1.35;
+  }
+
+  .draft-row__updated-label {
+    padding-block-start: 0.15rem;
+    white-space: nowrap;
+  }
+
+  .drafts-header__link:focus-visible,
+  .drafts-feedback__dismiss:focus-visible,
+  .drafts-state__cta:focus-visible,
+  .draft-row__content-link:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary-text) 18%, transparent);
+    border-radius: var(--radius-sm);
+  }
+
+  @media (max-width: 900px) {
+    .draft-row__content-link {
+      inline-size: 100%;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .drafts-page {
+      padding-inline: var(--space-3);
+    }
+
+    .drafts-header,
+    .drafts-header {
+      align-items: start;
+      flex-direction: column;
+    }
+
+    .drafts-feedback {
+      flex-direction: column;
+      gap: var(--space-2);
+    }
+  }
+</style>

--- a/apps/web/src/routes/[lang]/card-entry/drafts/actions/+server.ts
+++ b/apps/web/src/routes/[lang]/card-entry/drafts/actions/+server.ts
@@ -1,0 +1,60 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { withTransactionDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import {
+  CardEntryRequestError,
+  deleteCardEntryDraftsForLanguage,
+  promoteCardEntryDraftsForLanguage,
+} from '$lib/server/card-entry.js';
+
+type DraftActionRequestBody = {
+  action?: 'promote' | 'delete';
+  cardIds?: string[];
+};
+
+export const POST: RequestHandler = async (event) => {
+  const session = await event.locals.auth();
+  const userId = session?.user?.id;
+  const languageId = event.params.lang;
+
+  if (!userId || !languageId) {
+    return json({ message: 'You must be signed in to update draft cards.' }, { status: 401 });
+  }
+
+  const databaseUrl = env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    return json({ message: 'The draft card service is not configured right now.' }, { status: 500 });
+  }
+
+  let body: DraftActionRequestBody;
+
+  try {
+    body = (await event.request.json()) as DraftActionRequestBody;
+  } catch {
+    return json({ message: 'The draft action payload must be valid JSON.' }, { status: 400 });
+  }
+
+  try {
+    const result = await withTransactionDb(databaseUrl, async (database) => {
+      if (body.action === 'promote') {
+        return promoteCardEntryDraftsForLanguage(userId, languageId, body.cardIds, database as never);
+      }
+
+      if (body.action === 'delete') {
+        return deleteCardEntryDraftsForLanguage(userId, languageId, body.cardIds, database as never);
+      }
+
+      throw new CardEntryRequestError(400, 'A valid draft action is required.');
+    });
+
+    return json(result);
+  } catch (requestError) {
+    if (requestError instanceof CardEntryRequestError) {
+      return json({ message: requestError.message }, { status: requestError.status });
+    }
+
+    console.error('Failed to apply Card Entry draft action:', requestError);
+    return json({ message: 'The draft action could not be completed right now.' }, { status: 500 });
+  }
+};

--- a/packages/database/src/card-entry.ts
+++ b/packages/database/src/card-entry.ts
@@ -2,6 +2,7 @@ import { and, asc, desc, eq, inArray, sql } from 'drizzle-orm';
 import type { PgDatabase } from 'drizzle-orm/pg-core';
 import {
   cardEntryDailyStats,
+  cardGroups,
   cards,
   inboxNotes,
   noteCardLinks,
@@ -49,6 +50,16 @@ export type DeleteInboxNoteResult = {
 export type SignOffNoteResult = {
   note: InboxNote;
   promotedCardIds: string[];
+};
+
+export type PromoteDraftCardsResult = {
+  promotedCardIds: string[];
+  processedNoteIds: string[];
+};
+
+export type DeleteDraftCardsResult = {
+  deletedCardIds: string[];
+  deletedNoteIds: string[];
 };
 
 type CardEntryStatsIncrements = Partial<{
@@ -197,6 +208,34 @@ async function getNoteCardIds(
     .orderBy(asc(noteCardLinks.createdAt));
 
   return links.map((link) => link.cardId);
+}
+
+async function getRemainingDraftNoteIds(
+  userId: string,
+  languageId: string,
+  noteIds: string[],
+  db: AnyDb
+): Promise<string[]> {
+  if (noteIds.length === 0) {
+    return [];
+  }
+
+  const rows = await db
+    .select({ noteId: noteCardLinks.noteId })
+    .from(noteCardLinks)
+    .innerJoin(cards, and(
+      eq(cards.userId, noteCardLinks.userId),
+      eq(cards.languageId, noteCardLinks.languageId),
+      eq(cards.cardId, noteCardLinks.cardId)
+    ))
+    .where(and(
+      eq(noteCardLinks.userId, userId),
+      eq(noteCardLinks.languageId, languageId),
+      inArray(noteCardLinks.noteId, noteIds),
+      eq(cards.status, 'draft')
+    ));
+
+  return [...new Set(rows.map((row) => row.noteId))];
 }
 
 export async function createInboxNote(
@@ -661,7 +700,86 @@ export async function signOffNote(
       throw new Error(`Cannot sign off note ${noteId} because it has no linked draft cards`);
     }
 
+    await promoteDraftCards(userId, languageId, draftCardIds, tx);
+    const noteResult = await tx
+      .select()
+      .from(inboxNotes)
+      .where(and(
+        eq(inboxNotes.userId, userId),
+        eq(inboxNotes.languageId, languageId),
+        eq(inboxNotes.noteId, noteId)
+      ))
+      .limit(1);
+
+    return {
+      note: noteResult[0]!,
+      promotedCardIds: draftCardIds,
+    };
+  });
+}
+
+export async function promoteDraftCards(
+  userId: string,
+  languageId: string,
+  cardIds: string[],
+  db?: AnyDb
+): Promise<PromoteDraftCardsResult> {
+  return withTransaction(db, async (tx) => {
+    const uniqueCardIds = [...new Set(cardIds)];
+
+    if (uniqueCardIds.length === 0) {
+      return {
+        promotedCardIds: [],
+        processedNoteIds: [],
+      };
+    }
+
+    const draftCards = await tx
+      .select({ cardId: cards.cardId })
+      .from(cards)
+      .where(and(
+        eq(cards.userId, userId),
+        eq(cards.languageId, languageId),
+        eq(cards.status, 'draft'),
+        inArray(cards.cardId, uniqueCardIds)
+      ));
+
+    const foundCardIds = draftCards.map((card) => card.cardId);
+
+    if (foundCardIds.length !== uniqueCardIds.length) {
+      const foundCardIdSet = new Set(foundCardIds);
+      const missingCardId = uniqueCardIds.find((cardId) => !foundCardIdSet.has(cardId));
+      throw new Error(`Draft card not found: ${missingCardId}`);
+    }
+
+    const groupedCardRows = await tx
+      .select({ cardId: cardGroups.cardId })
+      .from(cardGroups)
+      .where(and(
+        eq(cardGroups.userId, userId),
+        eq(cardGroups.languageId, languageId),
+        inArray(cardGroups.cardId, uniqueCardIds)
+      ));
+
+    const groupedCardIds = new Set(groupedCardRows.map((row) => row.cardId));
+    const cardIdMissingGroup = uniqueCardIds.find((cardId) => !groupedCardIds.has(cardId));
+
+    if (cardIdMissingGroup) {
+      throw new Error(`Draft card requires at least one group before promotion: ${cardIdMissingGroup}`);
+    }
+
+    const linkedNoteRows = await tx
+      .select({ noteId: noteCardLinks.noteId })
+      .from(noteCardLinks)
+      .where(and(
+        eq(noteCardLinks.userId, userId),
+        eq(noteCardLinks.languageId, languageId),
+        inArray(noteCardLinks.cardId, uniqueCardIds)
+      ));
+
+    const affectedNoteIds = [...new Set(linkedNoteRows.map((row) => row.noteId))];
     const now = new Date();
+
     await tx
       .update(cards)
       .set({
@@ -671,27 +789,132 @@ export async function signOffNote(
       .where(and(
         eq(cards.userId, userId),
         eq(cards.languageId, languageId),
-        inArray(cards.cardId, draftCardIds)
+        inArray(cards.cardId, uniqueCardIds)
       ));
 
-    const noteResult = await tx
-      .update(inboxNotes)
-      .set({ state: 'processed' })
-      .where(and(
-        eq(inboxNotes.userId, userId),
-        eq(inboxNotes.languageId, languageId),
-        eq(inboxNotes.noteId, noteId)
-      ))
-      .returning();
+    const remainingDraftNoteIds = await getRemainingDraftNoteIds(userId, languageId, affectedNoteIds, tx);
+    const remainingDraftNoteIdSet = new Set(remainingDraftNoteIds);
+    const processedNoteIds = affectedNoteIds.filter((noteId) => !remainingDraftNoteIdSet.has(noteId));
+
+    if (processedNoteIds.length > 0) {
+      await tx
+        .update(inboxNotes)
+        .set({ state: 'processed' })
+        .where(and(
+          eq(inboxNotes.userId, userId),
+          eq(inboxNotes.languageId, languageId),
+          inArray(inboxNotes.noteId, processedNoteIds)
+        ));
+    }
 
     await incrementCardEntryDailyStats(userId, languageId, {
-      notesProcessed: 1,
-      cardsPromotedToActive: draftCardIds.length,
+      notesProcessed: processedNoteIds.length,
+      cardsPromotedToActive: uniqueCardIds.length,
     }, tx);
 
     return {
-      note: noteResult[0]!,
-      promotedCardIds: draftCardIds,
+      promotedCardIds: uniqueCardIds,
+      processedNoteIds,
+    };
+  });
+}
+
+export async function deleteDraftCards(
+  userId: string,
+  languageId: string,
+  cardIds: string[],
+  db?: AnyDb
+): Promise<DeleteDraftCardsResult> {
+  return withTransaction(db, async (tx) => {
+    const uniqueCardIds = [...new Set(cardIds)];
+
+    if (uniqueCardIds.length === 0) {
+      return {
+        deletedCardIds: [],
+        deletedNoteIds: [],
+      };
+    }
+
+    const draftCards = await tx
+      .select({ cardId: cards.cardId })
+      .from(cards)
+      .where(and(
+        eq(cards.userId, userId),
+        eq(cards.languageId, languageId),
+        eq(cards.status, 'draft'),
+        inArray(cards.cardId, uniqueCardIds)
+      ));
+
+    const foundCardIds = draftCards.map((card) => card.cardId);
+
+    if (foundCardIds.length !== uniqueCardIds.length) {
+      const foundCardIdSet = new Set(foundCardIds);
+      const missingCardId = uniqueCardIds.find((cardId) => !foundCardIdSet.has(cardId));
+      throw new Error(`Draft card not found: ${missingCardId}`);
+    }
+
+    const linkedNoteRows = await tx
+      .select({ noteId: noteCardLinks.noteId })
+      .from(noteCardLinks)
+      .where(and(
+        eq(noteCardLinks.userId, userId),
+        eq(noteCardLinks.languageId, languageId),
+        inArray(noteCardLinks.cardId, uniqueCardIds)
+      ));
+
+    const affectedNoteIds = [...new Set(linkedNoteRows.map((row) => row.noteId))];
+    const now = new Date();
+
+    await tx
+      .update(cards)
+      .set({
+        status: 'deleted',
+        deletedAt: now,
+        updatedAt: now,
+      })
+      .where(and(
+        eq(cards.userId, userId),
+        eq(cards.languageId, languageId),
+        inArray(cards.cardId, uniqueCardIds)
+      ));
+
+    await tx
+      .delete(noteCardLinks)
+      .where(and(
+        eq(noteCardLinks.userId, userId),
+        eq(noteCardLinks.languageId, languageId),
+        inArray(noteCardLinks.cardId, uniqueCardIds)
+      ));
+
+    const remainingDraftNoteIds = await getRemainingDraftNoteIds(userId, languageId, affectedNoteIds, tx);
+    const remainingDraftNoteIdSet = new Set(remainingDraftNoteIds);
+    const deletedNoteIds = affectedNoteIds.filter((noteId) => !remainingDraftNoteIdSet.has(noteId));
+
+    if (deletedNoteIds.length > 0) {
+      await tx
+        .delete(noteCardLinks)
+        .where(and(
+          eq(noteCardLinks.userId, userId),
+          eq(noteCardLinks.languageId, languageId),
+          inArray(noteCardLinks.noteId, deletedNoteIds)
+        ));
+
+      await tx
+        .delete(inboxNotes)
+        .where(and(
+          eq(inboxNotes.userId, userId),
+          eq(inboxNotes.languageId, languageId),
+          inArray(inboxNotes.noteId, deletedNoteIds)
+        ));
+    }
+
+    await incrementCardEntryDailyStats(userId, languageId, {
+      notesDeleted: deletedNoteIds.length,
+    }, tx);
+
+    return {
+      deletedCardIds: uniqueCardIds,
+      deletedNoteIds,
     };
   });
 }

--- a/packages/database/src/tests/card-entry.test.ts
+++ b/packages/database/src/tests/card-entry.test.ts
@@ -17,6 +17,7 @@ import {
   transitionInboxNoteAiState,
   updateInboxNoteAiState,
 } from '../card-entry.js';
+import { addCardToGroup, createGroup } from '../cards.js';
 
 const TEST_USER = { userId: 'auth0|card-entry-user', email: 'card-entry@example.com' };
 const TEST_LANG = { userId: TEST_USER.userId, languageId: 'es', languageName: 'Spanish' };
@@ -146,6 +147,20 @@ describe('Card Entry database operations', () => {
       noteId: note.noteId,
       cardId: 'draft-signoff-card',
       content: 'para que + subjuntivo',
+    }, db);
+
+    const group = await createGroup({
+      userId: TEST_USER.userId,
+      languageId: TEST_LANG.languageId,
+      groupId: 'group-signoff',
+      groupName: 'Grammar',
+    }, db);
+
+    await addCardToGroup({
+      userId: TEST_USER.userId,
+      languageId: TEST_LANG.languageId,
+      cardId: draft.cardId,
+      groupId: group.groupId,
     }, db);
 
     const result = await signOffNote(TEST_USER.userId, TEST_LANG.languageId, note.noteId, db);


### PR DESCRIPTION
## Summary
- add the Card Entry Drafts view with search, group filtering, row actions, and bulk promote/delete
- enforce the rule that draft cards need at least one group before promotion, including localized validation feedback in the Drafts UI
- extract shared card-list primitives and tune the Drafts presentation to better match the current design system

## Validation
- pnpm --filter web lint
- pnpm --filter web test
- pnpm --filter web build
- pnpm turbo test lint build --filter=web *(hit an unrelated local timeout in src/lib/components/CommandBar.test.ts during the test phase on this machine)*