### PR TITLE
Add per-language Card Entry example sentence formats

### DIFF
--- a/apps/web/src/lib/card-entry/example-sentence-format.test.ts
+++ b/apps/web/src/lib/card-entry/example-sentence-format.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCardEntryExampleSentenceFormatInstruction,
+  readCardEntryExampleSentenceFormat,
+  updateStudyLanguageCardEntryExampleSentenceFormat,
+} from './example-sentence-format.js';
+
+describe('readCardEntryExampleSentenceFormat', () => {
+  it('falls back to the default format when no setting exists', () => {
+    expect(readCardEntryExampleSentenceFormat(undefined)).toBe('sentence_translation');
+  });
+
+  it('reads the stored card entry format from language settings', () => {
+    expect(
+      readCardEntryExampleSentenceFormat({
+        cardEntry: {
+          exampleSentenceFormat: 'sentence_transliteration_translation',
+        },
+      })
+    ).toBe('sentence_transliteration_translation');
+  });
+});
+
+describe('updateStudyLanguageCardEntryExampleSentenceFormat', () => {
+  it('preserves unrelated settings while updating the card entry format', () => {
+    expect(
+      updateStudyLanguageCardEntryExampleSentenceFormat(
+        {
+          cefrOverride: 'B1',
+          cardEntry: {
+            customFlag: true,
+          },
+        },
+        'sentence_only'
+      )
+    ).toEqual({
+      cefrOverride: 'B1',
+      cardEntry: {
+        customFlag: true,
+        exampleSentenceFormat: 'sentence_only',
+      },
+    });
+  });
+});
+
+describe('buildCardEntryExampleSentenceFormatInstruction', () => {
+  it('uses Chinese-specific transliteration guidance for zh', () => {
+    expect(
+      buildCardEntryExampleSentenceFormatInstruction({
+        exampleSentenceFormat: 'sentence_transliteration_translation',
+        languageId: 'zh',
+      })
+    ).toContain('pinyin');
+  });
+});

--- a/apps/web/src/lib/card-entry/example-sentence-format.ts
+++ b/apps/web/src/lib/card-entry/example-sentence-format.ts
@@ -1,0 +1,110 @@
+import { z } from 'zod';
+
+export const cardEntryExampleSentenceFormatSchema = z.enum([
+  'sentence_only',
+  'sentence_translation',
+  'sentence_transliteration_translation',
+]);
+
+export type CardEntryExampleSentenceFormat = z.infer<typeof cardEntryExampleSentenceFormatSchema>;
+
+type StudyLanguageCardEntrySettings = {
+  exampleSentenceFormat?: CardEntryExampleSentenceFormat;
+} & Record<string, unknown>;
+
+export type StudyLanguageSettings = {
+  cardEntry?: StudyLanguageCardEntrySettings;
+} & Record<string, unknown>;
+
+const studyLanguageCardEntrySettingsSchema = z
+  .object({
+    exampleSentenceFormat: cardEntryExampleSentenceFormatSchema.optional(),
+  })
+  .catchall(z.unknown());
+
+const studyLanguageSettingsSchema = z
+  .object({
+    cardEntry: studyLanguageCardEntrySettingsSchema.optional(),
+  })
+  .catchall(z.unknown());
+
+export const DEFAULT_CARD_ENTRY_EXAMPLE_SENTENCE_FORMAT: CardEntryExampleSentenceFormat = 'sentence_translation';
+
+export const CARD_ENTRY_EXAMPLE_SENTENCE_FORMAT_OPTIONS = [
+  {
+    value: 'sentence_only',
+    label: 'Sentence only',
+    description: 'Use only the study-language sentence.',
+  },
+  {
+    value: 'sentence_translation',
+    label: 'Sentence + translation',
+    description: 'Use "sentence | translation".',
+  },
+  {
+    value: 'sentence_transliteration_translation',
+    label: 'Sentence + transliteration + translation',
+    description: 'Use "sentence | transliteration | translation".',
+  },
+] as const satisfies ReadonlyArray<{
+  value: CardEntryExampleSentenceFormat;
+  label: string;
+  description: string;
+}>;
+
+export function getCardEntryExampleSentenceFormatLabel(
+  exampleSentenceFormat: CardEntryExampleSentenceFormat
+): string {
+  return (
+    CARD_ENTRY_EXAMPLE_SENTENCE_FORMAT_OPTIONS.find((option) => option.value === exampleSentenceFormat)?.label ??
+    'Sentence + translation'
+  );
+}
+
+function normalizeStudyLanguageSettings(settings: unknown): StudyLanguageSettings {
+  const parsed = studyLanguageSettingsSchema.safeParse(settings);
+
+  if (!parsed.success) {
+    return {};
+  }
+
+  return parsed.data;
+}
+
+export function readCardEntryExampleSentenceFormat(settings: unknown): CardEntryExampleSentenceFormat {
+  return normalizeStudyLanguageSettings(settings).cardEntry?.exampleSentenceFormat ?? DEFAULT_CARD_ENTRY_EXAMPLE_SENTENCE_FORMAT;
+}
+
+export function updateStudyLanguageCardEntryExampleSentenceFormat(
+  settings: unknown,
+  exampleSentenceFormat: CardEntryExampleSentenceFormat
+): StudyLanguageSettings {
+  const normalizedSettings = normalizeStudyLanguageSettings(settings);
+
+  return {
+    ...normalizedSettings,
+    cardEntry: {
+      ...normalizedSettings.cardEntry,
+      exampleSentenceFormat,
+    },
+  };
+}
+
+export function buildCardEntryExampleSentenceFormatInstruction(input: {
+  exampleSentenceFormat: CardEntryExampleSentenceFormat;
+  languageId: string;
+}): string {
+  switch (input.exampleSentenceFormat) {
+    case 'sentence_only':
+      return 'Format every example as "<sentence>" only. Do not add transliteration or translation.';
+    case 'sentence_transliteration_translation':
+      if (input.languageId === 'zh') {
+        return 'Format every example as "<sentence> | <transliteration> | <translation>". For Chinese, use Hanzi for <sentence>, pinyin for <transliteration>, and English for <translation>.';
+      }
+
+      return 'Format every example as "<sentence> | <transliteration> | <translation>" in that exact order.';
+    case 'sentence_translation':
+    default:
+      return 'Format every example as "<sentence> | <translation>". Do not add transliteration.';
+  }
+}

--- a/apps/web/src/lib/server/ai-prompts/card-entry.test.ts
+++ b/apps/web/src/lib/server/ai-prompts/card-entry.test.ts
@@ -29,26 +29,64 @@ describe('cardEntryDraftSuggestionSchema', () => {
 
 describe('buildCardEntryPreprocessPrompt', () => {
   it('includes cardType in the JSON shape example', () => {
-    const { userPrompt } = buildCardEntryPreprocessPrompt({ languageId: 'zh', noteContent: 'test' });
+    const { userPrompt } = buildCardEntryPreprocessPrompt({
+      languageId: 'zh',
+      noteContent: 'test',
+      exampleSentenceFormat: 'sentence_translation',
+    });
     expect(userPrompt).toContain('cardType');
   });
 
   it('includes card type classification guidance in the system prompt', () => {
-    const { systemPrompt } = buildCardEntryPreprocessPrompt({ languageId: 'zh', noteContent: 'test' });
+    const { systemPrompt } = buildCardEntryPreprocessPrompt({
+      languageId: 'zh',
+      noteContent: 'test',
+      exampleSentenceFormat: 'sentence_translation',
+    });
     expect(systemPrompt).toContain('"word"');
     expect(systemPrompt).toContain('"pattern"');
     expect(systemPrompt).toContain('"complex_prompt"');
   });
 
   it('provides multi-word / phrase guidance that covers CJK expressions', () => {
-    const { systemPrompt } = buildCardEntryPreprocessPrompt({ languageId: 'zh', noteContent: 'test' });
+    const { systemPrompt } = buildCardEntryPreprocessPrompt({
+      languageId: 'zh',
+      noteContent: 'test',
+      exampleSentenceFormat: 'sentence_translation',
+    });
     // The prompt should explicitly mention phrase/expression/multi-word criteria so
     // the LLM does not classify Chinese phrases like 这还有什么说的 as "word".
     expect(systemPrompt).toMatch(/phrase|expression|multi-word/i);
   });
 
   it('embeds the active language code in the user prompt', () => {
-    const { userPrompt } = buildCardEntryPreprocessPrompt({ languageId: 'es', noteContent: 'repasar' });
+    const { userPrompt } = buildCardEntryPreprocessPrompt({
+      languageId: 'es',
+      noteContent: 'repasar',
+      exampleSentenceFormat: 'sentence_translation',
+    });
     expect(userPrompt).toContain('es');
+  });
+
+  it('includes deterministic translation formatting guidance in the user prompt', () => {
+    const { userPrompt } = buildCardEntryPreprocessPrompt({
+      languageId: 'es',
+      noteContent: 'repasar',
+      exampleSentenceFormat: 'sentence_translation',
+    });
+
+    expect(userPrompt).toContain('<sentence> | <translation>');
+  });
+
+  it('includes Chinese-specific Hanzi and pinyin guidance when transliteration is selected', () => {
+    const { userPrompt } = buildCardEntryPreprocessPrompt({
+      languageId: 'zh',
+      noteContent: '经历',
+      exampleSentenceFormat: 'sentence_transliteration_translation',
+    });
+
+    expect(userPrompt).toContain('Hanzi');
+    expect(userPrompt).toContain('pinyin');
+    expect(userPrompt).toContain('English');
   });
 });

--- a/apps/web/src/lib/server/ai-prompts/card-entry.ts
+++ b/apps/web/src/lib/server/ai-prompts/card-entry.ts
@@ -1,4 +1,9 @@
 import { z } from 'zod';
+import {
+  buildCardEntryExampleSentenceFormatInstruction,
+  getCardEntryExampleSentenceFormatLabel,
+  type CardEntryExampleSentenceFormat,
+} from '$lib/card-entry/example-sentence-format.js';
 
 export const cardEntryCardTypeSchema = z.enum(['word', 'pattern', 'complex_prompt']).default('word');
 
@@ -20,6 +25,7 @@ export type CardEntryPreprocessResponse = z.infer<typeof cardEntryPreprocessResp
 export function buildCardEntryPreprocessPrompt(input: {
   languageId: string;
   noteContent: string;
+  exampleSentenceFormat: CardEntryExampleSentenceFormat;
 }): {
   systemPrompt: string;
   userPrompt: string;
@@ -31,6 +37,7 @@ export function buildCardEntryPreprocessPrompt(input: {
       'Create 1 to 5 draft cards from the note.',
       'Preserve the user note intent instead of inventing unrelated material.',
       'Keep examples and mnemonics concise and useful for study.',
+      'Use the configured example sentence format consistently across every example string and do not mix formats within one response.',
       'If the note is ambiguous, produce the safest likely draft cards instead of refusing.',
       'Set cardType based on the content: use "word" for a single vocabulary word or very short vocabulary item (e.g. 经历, repasar, bonjour);',
       'use "pattern" for a phrase, expression, grammar pattern, or multi-word construction (e.g. 这还有什么说的, sin embargo, au fur et à mesure);',
@@ -39,6 +46,8 @@ export function buildCardEntryPreprocessPrompt(input: {
     ].join(' '),
     userPrompt: [
       `Active language code: ${input.languageId}.`,
+      `Example sentence format: ${getCardEntryExampleSentenceFormatLabel(input.exampleSentenceFormat)}.`,
+      buildCardEntryExampleSentenceFormatInstruction(input),
       'Return this JSON shape exactly:',
       '{"draftCards":[{"content":"string","cardType":"word|pattern|complex_prompt","meaning":"string|null","examples":["string"],"mnemonics":["string"],"llmInstructions":"string|null"}]}',
       'Source note:',

--- a/apps/web/src/lib/server/card-entry-ai.ts
+++ b/apps/web/src/lib/server/card-entry-ai.ts
@@ -1,10 +1,12 @@
 import {
   finalizeInboxNoteAiProcessing,
+  getActiveUserLanguages,
   getNoteWithDraftCards,
   transitionInboxNoteAiState,
   type InboxNoteAiState,
   type TransactionCapableDatabaseConnection,
 } from '@studypuck/database';
+import { readCardEntryExampleSentenceFormat } from '$lib/card-entry/example-sentence-format.js';
 import { buildCardEntryPreprocessPrompt, cardEntryPreprocessResponseSchema } from '$lib/server/ai-prompts/card-entry.js';
 import { createAiService } from '$lib/server/ai-service.js';
 
@@ -53,9 +55,12 @@ export async function ensureCardEntryNoteProcessingState(input: {
     const aiService = createAiService({
       privateEnv: input.privateEnv,
     });
+    const activeLanguages = await getActiveUserLanguages(input.userId, input.transactionDatabase as never);
+    const activeLanguage = activeLanguages.find((language) => language.languageId === input.languageId);
     const prompt = buildCardEntryPreprocessPrompt({
       languageId: input.languageId,
       noteContent: workspace.note.content,
+      exampleSentenceFormat: readCardEntryExampleSentenceFormat(activeLanguage?.settings),
     });
     const response = await aiService.generateStructured({
       metadata: {

--- a/apps/web/src/lib/server/settings.ts
+++ b/apps/web/src/lib/server/settings.ts
@@ -9,6 +9,7 @@ import {
   type StudyLanguage,
   type User,
 } from '@studypuck/database';
+import { readCardEntryExampleSentenceFormat, type CardEntryExampleSentenceFormat } from '$lib/card-entry/example-sentence-format.js';
 
 type DatabaseClient = NonNullable<Parameters<typeof getUserByAuth0Id>[1]>;
 
@@ -18,6 +19,7 @@ export type SettingsLanguageSummary = {
   isActive: boolean;
   cardCount: number;
   lastStudiedLabel: string;
+  exampleSentenceFormat: CardEntryExampleSentenceFormat;
 };
 
 export type SettingsData = {
@@ -119,6 +121,7 @@ async function loadLanguageSummary(
     isActive: language.languageId === currentLanguageId,
     cardCount: Number(cardCountResult[0]?.count ?? 0),
     lastStudiedLabel: formatRelativeStudyLabel(latestStudyDate),
+    exampleSentenceFormat: readCardEntryExampleSentenceFormat(language.settings),
   };
 }
 

--- a/apps/web/src/routes/[lang]/settings/languages/+page.server.ts
+++ b/apps/web/src/routes/[lang]/settings/languages/+page.server.ts
@@ -1,6 +1,11 @@
 import { fail, redirect } from '@sveltejs/kit';
-import { addStudyLanguage, getDb, getActiveUserLanguages } from '@studypuck/database';
+import { addStudyLanguage, getDb, getActiveUserLanguages, updateStudyLanguage } from '@studypuck/database';
 import { env } from '$env/dynamic/private';
+import {
+  cardEntryExampleSentenceFormatSchema,
+  getCardEntryExampleSentenceFormatLabel,
+  updateStudyLanguageCardEntryExampleSentenceFormat,
+} from '$lib/card-entry/example-sentence-format.js';
 import { getLanguageByCode } from '$lib/config/languages.js';
 import type { Actions } from './$types.js';
 
@@ -43,5 +48,56 @@ export const actions: Actions = {
     );
 
     throw redirect(303, `/${selectedLanguage.code}/`);
+  },
+
+  saveExampleSentenceFormat: async (event) => {
+    const session = await event.locals.auth();
+
+    if (!session?.user?.id) {
+      throw redirect(303, '/');
+    }
+
+    const formData = await event.request.formData();
+    const languageId = formData.get('languageId')?.toString().trim() ?? '';
+    const submittedExampleSentenceFormat = formData.get('exampleSentenceFormat')?.toString().trim() ?? '';
+    const parsedExampleSentenceFormat = cardEntryExampleSentenceFormatSchema.safeParse(submittedExampleSentenceFormat);
+
+    if (!parsedExampleSentenceFormat.success) {
+      return fail(400, {
+        exampleSentenceFormatLanguageId: languageId,
+        submittedExampleSentenceFormat,
+        exampleSentenceFormatError: 'Choose a valid example sentence format before saving.',
+      });
+    }
+
+    const database = getDb(env.DATABASE_URL);
+    const activeLanguages = await getActiveUserLanguages(session.user.id, database as never);
+    const targetLanguage = activeLanguages.find((language) => language.languageId === languageId);
+
+    if (!targetLanguage) {
+      return fail(404, {
+        exampleSentenceFormatLanguageId: languageId,
+        submittedExampleSentenceFormat: parsedExampleSentenceFormat.data,
+        exampleSentenceFormatError: 'That language is no longer available in your study setup.',
+      });
+    }
+
+    await updateStudyLanguage(
+      session.user.id,
+      targetLanguage.languageId,
+      {
+        settings: updateStudyLanguageCardEntryExampleSentenceFormat(
+          targetLanguage.settings,
+          parsedExampleSentenceFormat.data
+        ),
+      },
+      database as never
+    );
+
+    return {
+      exampleSentenceFormatLanguageId: targetLanguage.languageId,
+      savedExampleSentenceFormat: parsedExampleSentenceFormat.data,
+      exampleSentenceFormatSuccess: `${targetLanguage.languageName} Card Entry examples will now use ${getCardEntryExampleSentenceFormatLabel(parsedExampleSentenceFormat.data).toLowerCase()}.`,
+    };
   },
 };

--- a/apps/web/src/routes/[lang]/settings/languages/+page.svelte
+++ b/apps/web/src/routes/[lang]/settings/languages/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { ActionData, PageData } from './$types.js';
   import { page } from '$app/stores';
+  import { CARD_ENTRY_EXAMPLE_SENTENCE_FORMAT_OPTIONS } from '$lib/card-entry/example-sentence-format.js';
   import { SUPPORTED_LANGUAGES } from '$lib/config/languages.js';
 
   let { data, form } = $props<{ data: PageData; form?: ActionData }>();
@@ -77,6 +78,14 @@
     removeNotice = 'Language removal will be connected in a future milestone.';
     closeRemoveDialog();
   }
+
+  function getSelectedExampleSentenceFormat(language: LanguageSummary) {
+    if (form?.exampleSentenceFormatLanguageId === language.languageId && form?.submittedExampleSentenceFormat) {
+      return form.submittedExampleSentenceFormat;
+    }
+
+    return language.exampleSentenceFormat;
+  }
 </script>
 
 <svelte:window on:keydown={handleKeydown} />
@@ -127,6 +136,56 @@
         <p class="language-card__meta">
           {language.cardCount} {language.cardCount === 1 ? 'card' : 'cards'} • Last studied: {language.lastStudiedLabel}
         </p>
+
+        <section class="language-card__section stack">
+          <div class="stack language-card__section-copy">
+            <h4>Card Entry</h4>
+            <p class="text-muted">Standardize how AI-generated example sentences are formatted for this language.</p>
+          </div>
+
+          {#if form?.exampleSentenceFormatError && form?.exampleSentenceFormatLanguageId === language.languageId}
+            <p class="status-message status-message--error" role="alert">{form.exampleSentenceFormatError}</p>
+          {/if}
+
+          {#if form?.exampleSentenceFormatSuccess && form?.exampleSentenceFormatLanguageId === language.languageId}
+            <p class="status-message" role="status">{form.exampleSentenceFormatSuccess}</p>
+          {/if}
+
+          <form method="POST" action="?/saveExampleSentenceFormat" class="stack language-card__preference-form">
+            <input type="hidden" name="languageId" value={language.languageId} />
+
+            <fieldset class="preference-group stack">
+              <legend>Example sentence format</legend>
+
+              {#each CARD_ENTRY_EXAMPLE_SENTENCE_FORMAT_OPTIONS as option}
+                <label class="preference-option">
+                  <input
+                    checked={getSelectedExampleSentenceFormat(language) === option.value}
+                    class="preference-option__input"
+                    type="radio"
+                    name="exampleSentenceFormat"
+                    value={option.value}
+                  />
+
+                  <span class="preference-option__surface stack">
+                    <span class="preference-option__label">{option.label}</span>
+                    <span class="preference-option__description">{option.description}</span>
+                  </span>
+                </label>
+              {/each}
+            </fieldset>
+
+            {#if language.languageId === 'zh'}
+              <p class="language-card__hint text-muted">
+                Choose <strong>Sentence + transliteration + translation</strong> for Hanzi | pinyin | English examples.
+              </p>
+            {/if}
+
+            <div class="language-card__preference-actions">
+              <button type="submit" class="primary-button">Save Example Format</button>
+            </div>
+          </form>
+        </section>
 
         <div class="cluster language-card__actions">
           {#if !language.isActive}
@@ -242,7 +301,12 @@
   .language-card,
   .dialog,
   .dialog__copy,
-  .dialog__field {
+  .dialog__field,
+  .language-card__section,
+  .language-card__section-copy,
+  .language-card__preference-form,
+  .preference-group,
+  .preference-option__surface {
     --stack-space: var(--space-4);
   }
 
@@ -282,6 +346,23 @@
 
   .language-card__copy {
     --stack-space: var(--space-1);
+  }
+
+  .language-card__section {
+    padding: var(--space-4);
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--radius-md);
+    background: color-mix(in srgb, var(--color-surface) 88%, var(--color-primary-subtle));
+  }
+
+  .language-card__section-copy h4,
+  .language-card__section-copy p,
+  .language-card__hint {
+    margin: 0;
+  }
+
+  .language-card__section-copy h4 {
+    font-size: var(--font-size-h4);
   }
 
   .language-card__mark,
@@ -369,6 +450,12 @@
     color: var(--color-warning-text);
   }
 
+  .status-message--error {
+    border-color: var(--color-error-border);
+    background: var(--color-error-bg);
+    color: var(--color-error-text);
+  }
+
   .dialog-backdrop {
     position: fixed;
     inset: 0;
@@ -429,6 +516,67 @@
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
     gap: var(--space-3);
+  }
+
+  .preference-group {
+    margin: 0;
+    padding: 0;
+    border: 0;
+  }
+
+  .preference-group legend {
+    padding: 0;
+    font-family: var(--font-ui);
+    font-size: var(--font-size-ui);
+    color: var(--color-text-secondary);
+  }
+
+  .preference-option {
+    display: block;
+  }
+
+  .preference-option__input {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .preference-option__surface {
+    padding: var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+  }
+
+  .preference-option__input:checked + .preference-option__surface {
+    border-color: var(--color-primary);
+    background: var(--color-primary-subtle);
+  }
+
+  .preference-option__input:focus-visible + .preference-option__surface {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  .preference-option__label,
+  .preference-option__description {
+    display: block;
+  }
+
+  .preference-option__label {
+    font-family: var(--font-ui);
+    font-size: var(--font-size-ui);
+    font-weight: 600;
+  }
+
+  .preference-option__description {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-small);
+  }
+
+  .language-card__preference-actions {
+    display: flex;
+    justify-content: flex-start;
   }
 
   .language-picker__surface {

--- a/apps/web/tests/e2e/shell-and-settings.spec.ts
+++ b/apps/web/tests/e2e/shell-and-settings.spec.ts
@@ -85,9 +85,9 @@ test('saves a language-specific Card Entry example sentence format', async ({ pa
 	const chineseCard = page.locator('.language-card', {
 		has: page.getByRole('heading', { name: 'Chinese (Mandarin)' })
 	});
-	await chineseCard
-		.getByLabel('Sentence + transliteration + translation')
-		.check();
+	await chineseCard.locator('label.preference-option', {
+		hasText: 'Sentence + transliteration + translation'
+	}).click();
 	await chineseCard.getByRole('button', { name: 'Save Example Format', exact: true }).click();
 
 	await expect(
@@ -99,6 +99,6 @@ test('saves a language-specific Card Entry example sentence format', async ({ pa
 	await page.reload();
 
 	await expect(
-		chineseCard.getByLabel('Sentence + transliteration + translation')
+		chineseCard.locator('input[name="exampleSentenceFormat"][value="sentence_transliteration_translation"]')
 	).toBeChecked();
 });

--- a/apps/web/tests/e2e/shell-and-settings.spec.ts
+++ b/apps/web/tests/e2e/shell-and-settings.spec.ts
@@ -65,3 +65,40 @@ test('navigates settings tabs and supports the real add-language flow', async ({
 	await expect(page.getByRole('heading', { name: 'Appearance' })).toBeVisible();
 	await expect(page.getByText('Daily study reminder')).toBeVisible();
 });
+
+test('saves a language-specific Card Entry example sentence format', async ({ page }) => {
+	await resetDatabase();
+
+	const user = await seedUser({
+		userId: 'auth0|e2e-language-settings',
+		email: 'language-settings@example.com',
+		name: 'Language Settings User',
+		languages: [
+			{ code: 'es', label: 'Spanish' },
+			{ code: 'zh', label: 'Chinese (Mandarin)' }
+		]
+	});
+
+	await signInAs(page, user);
+	await page.goto('/es/settings/languages');
+
+	const chineseCard = page.locator('.language-card', {
+		has: page.getByRole('heading', { name: 'Chinese (Mandarin)' })
+	});
+	await chineseCard
+		.getByLabel('Sentence + transliteration + translation')
+		.check();
+	await chineseCard.getByRole('button', { name: 'Save Example Format', exact: true }).click();
+
+	await expect(
+		chineseCard.getByText(
+			'Chinese (Mandarin) Card Entry examples will now use sentence + transliteration + translation.'
+		)
+	).toBeVisible();
+
+	await page.reload();
+
+	await expect(
+		chineseCard.getByLabel('Sentence + transliteration + translation')
+	).toBeChecked();
+});


### PR DESCRIPTION
## Summary
- add a per-language Card Entry example sentence format setting under Settings > Languages
- persist the preference in study language settings and reuse it in Card Entry AI preprocessing prompts
- add coverage for prompt formatting guidance and the settings save flow

Closes #148