### PR TITLE
Add Card Entry semantic assistance

### DIFF
--- a/apps/web/src/lib/card-entry/workspace.test.ts
+++ b/apps/web/src/lib/card-entry/workspace.test.ts
@@ -25,10 +25,12 @@ function createNoteFixture(): CardEntryNoteShellData {
         llmInstructions: null,
         linkedAtIso: null,
         groups: [{ groupId: 'group-a', groupName: 'Grammar' }],
+        groupSuggestions: [],
         duplicateWarnings: [
           {
             warningId: 'warning-1',
             title: 'Possible duplicate',
+            similarCardId: 'active-1',
             similarCardLabel: 'ocurrírsele a alguien',
             dismissed: false,
           },
@@ -43,10 +45,12 @@ function createNoteFixture(): CardEntryNoteShellData {
         llmInstructions: null,
         linkedAtIso: null,
         groups: [],
+        groupSuggestions: [],
         duplicateWarnings: [
           {
             warningId: 'warning-2',
             title: 'Possible duplicate',
+            similarCardId: 'active-2',
             similarCardLabel: 'tiempo transcurrido',
             dismissed: true,
           },

--- a/apps/web/src/lib/components/card-entry/DraftCardEditor.svelte
+++ b/apps/web/src/lib/components/card-entry/DraftCardEditor.svelte
@@ -14,6 +14,9 @@
       card: CardEntryNoteDraftCardData;
       availableGroups: CardEntryGroupData[];
     };
+    noteUpdated: {
+      note: CardEntryNoteShellData;
+    };
     removed: {
       note: CardEntryNoteShellData;
     };
@@ -285,6 +288,47 @@
     }
   }
 
+  async function dismissDuplicateWarning(warningId: string) {
+    if (disabled) {
+      return;
+    }
+
+    saveState = 'saving';
+    saveError = null;
+
+    try {
+      const response = await fetch(
+        `/${lang}/card-entry/notes/${noteId}/draft-cards/${card.cardId}/duplicate-warnings`,
+        {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({ warningId }),
+        }
+      );
+      const data = (await response.json().catch(() => null)) as
+        | (CardEntryNoteShellData & {
+            message?: string;
+          })
+        | null;
+
+      if (!response.ok || !data?.noteId) {
+        throw new Error(data?.message ?? 'The duplicate warning could not be updated right now.');
+      }
+
+      dispatch('noteUpdated', {
+        note: data,
+      });
+      saveState = 'saved';
+      scheduleSavedIndicatorReset();
+    } catch (error) {
+      saveState = 'error';
+      saveError =
+        error instanceof Error ? error.message : 'The duplicate warning could not be updated right now.';
+    }
+  }
+
   onDestroy(() => {
     clearSavedIndicatorTimer();
   });
@@ -414,6 +458,24 @@
         </div>
       </div>
     {/if}
+
+    {#if draft.groupSuggestions.length > 0}
+      <div class="stack" style="--stack-space: var(--space-2)">
+        <p class="draft-card__suggestions-label">AI suggests</p>
+        <div class="draft-card__suggestions cluster">
+          {#each draft.groupSuggestions as suggestion}
+            <button
+              type="button"
+              class="draft-card__suggestion"
+              disabled={disabled}
+              on:click={() => void toggleGroup(suggestion)}
+            >
+              {suggestion.groupName}
+            </button>
+          {/each}
+        </div>
+      </div>
+    {/if}
   </div>
 
   <div class="draft-card__field stack" style="--stack-space: var(--space-2)">
@@ -513,12 +575,22 @@
     </label>
   </details>
 
-  {#if draft.duplicateWarnings.length > 0}
+  {#if draft.duplicateWarnings.some((warning) => !warning.dismissed)}
     <div class="stack" style="--stack-space: var(--space-2)">
-      {#each draft.duplicateWarnings as warning}
+      {#each draft.duplicateWarnings.filter((warning) => !warning.dismissed) as warning}
         <section class="draft-card__warning" role="alert">
-          <p class="draft-card__warning-title">Possible duplicate: {warning.title}</p>
+          <p class="draft-card__warning-title">{warning.title}</p>
           <p class="draft-card__warning-copy">Similar to: {warning.similarCardLabel}</p>
+          <div class="draft-card__warning-actions cluster">
+            <button
+              type="button"
+              class="draft-card__warning-dismiss"
+              disabled={disabled}
+              on:click={() => void dismissDuplicateWarning(warning.warningId)}
+            >
+              Dismiss
+            </button>
+          </div>
         </section>
       {/each}
     </div>
@@ -565,6 +637,7 @@
   .draft-card__error,
   .draft-card__warning-title,
   .draft-card__warning-copy,
+  .draft-card__suggestions-label,
   .draft-card__empty-inline {
     margin: 0;
   }
@@ -663,7 +736,7 @@
     gap: var(--space-2);
     align-items: center;
     border: 1px solid color-mix(in srgb, var(--color-primary) 35%, var(--color-border));
-    border-radius: var(--radius-pill, 999px);
+    border-radius: var(--radius-md);
     background: var(--color-primary-subtle);
     color: var(--color-primary-text);
     font-family: var(--font-ui);
@@ -674,6 +747,27 @@
   .draft-card__group-option:hover:not(:disabled) {
     border-color: color-mix(in srgb, var(--color-primary) 35%, var(--color-border));
     background: var(--color-primary-subtle);
+  }
+
+  .draft-card__suggestions-label {
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+  }
+
+  .draft-card__suggestions {
+    gap: var(--space-2);
+  }
+
+  .draft-card__suggestion,
+  .draft-card__warning-dismiss {
+    border: 1px solid color-mix(in srgb, var(--color-primary) 25%, var(--color-border));
+    border-radius: var(--radius-md);
+    background: var(--color-surface-subtle);
+    color: var(--color-text-primary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+    padding: var(--space-2) var(--space-3);
   }
 
   .draft-card__list-row {
@@ -738,6 +832,11 @@
     font-size: var(--font-size-small);
   }
 
+  .draft-card__warning-actions {
+    justify-content: flex-end;
+    margin-top: var(--space-2);
+  }
+
   .draft-card__footer {
     display: flex;
     justify-content: end;
@@ -756,6 +855,8 @@
   .draft-card__list-button:focus-visible,
   .draft-card__create-group:focus-visible,
   .draft-card__group-chip:focus-visible,
+  .draft-card__suggestion:focus-visible,
+  .draft-card__warning-dismiss:focus-visible,
   .draft-card__list-remove:focus-visible,
   .draft-card__remove:focus-visible {
     outline: 2px solid var(--color-primary);

--- a/apps/web/src/lib/server/ai-service.test.ts
+++ b/apps/web/src/lib/server/ai-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { AiServiceConfigurationError, createAiService } from './ai-service.js';
 
@@ -16,6 +16,10 @@ const silentHooks = {
 };
 
 describe('createAiService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('parses structured JSON responses from the configured primary provider', async () => {
     const geminiGenerator = vi.fn(async () => '```json\n{"draftCards":[{"content":"hola"}]}\n```');
     const service = createAiService({
@@ -102,5 +106,71 @@ describe('createAiService', () => {
       userPrompt: 'user',
       responseSchema,
     })).rejects.toBeInstanceOf(AiServiceConfigurationError);
+  });
+
+  it('generates embeddings from the configured primary provider', async () => {
+    const geminiEmbedding = vi.fn(async () => [0.1, 0.2, 0.3]);
+    const service = createAiService({
+      privateEnv: {
+        GEMINI_API_KEY: 'test-gemini-key',
+      },
+      hooks: silentHooks,
+      embeddingGenerators: {
+        gemini: geminiEmbedding,
+      },
+    });
+
+    const response = await service.generateEmbedding({
+      metadata: {
+        feature: 'card-entry',
+        operation: 'semantic-embedding',
+        userId: 'user-1',
+        languageId: 'es',
+        noteId: 'note-1',
+      },
+      input: 'hola mundo',
+    });
+
+    expect(response).toEqual({
+      embedding: [0.1, 0.2, 0.3],
+      model: 'gemini-embedding-001',
+    });
+    expect(geminiEmbedding).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the secondary provider when the primary embedding call fails', async () => {
+    const geminiEmbedding = vi.fn(async () => {
+      throw new Error('gemini unavailable');
+    });
+    const openAiEmbedding = vi.fn(async () => [0.4, 0.5, 0.6]);
+    const service = createAiService({
+      privateEnv: {
+        GEMINI_API_KEY: 'test-gemini-key',
+        OPENAI_API_KEY: 'test-openai-key',
+      },
+      hooks: silentHooks,
+      embeddingGenerators: {
+        gemini: geminiEmbedding,
+        openai: openAiEmbedding,
+      },
+    });
+
+    const response = await service.generateEmbedding({
+      metadata: {
+        feature: 'card-entry',
+        operation: 'semantic-embedding',
+        userId: 'user-1',
+        languageId: 'es',
+        noteId: 'note-1',
+      },
+      input: 'fallback embedding',
+    });
+
+    expect(response).toEqual({
+      embedding: [0.4, 0.5, 0.6],
+      model: 'text-embedding-3-small',
+    });
+    expect(geminiEmbedding).toHaveBeenCalledTimes(1);
+    expect(openAiEmbedding).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/lib/server/ai-service.ts
+++ b/apps/web/src/lib/server/ai-service.ts
@@ -4,7 +4,7 @@ export type AiProviderName = 'gemini' | 'openai';
 
 export type AiRequestMetadata = {
   feature: 'card-entry';
-  operation: 'preprocess-note';
+  operation: 'preprocess-note' | 'semantic-embedding';
   userId: string;
   languageId: string;
   noteId: string;
@@ -31,7 +31,8 @@ export type AiRequestHooks = {
 
 type AiProviderConfig = {
   name: AiProviderName;
-  model: string;
+  textModel: string;
+  embeddingModel: string;
   apiKey: string;
 };
 
@@ -49,7 +50,24 @@ type ProviderRequest = {
   userPrompt: string;
 };
 
+type EmbeddingProviderRequest = {
+  config: AiProviderConfig;
+  input: string;
+};
+
 type ProviderGenerateJson = (request: ProviderRequest) => Promise<string>;
+type ProviderGenerateEmbedding = (request: EmbeddingProviderRequest) => Promise<number[]>;
+
+type EmbeddingRequest = {
+  metadata: AiRequestMetadata;
+  input: string;
+  cacheKey?: string;
+};
+
+export type AiEmbeddingResult = {
+  embedding: number[];
+  model: string;
+};
 
 const DEFAULT_HOOKS: AiRequestHooks = {
   enforceQuota: () => undefined,
@@ -95,17 +113,19 @@ function getConfiguredProviders(privateEnv: Record<string, string | undefined>):
 
   const providerConfigs: Record<AiProviderName, AiProviderConfig | null> = {
     gemini: privateEnv.GEMINI_API_KEY
-      ? {
-          name: 'gemini',
+        ? {
+            name: 'gemini',
           apiKey: privateEnv.GEMINI_API_KEY,
-          model: privateEnv.GEMINI_TEXT_MODEL || 'gemini-2.5-flash',
+          textModel: privateEnv.GEMINI_TEXT_MODEL || 'gemini-2.5-flash',
+          embeddingModel: 'gemini-embedding-001',
         }
       : null,
     openai: privateEnv.OPENAI_API_KEY
       ? {
           name: 'openai',
           apiKey: privateEnv.OPENAI_API_KEY,
-          model: privateEnv.OPENAI_TEXT_MODEL || 'gpt-4o-mini',
+          textModel: privateEnv.OPENAI_TEXT_MODEL || 'gpt-4o-mini',
+          embeddingModel: 'text-embedding-3-small',
         }
       : null,
   };
@@ -145,7 +165,7 @@ async function parseStructuredResponse<T>(rawText: string, responseSchema: z.Zod
 
 async function callGemini(request: ProviderRequest): Promise<string> {
   const response = await fetch(
-    `https://generativelanguage.googleapis.com/v1beta/models/${request.config.model}:generateContent?key=${request.config.apiKey}`,
+    `https://generativelanguage.googleapis.com/v1beta/models/${request.config.textModel}:generateContent?key=${request.config.apiKey}`,
     {
       method: 'POST',
       headers: {
@@ -188,6 +208,42 @@ async function callGemini(request: ProviderRequest): Promise<string> {
   return rawText;
 }
 
+async function callGeminiEmbedding(request: EmbeddingProviderRequest): Promise<number[]> {
+  const response = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${request.config.embeddingModel}:embedContent?key=${request.config.apiKey}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: `models/${request.config.embeddingModel}`,
+        content: {
+          parts: [{ text: request.input }],
+        },
+        taskType: 'SEMANTIC_SIMILARITY',
+        outputDimensionality: 768,
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(
+      `Gemini embedding request failed with status ${response.status}${errorText ? `: ${errorText}` : ''}`
+    );
+  }
+
+  const body = await response.json();
+  const embedding = body.embedding?.values;
+
+  if (!Array.isArray(embedding) || embedding.length === 0) {
+    throw new Error('Gemini returned an empty embedding.');
+  }
+
+  return embedding;
+}
+
 async function callOpenAi(request: ProviderRequest): Promise<string> {
   const response = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
@@ -196,7 +252,7 @@ async function callOpenAi(request: ProviderRequest): Promise<string> {
       Authorization: `Bearer ${request.config.apiKey}`,
     },
     body: JSON.stringify({
-      model: request.config.model,
+      model: request.config.textModel,
       response_format: {
         type: 'json_object',
       },
@@ -227,15 +283,52 @@ async function callOpenAi(request: ProviderRequest): Promise<string> {
   return rawText;
 }
 
+async function callOpenAiEmbedding(request: EmbeddingProviderRequest): Promise<number[]> {
+  const response = await fetch('https://api.openai.com/v1/embeddings', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${request.config.apiKey}`,
+    },
+    body: JSON.stringify({
+      model: request.config.embeddingModel,
+      input: request.input,
+      dimensions: 768,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(
+      `OpenAI embedding request failed with status ${response.status}${errorText ? `: ${errorText}` : ''}`
+    );
+  }
+
+  const body = await response.json();
+  const embedding = body.data?.[0]?.embedding;
+
+  if (!Array.isArray(embedding) || embedding.length === 0) {
+    throw new Error('OpenAI returned an empty embedding.');
+  }
+
+  return embedding;
+}
+
 const DEFAULT_PROVIDER_GENERATORS: Record<AiProviderName, ProviderGenerateJson> = {
   gemini: callGemini,
   openai: callOpenAi,
+};
+
+const DEFAULT_EMBEDDING_GENERATORS: Record<AiProviderName, ProviderGenerateEmbedding> = {
+  gemini: callGeminiEmbedding,
+  openai: callOpenAiEmbedding,
 };
 
 export function createAiService(options: {
   privateEnv: Record<string, string | undefined>;
   hooks?: Partial<AiRequestHooks>;
   providerGenerators?: Partial<Record<AiProviderName, ProviderGenerateJson>>;
+  embeddingGenerators?: Partial<Record<AiProviderName, ProviderGenerateEmbedding>>;
 }) {
   const providers = getConfiguredProviders(options.privateEnv);
   const hooks = {
@@ -245,6 +338,10 @@ export function createAiService(options: {
   const providerGenerators = {
     ...DEFAULT_PROVIDER_GENERATORS,
     ...options.providerGenerators,
+  };
+  const embeddingGenerators = {
+    ...DEFAULT_EMBEDDING_GENERATORS,
+    ...options.embeddingGenerators,
   };
 
   return {
@@ -272,7 +369,7 @@ export function createAiService(options: {
           await hooks.onRequestStart({
             provider: provider.name,
             metadata: request.metadata,
-            model: provider.model,
+            model: provider.textModel,
           });
 
           const rawText = await providerGenerators[provider.name]({
@@ -285,7 +382,7 @@ export function createAiService(options: {
           await hooks.onRequestSuccess({
             provider: provider.name,
             metadata: request.metadata,
-            model: provider.model,
+            model: provider.textModel,
             rawTextLength: rawText.length,
           });
 
@@ -299,7 +396,7 @@ export function createAiService(options: {
           await hooks.onRequestFailure({
             provider: provider.name,
             metadata: request.metadata,
-            model: provider.model,
+            model: provider.textModel,
             error,
           });
         }
@@ -308,6 +405,72 @@ export function createAiService(options: {
       throw new AiServiceRequestError(
         providers[0]!.name,
         'All configured AI providers failed to return a valid response.',
+        lastError
+      );
+    },
+
+    async generateEmbedding(request: EmbeddingRequest): Promise<AiEmbeddingResult> {
+      if (providers.length === 0) {
+        throw new AiServiceConfigurationError(
+          'No AI embedding provider is configured. Set GEMINI_API_KEY or OPENAI_API_KEY.'
+        );
+      }
+
+      await hooks.enforceQuota(request.metadata);
+
+      if (request.cacheKey) {
+        const cached = await hooks.readCache<AiEmbeddingResult>(request.cacheKey);
+
+        if (cached) {
+          return cached;
+        }
+      }
+
+      let lastError: unknown;
+
+      for (const provider of providers) {
+        try {
+          await hooks.onRequestStart({
+            provider: provider.name,
+            metadata: request.metadata,
+            model: provider.embeddingModel,
+          });
+
+          const embedding = await embeddingGenerators[provider.name]({
+            config: provider,
+            input: request.input,
+          });
+          const result: AiEmbeddingResult = {
+            embedding,
+            model: provider.embeddingModel,
+          };
+
+          await hooks.onRequestSuccess({
+            provider: provider.name,
+            metadata: request.metadata,
+            model: provider.embeddingModel,
+            rawTextLength: request.input.length,
+          });
+
+          if (request.cacheKey) {
+            await hooks.writeCache(request.cacheKey, result);
+          }
+
+          return result;
+        } catch (error) {
+          lastError = error;
+          await hooks.onRequestFailure({
+            provider: provider.name,
+            metadata: request.metadata,
+            model: provider.embeddingModel,
+            error,
+          });
+        }
+      }
+
+      throw new AiServiceRequestError(
+        providers[0]!.name,
+        'All configured AI providers failed to return a valid embedding.',
         lastError
       );
     },

--- a/apps/web/src/lib/server/card-entry-semantic.test.ts
+++ b/apps/web/src/lib/server/card-entry-semantic.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { rankGroupSuggestionsFromSimilarCards } from './card-entry-semantic.js';
+
+describe('rankGroupSuggestionsFromSimilarCards', () => {
+  it('ranks groups from the strongest matching active-card evidence and skips selected groups', () => {
+    const similarCards = [
+      { cardId: 'card-verb-1', similarity: 0.91 },
+      { cardId: 'card-verb-2', similarity: 0.87 },
+      { cardId: 'card-adjective-1', similarity: 0.73 },
+    ];
+    const groupsByCardId = new Map([
+      [
+        'card-verb-1',
+        [
+          { groupId: 'group-verbs', groupName: 'Common verbs' },
+          { groupId: 'group-hsk', groupName: 'HSK 3' },
+        ],
+      ],
+      [
+        'card-verb-2',
+        [
+          { groupId: 'group-verbs', groupName: 'Common verbs' },
+          { groupId: 'group-emotion', groupName: 'Emotion words' },
+        ],
+      ],
+      [
+        'card-adjective-1',
+        [{ groupId: 'group-adjectives', groupName: 'Common adjectives' }],
+      ],
+    ]);
+
+    const ranked = rankGroupSuggestionsFromSimilarCards(
+      similarCards,
+      groupsByCardId,
+      new Set(['group-hsk']),
+      5
+    );
+
+    expect(ranked).toEqual([
+      {
+        groupId: 'group-verbs',
+        groupName: 'Common verbs',
+        similarityScore: 0.91,
+      },
+      {
+        groupId: 'group-emotion',
+        groupName: 'Emotion words',
+        similarityScore: 0.87,
+      },
+    ]);
+  });
+});

--- a/apps/web/src/lib/server/card-entry-semantic.ts
+++ b/apps/web/src/lib/server/card-entry-semantic.ts
@@ -1,0 +1,546 @@
+import {
+  cards,
+  findSimilarCards,
+  getCardsByStatus,
+  getCardGroupsForCards,
+  getDb,
+  getNoteWithDraftCards,
+  type Card,
+} from '@studypuck/database';
+import { and, eq } from 'drizzle-orm';
+import { createAiService } from '$lib/server/ai-service.js';
+import {
+  CardEntryRequestError,
+  loadCardEntryNoteShellData,
+  type CardEntryDuplicateWarningData,
+  type CardEntryGroupData,
+  type CardEntryGroupSuggestionData,
+  type CardEntryNoteDraftCardData,
+  type CardEntryNoteShellData,
+} from './card-entry.js';
+
+type DatabaseClient = ReturnType<typeof getDb>;
+
+type CardEntryMetadata = {
+  semanticFingerprint?: string;
+  dismissedDuplicateWarningIds?: string[];
+};
+
+type SimilarCardForGroupSuggestion = {
+  cardId: string;
+  similarity: number;
+};
+
+type GroupForSuggestionRanking = {
+  groupId: string;
+  groupName: string;
+};
+
+const GROUP_SUGGESTION_LIMIT = 5;
+const GROUP_SUGGESTION_CARD_LIMIT = 12;
+const GROUP_SUGGESTION_CARD_THRESHOLD = 0.72;
+const GROUP_SUGGESTION_RELATIVE_MARGIN = 0.08;
+const DUPLICATE_WARNING_LIMIT = 3;
+const DUPLICATE_WARNING_THRESHOLD = 0.82;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getCardEntryMetadata(value: unknown): CardEntryMetadata {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  const cardEntry = value.cardEntry;
+
+  if (!isRecord(cardEntry)) {
+    return {};
+  }
+
+  return {
+    semanticFingerprint:
+      typeof cardEntry.semanticFingerprint === 'string' ? cardEntry.semanticFingerprint : undefined,
+    dismissedDuplicateWarningIds: Array.isArray(cardEntry.dismissedDuplicateWarningIds)
+      ? cardEntry.dismissedDuplicateWarningIds.filter(
+          (warningId): warningId is string => typeof warningId === 'string' && warningId.length > 0
+        )
+      : [],
+  };
+}
+
+function mergeCardEntryMetadata(
+  existing: unknown,
+  patch: Partial<CardEntryMetadata>
+): Record<string, unknown> {
+  const base = isRecord(existing) ? { ...existing } : {};
+  const currentCardEntry = getCardEntryMetadata(existing);
+
+  return {
+    ...base,
+    cardEntry: {
+      ...currentCardEntry,
+      ...patch,
+    },
+  };
+}
+
+function hashString(input: string): string {
+  let hash = 2166136261;
+
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+function normalizeStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0);
+}
+
+function buildCardSemanticText(card: Pick<Card, 'content' | 'meaning' | 'examples' | 'mnemonics' | 'llmInstructions'>) {
+  return [
+    card.content,
+    card.meaning ?? '',
+    ...normalizeStringList(card.examples),
+    ...normalizeStringList(card.mnemonics),
+    card.llmInstructions ?? '',
+  ]
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .join('\n');
+}
+
+function buildSemanticFingerprint(input: string) {
+  return hashString(input.trim());
+}
+
+function formatSimilarCardLabel(card: Pick<Card, 'content' | 'meaning'>) {
+  const trimmedContent = card.content.trim();
+  const trimmedMeaning = card.meaning?.trim();
+
+  if (trimmedMeaning) {
+    return `${trimmedContent} (${trimmedMeaning})`;
+  }
+
+  return trimmedContent;
+}
+
+function createDuplicateWarningId(input: {
+  draftFingerprint: string;
+  similarCardId: string;
+  similarCardUpdatedAt: Date | null;
+}) {
+  return `duplicate-${hashString(
+    `${input.draftFingerprint}:${input.similarCardId}:${input.similarCardUpdatedAt?.toISOString() ?? 'none'}`
+  )}`;
+}
+
+async function ensureCardEmbedding(
+  input: {
+    userId: string;
+    languageId: string;
+    noteId: string;
+    card: Card;
+    privateEnv: Record<string, string | undefined>;
+    database: DatabaseClient;
+  }
+): Promise<Card> {
+  const semanticInput = buildCardSemanticText(input.card);
+  const fingerprint = buildSemanticFingerprint(semanticInput);
+  const metadata = getCardEntryMetadata(input.card.metadata);
+
+  if (!semanticInput) {
+    if (!input.card.embedding && metadata.semanticFingerprint === fingerprint) {
+      return input.card;
+    }
+
+    await input.database
+      .update(cards)
+      .set({
+        embedding: null,
+        embeddingModel: null,
+        embeddingGeneratedAt: null,
+        metadata: mergeCardEntryMetadata(input.card.metadata, {
+          semanticFingerprint: fingerprint,
+        }),
+      })
+      .where(
+        and(
+          eq(cards.userId, input.card.userId),
+          eq(cards.languageId, input.card.languageId),
+          eq(cards.cardId, input.card.cardId)
+        )
+      );
+
+    return {
+      ...input.card,
+      embedding: null,
+      embeddingModel: null,
+      embeddingGeneratedAt: null,
+      metadata: mergeCardEntryMetadata(input.card.metadata, {
+        semanticFingerprint: fingerprint,
+      }),
+    };
+  }
+
+  if (input.card.embedding && metadata.semanticFingerprint === fingerprint) {
+    return input.card;
+  }
+
+  const aiService = createAiService({
+    privateEnv: input.privateEnv,
+  });
+  const result = await aiService.generateEmbedding({
+    metadata: {
+      feature: 'card-entry',
+      operation: 'semantic-embedding',
+      userId: input.userId,
+      languageId: input.languageId,
+      noteId: input.noteId,
+    },
+    input: semanticInput,
+    cacheKey: `card-entry:${input.userId}:${input.languageId}:${input.card.cardId}:embedding:${fingerprint}`,
+  });
+  const nextMetadata = mergeCardEntryMetadata(input.card.metadata, {
+    semanticFingerprint: fingerprint,
+  });
+  const generatedAt = new Date();
+
+  await input.database
+    .update(cards)
+    .set({
+      embedding: result.embedding,
+      embeddingModel: result.model,
+      embeddingGeneratedAt: generatedAt,
+      metadata: nextMetadata,
+    })
+    .where(
+      and(
+        eq(cards.userId, input.card.userId),
+        eq(cards.languageId, input.card.languageId),
+        eq(cards.cardId, input.card.cardId)
+      )
+    );
+
+  return {
+    ...input.card,
+    embedding: result.embedding,
+    embeddingModel: result.model,
+    embeddingGeneratedAt: generatedAt,
+    metadata: nextMetadata,
+  };
+}
+
+async function ensureSemanticCandidates(
+  input: {
+    userId: string;
+    languageId: string;
+    noteId: string;
+    draftCards: Card[];
+    privateEnv: Record<string, string | undefined>;
+    database: DatabaseClient;
+  }
+) {
+  const activeCards = await getCardsByStatus(input.userId, input.languageId, 'active', input.database as never);
+
+  const ensuredDraftCards: Card[] = [];
+
+  for (const draftCard of input.draftCards) {
+    ensuredDraftCards.push(
+      await ensureCardEmbedding({
+        ...input,
+        card: draftCard,
+      })
+    );
+  }
+
+  const ensuredActiveCards: Card[] = [];
+
+  for (const activeCard of activeCards) {
+    ensuredActiveCards.push(
+      await ensureCardEmbedding({
+        ...input,
+        card: activeCard,
+      })
+    );
+  }
+
+  return {
+    draftCards: ensuredDraftCards,
+    activeCards: ensuredActiveCards,
+  };
+}
+
+async function buildGroupSuggestions(
+  input: {
+    userId: string;
+    languageId: string;
+    draftCard: Card;
+    selectedGroups: CardEntryGroupData[];
+    database: DatabaseClient;
+  }
+): Promise<CardEntryGroupSuggestionData[]> {
+  if (!input.draftCard.embedding) {
+    return [];
+  }
+
+  const selectedGroupIds = new Set(input.selectedGroups.map((group) => group.groupId));
+  const similarCards = await findSimilarCards(
+    input.userId,
+    input.languageId,
+    input.draftCard.embedding,
+    GROUP_SUGGESTION_CARD_LIMIT,
+    GROUP_SUGGESTION_CARD_THRESHOLD,
+    input.database as never
+  );
+
+  if (similarCards.length === 0) {
+    return [];
+  }
+
+  const groupsByCardId = await getCardGroupsForCards(
+    input.userId,
+    input.languageId,
+    similarCards.map((card) => card.cardId),
+    input.database as never
+  );
+
+  return rankGroupSuggestionsFromSimilarCards(
+    similarCards,
+    groupsByCardId,
+    selectedGroupIds,
+    GROUP_SUGGESTION_LIMIT
+  );
+}
+
+export function rankGroupSuggestionsFromSimilarCards(
+  similarCards: SimilarCardForGroupSuggestion[],
+  groupsByCardId: Map<string, GroupForSuggestionRanking[]>,
+  selectedGroupIds: Set<string>,
+  limit = GROUP_SUGGESTION_LIMIT
+): CardEntryGroupSuggestionData[] {
+  const groupCandidates = new Map<
+    string,
+    {
+      groupId: string;
+      groupName: string;
+      maxSimilarity: number;
+      totalSimilarity: number;
+      supportingCardCount: number;
+    }
+  >();
+
+  for (const similarCard of similarCards) {
+    for (const group of groupsByCardId.get(similarCard.cardId) ?? []) {
+      if (selectedGroupIds.has(group.groupId)) {
+        continue;
+      }
+
+      const existing = groupCandidates.get(group.groupId);
+
+      if (existing) {
+        existing.maxSimilarity = Math.max(existing.maxSimilarity, similarCard.similarity);
+        existing.totalSimilarity += similarCard.similarity;
+        existing.supportingCardCount += 1;
+        continue;
+      }
+
+      groupCandidates.set(group.groupId, {
+        groupId: group.groupId,
+        groupName: group.groupName,
+        maxSimilarity: similarCard.similarity,
+        totalSimilarity: similarCard.similarity,
+        supportingCardCount: 1,
+      });
+    }
+  }
+
+  const rankedGroups = Array.from(groupCandidates.values())
+    .sort((left, right) => {
+      if (right.maxSimilarity !== left.maxSimilarity) {
+        return right.maxSimilarity - left.maxSimilarity;
+      }
+
+      if (right.supportingCardCount !== left.supportingCardCount) {
+        return right.supportingCardCount - left.supportingCardCount;
+      }
+
+      if (right.totalSimilarity !== left.totalSimilarity) {
+        return right.totalSimilarity - left.totalSimilarity;
+      }
+
+      return left.groupName.localeCompare(right.groupName);
+    });
+
+  const bestSimilarity = rankedGroups[0]?.maxSimilarity ?? 0;
+  const cutoff = Math.max(
+    GROUP_SUGGESTION_CARD_THRESHOLD,
+    bestSimilarity - GROUP_SUGGESTION_RELATIVE_MARGIN
+  );
+
+  return rankedGroups
+    .filter((group) => group.maxSimilarity >= cutoff)
+    .slice(0, limit)
+    .map((group) => ({
+      groupId: group.groupId,
+      groupName: group.groupName,
+      similarityScore: Number(group.maxSimilarity.toFixed(3)),
+    }));
+}
+
+async function buildDuplicateWarnings(
+  input: {
+    userId: string;
+    languageId: string;
+    draftCard: Card;
+    database: DatabaseClient;
+  }
+): Promise<CardEntryDuplicateWarningData[]> {
+  if (!input.draftCard.embedding) {
+    return [];
+  }
+
+  const metadata = getCardEntryMetadata(input.draftCard.metadata);
+  const dismissedIds = new Set(metadata.dismissedDuplicateWarningIds ?? []);
+  const similarCards = await findSimilarCards(
+    input.userId,
+    input.languageId,
+    input.draftCard.embedding,
+    DUPLICATE_WARNING_LIMIT,
+    DUPLICATE_WARNING_THRESHOLD,
+    input.database as never
+  );
+  const draftFingerprint =
+    metadata.semanticFingerprint ?? buildSemanticFingerprint(buildCardSemanticText(input.draftCard));
+
+  return similarCards.map((similarCard) => {
+    const warningId = createDuplicateWarningId({
+      draftFingerprint,
+      similarCardId: similarCard.cardId,
+      similarCardUpdatedAt: similarCard.updatedAt ?? null,
+    });
+
+    return {
+      warningId,
+      title: 'Possible duplicate',
+      similarCardId: similarCard.cardId,
+      similarCardLabel: formatSimilarCardLabel(similarCard),
+      dismissed: dismissedIds.has(warningId),
+    };
+  });
+}
+
+export async function refreshCardEntryNoteSemanticAssistance(input: {
+  userId: string;
+  languageId: string;
+  noteId: string;
+  privateEnv: Record<string, string | undefined>;
+  database: DatabaseClient;
+}): Promise<CardEntryNoteShellData> {
+  const [baseNote, workspace] = await Promise.all([
+    loadCardEntryNoteShellData(input.userId, input.languageId, input.noteId, input.database),
+    getNoteWithDraftCards(input.userId, input.languageId, input.noteId, input.database as never),
+  ]);
+
+  if (!workspace || baseNote.aiState === 'queued' || baseNote.aiState === 'processing') {
+    return baseNote;
+  }
+
+  const semanticCandidates = await ensureSemanticCandidates({
+    ...input,
+    draftCards: workspace.draftCards,
+  });
+  const rawDraftsById = new Map(
+    semanticCandidates.draftCards.map((draftCard) => [draftCard.cardId, draftCard])
+  );
+  const semanticDraftCards: CardEntryNoteDraftCardData[] = [];
+
+  for (const draftCard of baseNote.draftCards) {
+    const rawDraftCard = rawDraftsById.get(draftCard.cardId);
+
+    if (!rawDraftCard) {
+      semanticDraftCards.push(draftCard);
+      continue;
+    }
+
+    semanticDraftCards.push({
+      ...draftCard,
+      groupSuggestions: await buildGroupSuggestions({
+        userId: input.userId,
+        languageId: input.languageId,
+        draftCard: rawDraftCard,
+        selectedGroups: draftCard.groups,
+        database: input.database,
+      }),
+      duplicateWarnings: await buildDuplicateWarnings({
+        userId: input.userId,
+        languageId: input.languageId,
+        draftCard: rawDraftCard,
+        database: input.database,
+      }),
+    });
+  }
+
+  return {
+    ...baseNote,
+    draftCards: semanticDraftCards,
+  };
+}
+
+export async function dismissCardEntryDuplicateWarning(input: {
+  userId: string;
+  languageId: string;
+  noteId: string;
+  cardId: string;
+  warningId: string;
+  privateEnv: Record<string, string | undefined>;
+  database: DatabaseClient;
+}): Promise<CardEntryNoteShellData> {
+  const note = await refreshCardEntryNoteSemanticAssistance(input);
+  const card = note.draftCards.find((draftCard) => draftCard.cardId === input.cardId);
+  const warning = card?.duplicateWarnings.find((duplicateWarning) => duplicateWarning.warningId === input.warningId);
+
+  if (!card || !warning) {
+    throw new CardEntryRequestError(404, 'That duplicate warning is no longer available.');
+  }
+
+  const workspace = await getNoteWithDraftCards(
+    input.userId,
+    input.languageId,
+    input.noteId,
+    input.database as never
+  );
+  const rawDraftCard = workspace?.draftCards.find((draftCard) => draftCard.cardId === input.cardId);
+
+  if (!rawDraftCard) {
+    throw new CardEntryRequestError(404, 'Draft card not found for this note.');
+  }
+
+  const metadata = getCardEntryMetadata(rawDraftCard.metadata);
+  const dismissedDuplicateWarningIds = new Set(metadata.dismissedDuplicateWarningIds ?? []);
+  dismissedDuplicateWarningIds.add(input.warningId);
+
+  await input.database
+    .update(cards)
+    .set({
+      metadata: mergeCardEntryMetadata(rawDraftCard.metadata, {
+        dismissedDuplicateWarningIds: Array.from(dismissedDuplicateWarningIds),
+      }),
+    })
+    .where(
+      and(
+        eq(cards.userId, rawDraftCard.userId),
+        eq(cards.languageId, rawDraftCard.languageId),
+        eq(cards.cardId, rawDraftCard.cardId)
+      )
+    );
+
+  return refreshCardEntryNoteSemanticAssistance(input);
+}

--- a/apps/web/src/lib/server/card-entry.ts
+++ b/apps/web/src/lib/server/card-entry.ts
@@ -79,8 +79,15 @@ export type CardEntryGroupData = {
 export type CardEntryDuplicateWarningData = {
   warningId: string;
   title: string;
+  similarCardId: string;
   similarCardLabel: string;
   dismissed: boolean;
+};
+
+export type CardEntryGroupSuggestionData = {
+  groupId: string;
+  groupName: string;
+  similarityScore: number;
 };
 
 export type CardEntryNoteDraftCardData = {
@@ -92,6 +99,7 @@ export type CardEntryNoteDraftCardData = {
   llmInstructions: string | null;
   linkedAtIso: string | null;
   groups: CardEntryGroupData[];
+  groupSuggestions: CardEntryGroupSuggestionData[];
   duplicateWarnings: CardEntryDuplicateWarningData[];
 };
 
@@ -276,6 +284,7 @@ function mapDraftCard(
     llmInstructions: parseOptionalText(draftCard.llmInstructions ?? ''),
     linkedAtIso: draftCard.linkedAt?.toISOString() ?? null,
     groups,
+    groupSuggestions: [],
     duplicateWarnings: [],
   };
 }

--- a/apps/web/src/routes/[lang]/card-entry/notes/[noteId]/+page.svelte
+++ b/apps/web/src/routes/[lang]/card-entry/notes/[noteId]/+page.svelte
@@ -12,22 +12,30 @@
   let note: CardEntryNoteShellData = data.note;
   let isRefreshing = false;
   let pollingError: string | null = null;
+  let semanticError: string | null = null;
   let workspaceError: string | null = null;
   let addCardPending = false;
   let pollTimer: ReturnType<typeof setTimeout> | null = null;
   let showDuplicateDialog = false;
   let signOffForm: HTMLFormElement | null = null;
+  let semanticRefreshPending = false;
+  let semanticRefreshQueued = false;
 
   $: currentLang = $page.params.lang ?? '';
   $: actionError = (form as { errorMessage?: string } | null | undefined)?.errorMessage ?? null;
   $: unresolvedDuplicateWarnings = getUnresolvedDuplicateWarnings(note);
   $: signOffDisabled =
-    note.draftCards.length === 0 || note.aiState === 'queued' || note.aiState === 'processing';
+    note.draftCards.length === 0 ||
+    note.aiState === 'queued' ||
+    note.aiState === 'processing' ||
+    semanticRefreshPending;
   $: signOffLabel =
     note.draftCards.length === 0
       ? 'Sign off unavailable — add at least one draft card'
-      : note.aiState === 'queued' || note.aiState === 'processing'
+    : note.aiState === 'queued' || note.aiState === 'processing'
         ? 'Sign off unavailable while AI is still processing'
+        : semanticRefreshPending
+          ? 'Checking suggestions and duplicates before sign off...'
         : `Sign off — Promote all to active (${note.draftCards.length} ${
             note.draftCards.length === 1 ? 'card' : 'cards'
           }) →`;
@@ -61,6 +69,10 @@
 
       note = await response.json();
       pollingError = null;
+
+      if (!shouldPollAiState(note)) {
+        void refreshSemanticAssistance();
+      }
     } catch (error) {
       console.error('Failed to refresh Card Entry note processing state:', error);
       pollingError = 'The latest AI processing status could not be loaded right now.';
@@ -71,6 +83,42 @@
         pollTimer = setTimeout(() => {
           void refreshProcessingState();
         }, 2_000);
+      }
+    }
+  }
+
+  async function refreshSemanticAssistance() {
+    if (semanticRefreshPending) {
+      semanticRefreshQueued = true;
+      return;
+    }
+
+    if (shouldPollAiState(note) || note.draftCards.length === 0) {
+      return;
+    }
+
+    semanticRefreshPending = true;
+
+    try {
+      const response = await fetch(`/${currentLang}/card-entry/notes/${note.noteId}/semantic-assistance`, {
+        method: 'POST',
+      });
+
+      if (!response.ok) {
+        throw new Error(`Unexpected semantic assistance response: ${response.status}`);
+      }
+
+      note = await response.json();
+      semanticError = null;
+    } catch (error) {
+      console.error('Failed to refresh Card Entry semantic assistance:', error);
+      semanticError = 'Suggestions and duplicate checks could not be refreshed right now.';
+    } finally {
+      semanticRefreshPending = false;
+
+      if (semanticRefreshQueued) {
+        semanticRefreshQueued = false;
+        void refreshSemanticAssistance();
       }
     }
   }
@@ -97,6 +145,7 @@
       }
 
       note = updatedNote;
+      void refreshSemanticAssistance();
     } catch (error) {
       workspaceError = error instanceof Error ? error.message : 'A draft card could not be created right now.';
     } finally {
@@ -107,11 +156,19 @@
   function handleDraftCardUpdated(event: CustomEvent<{ card: CardEntryNoteShellData['draftCards'][number]; availableGroups: CardEntryNoteShellData['availableGroups'] }>) {
     note = replaceDraftCardInNote(note, event.detail.card, event.detail.availableGroups);
     workspaceError = null;
+    void refreshSemanticAssistance();
+  }
+
+  function handleDraftCardNoteUpdated(event: CustomEvent<{ note: CardEntryNoteShellData }>) {
+    note = event.detail.note;
+    workspaceError = null;
+    semanticError = null;
   }
 
   function handleDraftCardRemoved(event: CustomEvent<{ note: CardEntryNoteShellData }>) {
     note = event.detail.note;
     workspaceError = null;
+    void refreshSemanticAssistance();
   }
 
   function handleSignOffClick(event: MouseEvent) {
@@ -141,6 +198,8 @@
   onMount(() => {
     if (shouldPollAiState(note)) {
       void refreshProcessingState();
+    } else {
+      void refreshSemanticAssistance();
     }
 
     return () => {
@@ -215,6 +274,11 @@
       <p class="note-workspace__supporting">
         Edit each linked draft inline. Fields save automatically when focus leaves them.
       </p>
+      {#if semanticRefreshPending}
+        <p class="note-workspace__supporting">Refreshing suggestions and duplicate checks…</p>
+      {:else if semanticError}
+        <p class="note-workspace__supporting note-workspace__supporting--error">{semanticError}</p>
+      {/if}
     </div>
 
     {#if note.draftCards.length === 0}
@@ -234,6 +298,7 @@
           card={draftCard}
           availableGroups={note.availableGroups}
           on:updated={handleDraftCardUpdated}
+          on:noteUpdated={handleDraftCardNoteUpdated}
           on:removed={handleDraftCardRemoved}
         />
       {/each}
@@ -304,6 +369,7 @@
   .note-workspace__meta,
   .note-workspace__content,
   .note-workspace__supporting,
+  .note-workspace__supporting--error,
   .note-workspace__empty h3,
   .note-workspace__empty p,
   .note-workspace__status h2,
@@ -359,6 +425,10 @@
     max-inline-size: var(--measure-body);
     font-size: var(--font-size-h4);
     line-height: var(--leading-body);
+  }
+
+  .note-workspace__supporting--error {
+    color: var(--color-error-text);
   }
 
   .note-workspace__supporting,

--- a/apps/web/src/routes/[lang]/card-entry/notes/[noteId]/draft-cards/[cardId]/duplicate-warnings/+server.ts
+++ b/apps/web/src/routes/[lang]/card-entry/notes/[noteId]/draft-cards/[cardId]/duplicate-warnings/+server.ts
@@ -1,0 +1,63 @@
+import { error, json, type RequestHandler } from '@sveltejs/kit';
+import { withTransactionDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import { dismissCardEntryDuplicateWarning } from '$lib/server/card-entry-semantic.js';
+import { CardEntryRequestError } from '$lib/server/card-entry.js';
+
+export const POST: RequestHandler = async (event) => {
+  const session = await event.locals.auth();
+  const userId = session?.user?.id;
+  const languageId = event.params.lang;
+  const noteId = event.params.noteId;
+  const cardId = event.params.cardId;
+
+  if (!userId || !languageId || !noteId || !cardId) {
+    throw error(401, 'You must be signed in to update duplicate warnings.');
+  }
+
+  const databaseUrl = env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    throw error(500, 'The duplicate warning service is not configured right now.');
+  }
+
+  let body: unknown;
+
+  try {
+    body = await event.request.json();
+  } catch {
+    throw error(400, 'The duplicate warning request must be valid JSON.');
+  }
+
+  const warningId =
+    typeof (body as { warningId?: unknown } | null | undefined)?.warningId === 'string'
+      ? (body as { warningId: string }).warningId.trim()
+      : '';
+
+  if (!warningId) {
+    throw error(400, 'A duplicate warning identifier is required.');
+  }
+
+  try {
+    const note = await withTransactionDb(databaseUrl, (database) =>
+      dismissCardEntryDuplicateWarning({
+        userId,
+        languageId,
+        noteId,
+        cardId,
+        warningId,
+        privateEnv: env,
+        database,
+      })
+    );
+
+    return json(note);
+  } catch (requestError) {
+    if (requestError instanceof CardEntryRequestError) {
+      throw error(requestError.status, requestError.message);
+    }
+
+    console.error('Failed to dismiss Card Entry duplicate warning:', requestError);
+    throw error(500, 'The duplicate warning could not be updated right now.');
+  }
+};

--- a/apps/web/src/routes/[lang]/card-entry/notes/[noteId]/semantic-assistance/+server.ts
+++ b/apps/web/src/routes/[lang]/card-entry/notes/[noteId]/semantic-assistance/+server.ts
@@ -1,0 +1,43 @@
+import { error, json, type RequestHandler } from '@sveltejs/kit';
+import { withTransactionDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import { refreshCardEntryNoteSemanticAssistance } from '$lib/server/card-entry-semantic.js';
+import { CardEntryRequestError } from '$lib/server/card-entry.js';
+
+export const POST: RequestHandler = async (event) => {
+  const session = await event.locals.auth();
+  const userId = session?.user?.id;
+  const languageId = event.params.lang;
+  const noteId = event.params.noteId;
+
+  if (!userId || !languageId || !noteId) {
+    throw error(401, 'You must be signed in to refresh semantic assistance.');
+  }
+
+  const databaseUrl = env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    throw error(500, 'The semantic assistance service is not configured right now.');
+  }
+
+  try {
+    const note = await withTransactionDb(databaseUrl, (database) =>
+      refreshCardEntryNoteSemanticAssistance({
+        userId,
+        languageId,
+        noteId,
+        privateEnv: env,
+        database,
+      })
+    );
+
+    return json(note);
+  } catch (requestError) {
+    if (requestError instanceof CardEntryRequestError) {
+      throw error(requestError.status, requestError.message);
+    }
+
+    console.error('Failed to refresh Card Entry semantic assistance:', requestError);
+    throw error(500, 'Semantic assistance could not be refreshed right now.');
+  }
+};

--- a/packages/database/src/cards.ts
+++ b/packages/database/src/cards.ts
@@ -35,8 +35,13 @@ export async function getActiveCards(userId: string, languageId: string): Promis
 /**
  * Get cards by status for a user+language
  */
-export async function getCardsByStatus(userId: string, languageId: string, status: string): Promise<Card[]> {
-  return await db
+export async function getCardsByStatus(
+  userId: string,
+  languageId: string,
+  status: string,
+  database?: AnyDb
+): Promise<Card[]> {
+  return await getConn(database)
     .select()
     .from(cards)
     .where(and(
@@ -154,9 +159,10 @@ export async function findSimilarCards(
   languageId: string,
   queryEmbedding: number[], 
   limit: number = 10,
-  threshold: number = 0.7
+  threshold: number = 0.7,
+  database?: AnyDb
 ): Promise<Array<Card & { similarity: number }>> {
-  const result = await db
+  const result = await getConn(database)
     .select({
       userId: cards.userId,
       languageId: cards.languageId,
@@ -271,9 +277,10 @@ export async function findSimilarGroups(
   languageId: string,
   queryEmbedding: number[], 
   limit: number = 5,
-  threshold: number = 0.6
+  threshold: number = 0.6,
+  database?: AnyDb
 ): Promise<Array<Group & { similarity: number }>> {
-  const result = await db
+  const result = await getConn(database)
     .select({
       userId: groups.userId,
       languageId: groups.languageId,

--- a/packages/database/src/tests/card-entry.test.ts
+++ b/packages/database/src/tests/card-entry.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import postgres from 'postgres';
 import { eq, and } from 'drizzle-orm';
 import { setupTestDatabase, cleanupTestDatabase, resetTestTables, type TestDb } from '../test-utils.js';
-import { users, studyLanguages, cards, inboxNotes, noteCardLinks, cardEntryDailyStats } from '../schema.js';
+import { users, studyLanguages, cards, groups, inboxNotes, noteCardLinks, cardEntryDailyStats } from '../schema.js';
 import {
   createDraftCardFromNote,
   createInboxNote,
@@ -17,10 +17,17 @@ import {
   transitionInboxNoteAiState,
   updateInboxNoteAiState,
 } from '../card-entry.js';
-import { addCardToGroup, createGroup } from '../cards.js';
+import { addCardToGroup, createGroup, findSimilarCards, findSimilarGroups } from '../cards.js';
 
 const TEST_USER = { userId: 'auth0|card-entry-user', email: 'card-entry@example.com' };
 const TEST_LANG = { userId: TEST_USER.userId, languageId: 'es', languageName: 'Spanish' };
+
+function createEmbedding(primary: number, secondary = 0): number[] {
+  const embedding = new Array<number>(768).fill(0);
+  embedding[0] = primary;
+  embedding[1] = secondary;
+  return embedding;
+}
 
 describe('Card Entry database operations', () => {
   let db: TestDb;
@@ -335,5 +342,113 @@ describe('Card Entry database operations', () => {
 
     const counts = await getCardEntryCounts(TEST_USER.userId, TEST_LANG.languageId, db);
     expect(counts.draftCardCount).toBe(1);
+  });
+
+  it('limits similar-card detection to the same user, language, and active cards', async () => {
+    await db.insert(users).values({ userId: 'auth0|other-user', email: 'other@example.com' });
+    await db.insert(studyLanguages).values({ userId: 'auth0|other-user', languageId: 'es', languageName: 'Spanish' });
+    await db.insert(studyLanguages).values({ userId: TEST_USER.userId, languageId: 'fr', languageName: 'French' });
+
+    await db.insert(cards).values([
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'active-similar-card',
+        content: 'por si acaso',
+        meaning: 'just in case',
+        status: 'active',
+        embedding: createEmbedding(1, 0),
+        embeddingModel: 'test-model',
+        embeddingGeneratedAt: new Date('2026-04-01T00:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'draft-similar-card',
+        content: 'draft should be excluded',
+        status: 'draft',
+        embedding: createEmbedding(1, 0),
+        embeddingModel: 'test-model',
+        embeddingGeneratedAt: new Date('2026-04-01T00:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: 'fr',
+        cardId: 'other-language-card',
+        content: 'autre langue',
+        status: 'active',
+        embedding: createEmbedding(1, 0),
+        embeddingModel: 'test-model',
+        embeddingGeneratedAt: new Date('2026-04-01T00:00:00.000Z'),
+      },
+      {
+        userId: 'auth0|other-user',
+        languageId: TEST_LANG.languageId,
+        cardId: 'other-user-card',
+        content: 'other user',
+        status: 'active',
+        embedding: createEmbedding(1, 0),
+        embeddingModel: 'test-model',
+        embeddingGeneratedAt: new Date('2026-04-01T00:00:00.000Z'),
+      },
+    ]);
+
+    const similarCards = await findSimilarCards(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      createEmbedding(1, 0),
+      5,
+      0.8,
+      db
+    );
+
+    expect(similarCards.map((card) => card.cardId)).toEqual(['active-similar-card']);
+  });
+
+  it('limits similar-group detection to the same user and language', async () => {
+    await db.insert(users).values({ userId: 'auth0|group-user', email: 'group-user@example.com' });
+    await db.insert(studyLanguages).values({ userId: 'auth0|group-user', languageId: 'es', languageName: 'Spanish' });
+    await db.insert(studyLanguages).values({ userId: TEST_USER.userId, languageId: 'de', languageName: 'German' });
+
+    await db.insert(groups).values([
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        groupId: 'group-similar',
+        groupName: 'Time expressions',
+        embedding: createEmbedding(1, 0),
+        embeddingModel: 'test-model',
+        embeddingGeneratedAt: new Date('2026-04-01T00:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: 'de',
+        groupId: 'group-other-language',
+        groupName: 'Zeit',
+        embedding: createEmbedding(1, 0),
+        embeddingModel: 'test-model',
+        embeddingGeneratedAt: new Date('2026-04-01T00:00:00.000Z'),
+      },
+      {
+        userId: 'auth0|group-user',
+        languageId: TEST_LANG.languageId,
+        groupId: 'group-other-user',
+        groupName: 'Other user group',
+        embedding: createEmbedding(1, 0),
+        embeddingModel: 'test-model',
+        embeddingGeneratedAt: new Date('2026-04-01T00:00:00.000Z'),
+      },
+    ]);
+
+    const similarGroups = await findSimilarGroups(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      createEmbedding(1, 0),
+      5,
+      0.8,
+      db
+    );
+
+    expect(similarGroups.map((group) => group.groupId)).toEqual(['group-similar']);
   });
 });


### PR DESCRIPTION
## Summary
- add provider-agnostic embedding support to the shared AI service for Card Entry semantic assistance
- surface async group suggestions and duplicate warnings in the note-processing workspace with persistent duplicate dismissal
- improve group suggestion relevance by ranking groups from similar active-card matches instead of low-signal raw group-name similarity

## Testing
- pnpm --filter web test
- pnpm --filter web lint
- pnpm --filter web build
- pnpm --filter @studypuck/database test:docker:raw
- manual local verification of group suggestions, duplicate warnings, dismissal persistence, and sign-off confirmation