### PR TITLE
Implement Card Library backend foundation

### DIFF
--- a/apps/web/src/lib/schemas/cards.ts
+++ b/apps/web/src/lib/schemas/cards.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const activeCardIdSchema = z.string().trim().min(1, 'A card identifier is required.');
+export const activeGroupIdSchema = z.string().trim().min(1, 'A group identifier is required.');
+export const activeCardTypeSchema = z.enum(['word', 'pattern', 'complex_prompt']);
+
+export const cardLibrarySearchSchema = z.string().trim().max(200, 'Search text must be 200 characters or fewer.');
+
+export const cardLibraryFiltersSchema = z.object({
+  searchText: cardLibrarySearchSchema.default(''),
+  groupIds: z.array(activeGroupIdSchema).max(20, 'No more than 20 groups can be filtered at once.'),
+  cardType: activeCardTypeSchema.nullable(),
+});

--- a/apps/web/src/lib/server/cards.test.ts
+++ b/apps/web/src/lib/server/cards.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CardLibraryRequestError,
+  formatCardLibraryRelativeTime,
+  loadCardLibraryData,
+  loadGroupDetailData,
+  loadActiveCardDetailData,
+} from './cards.js';
+
+describe('Card Library server helpers', () => {
+  const database = {} as never;
+
+  const baseDeps = {
+    getActiveUserLanguages: vi.fn(async () => [{
+      userId: 'user-1',
+      languageId: 'zh',
+      languageName: 'Chinese',
+      isActive: true,
+      cefrLevel: null,
+      settings: null,
+      createdAt: null,
+    }]),
+    listActiveCards: vi.fn(async () => [
+      {
+        cardId: 'card-2',
+        content: '聊天',
+        meaning: 'to chat',
+        cardType: 'pattern',
+        updatedAt: new Date('2026-04-02T00:00:00.000Z'),
+        groups: [{ groupId: 'group-chat', groupName: 'Chat' }],
+      },
+    ]),
+    listGroupsWithActiveCardCounts: vi.fn(async () => [
+      {
+        userId: 'user-1',
+        languageId: 'zh',
+        groupId: 'group-chat',
+        groupName: 'Chat',
+        description: null,
+        embedding: null,
+        embeddingModel: null,
+        embeddingGeneratedAt: null,
+        createdAt: null,
+        metadata: null,
+        activeCardCount: 1,
+      },
+    ]),
+    getGroupWithActiveCardCount: vi.fn(async () => ({
+      userId: 'user-1',
+      languageId: 'zh',
+      groupId: 'group-chat',
+      groupName: 'Chat',
+      description: 'Conversation cards',
+      embedding: null,
+      embeddingModel: null,
+      embeddingGeneratedAt: null,
+      createdAt: null,
+      metadata: null,
+      activeCardCount: 1,
+    })),
+    listActiveCardsInGroup: vi.fn(async () => [
+      {
+        cardId: 'card-2',
+        content: '聊天',
+        meaning: 'to chat',
+        cardType: 'pattern',
+        updatedAt: new Date('2026-04-02T00:00:00.000Z'),
+        groups: [{ groupId: 'group-chat', groupName: 'Chat' }],
+      },
+    ]),
+    getActiveCardWithGroups: vi.fn(async () => ({
+      userId: 'user-1',
+      languageId: 'zh',
+      cardId: 'card-2',
+      content: '聊天',
+      status: 'active',
+      cardType: 'pattern',
+      meaning: 'to chat',
+      examples: ['我们聊天吧。'],
+      mnemonics: ['chat hook'],
+      llmInstructions: null,
+      embedding: null,
+      embeddingModel: null,
+      embeddingGeneratedAt: null,
+      createdAt: null,
+      updatedAt: new Date('2026-04-02T00:00:00.000Z'),
+      deletedAt: null,
+      metadata: null,
+      groups: [{ groupId: 'group-chat', groupName: 'Chat' }],
+    })),
+    getGroups: vi.fn(async () => [
+      {
+        userId: 'user-1',
+        languageId: 'zh',
+        groupId: 'group-chat',
+        groupName: 'Chat',
+        description: null,
+        embedding: null,
+        embeddingModel: null,
+        embeddingGeneratedAt: null,
+        createdAt: null,
+        metadata: null,
+      },
+    ]),
+  };
+
+  it('loads Card Library data with the active query/filter state and filtered ids', async () => {
+    const url = new URL('https://studypuck.test/zh/cards?q=chat&group=group-chat&type=pattern');
+
+    const result = await loadCardLibraryData('user-1', 'zh', url, database, baseDeps);
+
+    expect(result.filters).toEqual({
+      searchText: 'chat',
+      groupIds: ['group-chat'],
+      cardType: 'pattern',
+    });
+    expect(result.filteredCardIds).toEqual(['card-2']);
+    expect(baseDeps.listActiveCards).toHaveBeenCalledWith(
+      'user-1',
+      'zh',
+      {
+        search: 'chat',
+        groupIds: ['group-chat'],
+        cardType: 'pattern',
+      },
+      database,
+    );
+  });
+
+  it('loads group detail data with scoped filters and group summary', async () => {
+    const url = new URL('https://studypuck.test/zh/cards/groups/group-chat?q=chat&type=pattern');
+
+    const result = await loadGroupDetailData('user-1', 'zh', 'group-chat', url, database, baseDeps);
+
+    expect(result.group).toEqual({
+      groupId: 'group-chat',
+      groupName: 'Chat',
+      description: 'Conversation cards',
+      activeCardCount: 1,
+    });
+    expect(result.cards.filters).toEqual({
+      searchText: 'chat',
+      groupIds: [],
+      cardType: 'pattern',
+    });
+    expect(baseDeps.listActiveCardsInGroup).toHaveBeenCalledWith(
+      'user-1',
+      'zh',
+      'group-chat',
+      {
+        search: 'chat',
+        cardType: 'pattern',
+      },
+      database,
+    );
+  });
+
+  it('loads active card detail with available groups', async () => {
+    const result = await loadActiveCardDetailData('user-1', 'zh', 'card-2', database, baseDeps);
+
+    expect(result.card.examples).toEqual(['我们聊天吧。']);
+    expect(result.availableGroups).toEqual([{ groupId: 'group-chat', groupName: 'Chat' }]);
+  });
+
+  it('rejects invalid filter input before hitting the data layer', async () => {
+    const url = new URL('https://studypuck.test/zh/cards?type=invalid');
+
+    await expect(loadCardLibraryData('user-1', 'zh', url, database, baseDeps)).rejects.toMatchObject({
+      status: 400,
+    } satisfies Partial<CardLibraryRequestError>);
+  });
+
+  it('formats relative card timestamps using compact labels', () => {
+    expect(formatCardLibraryRelativeTime(new Date('2026-04-10T12:00:00Z'), new Date('2026-04-12T12:00:00Z'))).toBe('2d ago');
+  });
+});

--- a/apps/web/src/lib/server/cards.ts
+++ b/apps/web/src/lib/server/cards.ts
@@ -1,0 +1,593 @@
+import {
+  addCardToGroup,
+  bulkAssignActiveCardsToGroup,
+  createGroup,
+  getActiveCardWithGroups,
+  getActiveUserLanguages,
+  getDb,
+  getGroupWithActiveCardCount,
+  getGroups,
+  listActiveCards,
+  listActiveCardsInGroup,
+  listGroupsWithActiveCardCounts,
+  removeCardFromGroup,
+  softDeleteActiveCards,
+  updateActiveCard,
+  type ActiveCardDetail,
+  type ActiveCardGroupSummary,
+  type ActiveCardListItem,
+  type GroupWithActiveCardCount,
+  type SupportedCardType,
+} from '@studypuck/database';
+import {
+  cardEntryDraftCardUpdateSchema,
+  editableGroupNameSchema,
+} from '$lib/schemas/card-entry.js';
+import {
+  activeCardIdSchema,
+  activeCardTypeSchema,
+  activeGroupIdSchema,
+  cardLibraryFiltersSchema,
+  cardLibrarySearchSchema,
+} from '$lib/schemas/cards.js';
+
+type DatabaseClient = ReturnType<typeof getDb>;
+type ActiveCardUpdateInput = typeof cardEntryDraftCardUpdateSchema._output;
+
+type LoaderDeps = {
+  getActiveUserLanguages: typeof getActiveUserLanguages;
+  listActiveCards: typeof listActiveCards;
+  listGroupsWithActiveCardCounts: typeof listGroupsWithActiveCardCounts;
+  getGroupWithActiveCardCount: typeof getGroupWithActiveCardCount;
+  listActiveCardsInGroup: typeof listActiveCardsInGroup;
+  getActiveCardWithGroups: typeof getActiveCardWithGroups;
+  getGroups: typeof getGroups;
+};
+
+const defaultLoaderDeps: LoaderDeps = {
+  getActiveUserLanguages,
+  listActiveCards,
+  listGroupsWithActiveCardCounts,
+  getGroupWithActiveCardCount,
+  listActiveCardsInGroup,
+  getActiveCardWithGroups,
+  getGroups,
+};
+
+export class CardLibraryRequestError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'CardLibraryRequestError';
+    this.status = status;
+  }
+}
+
+export type CardLibraryGroupData = {
+  groupId: string;
+  groupName: string;
+};
+
+export type CardLibraryGroupFilterOption = CardLibraryGroupData & {
+  activeCardCount: number;
+};
+
+export type CardLibraryFilters = {
+  searchText: string;
+  groupIds: string[];
+  cardType: SupportedCardType | null;
+};
+
+export type CardLibraryCardListItemData = {
+  cardId: string;
+  content: string;
+  meaning: string | null;
+  cardType: string | null;
+  updatedAtIso: string | null;
+  updatedAtLabel: string;
+  groups: CardLibraryGroupData[];
+};
+
+export type CardLibraryCardDetailData = {
+  cardId: string;
+  content: string;
+  meaning: string | null;
+  cardType: string | null;
+  examples: string[];
+  mnemonics: string[];
+  llmInstructions: string | null;
+  updatedAtIso: string | null;
+  groups: CardLibraryGroupData[];
+};
+
+export type CardLibraryData = {
+  items: CardLibraryCardListItemData[];
+  totalCount: number;
+  filteredCardIds: string[];
+  filters: CardLibraryFilters;
+  availableGroups: CardLibraryGroupFilterOption[];
+};
+
+export type GroupDetailData = {
+  group: {
+    groupId: string;
+    groupName: string;
+    description: string | null;
+    activeCardCount: number;
+  };
+  cards: CardLibraryData;
+};
+
+function normalizeStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+}
+
+function createGroupId(): string {
+  return `group-${globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`}`;
+}
+
+async function assertUserHasLanguage(
+  userId: string,
+  languageId: string,
+  database: DatabaseClient,
+  deps: Pick<LoaderDeps, 'getActiveUserLanguages'> = defaultLoaderDeps,
+): Promise<void> {
+  const activeLanguages = await deps.getActiveUserLanguages(userId, database as never);
+  const languageExists = activeLanguages.some((language) => language.languageId === languageId);
+
+  if (!languageExists) {
+    throw new CardLibraryRequestError(404, 'That language is not available for this user.');
+  }
+}
+
+function parseCardId(cardId: unknown): string {
+  const parsed = activeCardIdSchema.safeParse(typeof cardId === 'string' ? cardId : '');
+
+  if (!parsed.success) {
+    throw new CardLibraryRequestError(400, parsed.error.issues[0]?.message ?? 'Card identifier is invalid.');
+  }
+
+  return parsed.data;
+}
+
+function parseGroupId(groupId: unknown): string {
+  const parsed = activeGroupIdSchema.safeParse(typeof groupId === 'string' ? groupId : '');
+
+  if (!parsed.success) {
+    throw new CardLibraryRequestError(400, parsed.error.issues[0]?.message ?? 'Group identifier is invalid.');
+  }
+
+  return parsed.data;
+}
+
+function parseCardIds(cardIds: unknown): string[] {
+  if (!Array.isArray(cardIds)) {
+    throw new CardLibraryRequestError(400, 'At least one card must be selected.');
+  }
+
+  const parsedCardIds = [...new Set(cardIds.map((cardId) => parseCardId(cardId)))];
+
+  if (parsedCardIds.length === 0) {
+    throw new CardLibraryRequestError(400, 'At least one card must be selected.');
+  }
+
+  return parsedCardIds;
+}
+
+function parseFilters(url: URL): CardLibraryFilters {
+  const searchText = cardLibrarySearchSchema.parse(url.searchParams.get('q') ?? '');
+  const groupIds = [...new Set(url.searchParams.getAll('group').map((groupId) => groupId.trim()).filter(Boolean))];
+  const rawCardType = url.searchParams.get('type');
+  let parsedCardType: SupportedCardType | null = null;
+
+  if (rawCardType !== null && rawCardType.trim().length > 0) {
+    const cardTypeResult = activeCardTypeSchema.safeParse(rawCardType);
+
+    if (!cardTypeResult.success) {
+      throw new CardLibraryRequestError(
+        400,
+        cardTypeResult.error.issues[0]?.message ?? 'Card type filter is invalid.',
+      );
+    }
+
+    parsedCardType = cardTypeResult.data;
+  }
+
+  const parsed = cardLibraryFiltersSchema.safeParse({
+    searchText,
+    groupIds,
+    cardType: parsedCardType,
+  });
+
+  if (!parsed.success) {
+    throw new CardLibraryRequestError(400, parsed.error.issues[0]?.message ?? 'Card Library filters are invalid.');
+  }
+
+  return parsed.data;
+}
+
+export function formatCardLibraryRelativeTime(date: Date, now = new Date()): string {
+  const differenceInSeconds = Math.max(0, Math.floor((now.getTime() - date.getTime()) / 1_000));
+
+  if (differenceInSeconds < 60) {
+    return 'Just now';
+  }
+
+  const differenceInMinutes = Math.floor(differenceInSeconds / 60);
+
+  if (differenceInMinutes < 60) {
+    return `${differenceInMinutes}m ago`;
+  }
+
+  const differenceInHours = Math.floor(differenceInMinutes / 60);
+
+  if (differenceInHours < 24) {
+    return `${differenceInHours}h ago`;
+  }
+
+  const differenceInDays = Math.floor(differenceInHours / 24);
+
+  if (differenceInDays < 7) {
+    return `${differenceInDays}d ago`;
+  }
+
+  const differenceInWeeks = Math.floor(differenceInDays / 7);
+
+  if (differenceInWeeks < 5) {
+    return `${differenceInWeeks}w ago`;
+  }
+
+  const differenceInMonths = Math.floor(differenceInDays / 30);
+
+  if (differenceInMonths < 12) {
+    return `${differenceInMonths}mo ago`;
+  }
+
+  const differenceInYears = Math.floor(differenceInDays / 365);
+  return `${differenceInYears}y ago`;
+}
+
+function mapGroupSummary(group: ActiveCardGroupSummary): CardLibraryGroupData {
+  return {
+    groupId: group.groupId,
+    groupName: group.groupName,
+  };
+}
+
+function mapGroupFilterOption(group: GroupWithActiveCardCount): CardLibraryGroupFilterOption {
+  return {
+    groupId: group.groupId,
+    groupName: group.groupName,
+    activeCardCount: group.activeCardCount,
+  };
+}
+
+function mapCardListItem(card: ActiveCardListItem, now = new Date()): CardLibraryCardListItemData {
+  return {
+    cardId: card.cardId,
+    content: card.content,
+    meaning: card.meaning,
+    cardType: card.cardType,
+    updatedAtIso: card.updatedAt?.toISOString() ?? null,
+    updatedAtLabel: card.updatedAt ? formatCardLibraryRelativeTime(card.updatedAt, now) : 'Never',
+    groups: card.groups.map((group) => mapGroupSummary(group)),
+  };
+}
+
+function mapActiveCardDetail(card: ActiveCardDetail): CardLibraryCardDetailData {
+  return {
+    cardId: card.cardId,
+    content: card.content,
+    meaning: card.meaning,
+    cardType: card.cardType,
+    examples: normalizeStringList(card.examples),
+    mnemonics: normalizeStringList(card.mnemonics),
+    llmInstructions: card.llmInstructions ?? null,
+    updatedAtIso: card.updatedAt?.toISOString() ?? null,
+    groups: card.groups.map((group) => mapGroupSummary(group)),
+  };
+}
+
+async function resolveGroupSelections(
+  userId: string,
+  languageId: string,
+  selections: ActiveCardUpdateInput['groups'],
+  database: DatabaseClient,
+): Promise<CardLibraryGroupData[]> {
+  const existingGroups = await getGroups(userId, languageId, database as never);
+  const groupsById = new Map(existingGroups.map((group) => [group.groupId, group]));
+  const groupsByNormalizedName = new Map(
+    existingGroups.map((group) => [group.groupName.trim().toLocaleLowerCase(), group]),
+  );
+  const resolvedGroups = new Map<string, CardLibraryGroupData>();
+
+  for (const selection of selections) {
+    const normalizedName = selection.groupName.trim().toLocaleLowerCase();
+    const explicitGroupId = selection.groupId?.trim() || null;
+
+    if (explicitGroupId) {
+      const explicitGroup = groupsById.get(explicitGroupId);
+
+      if (!explicitGroup) {
+        throw new CardLibraryRequestError(404, 'One of the selected groups no longer exists.');
+      }
+
+      resolvedGroups.set(explicitGroup.groupId, mapGroupSummary(explicitGroup));
+      continue;
+    }
+
+    const existingGroup = groupsByNormalizedName.get(normalizedName);
+
+    if (existingGroup) {
+      resolvedGroups.set(existingGroup.groupId, mapGroupSummary(existingGroup));
+      continue;
+    }
+
+    const parsedGroupName = editableGroupNameSchema.safeParse(selection.groupName);
+
+    if (!parsedGroupName.success) {
+      throw new CardLibraryRequestError(
+        400,
+        parsedGroupName.error.issues[0]?.message ?? 'Group name is invalid.',
+      );
+    }
+
+    const createdGroup = await createGroup(
+      {
+        userId,
+        languageId,
+        groupId: createGroupId(),
+        groupName: parsedGroupName.data,
+      },
+      database as never,
+    );
+
+    groupsById.set(createdGroup.groupId, createdGroup);
+    groupsByNormalizedName.set(createdGroup.groupName.trim().toLocaleLowerCase(), createdGroup);
+    resolvedGroups.set(createdGroup.groupId, mapGroupSummary(createdGroup));
+  }
+
+  return Array.from(resolvedGroups.values()).sort((left, right) => left.groupName.localeCompare(right.groupName));
+}
+
+async function syncActiveCardGroups(
+  userId: string,
+  languageId: string,
+  cardId: string,
+  nextGroups: CardLibraryGroupData[],
+  database: DatabaseClient,
+) {
+  const activeCard = await getActiveCardWithGroups(userId, languageId, cardId, database as never);
+
+  if (!activeCard) {
+    throw new CardLibraryRequestError(404, 'Active card not found.');
+  }
+
+  const currentGroupIds = new Set(activeCard.groups.map((group) => group.groupId));
+  const nextGroupIds = new Set(nextGroups.map((group) => group.groupId));
+
+  for (const group of nextGroups) {
+    if (!currentGroupIds.has(group.groupId)) {
+      await addCardToGroup(
+        {
+          userId,
+          languageId,
+          cardId,
+          groupId: group.groupId,
+        },
+        database as never,
+      );
+    }
+  }
+
+  for (const group of activeCard.groups) {
+    if (!nextGroupIds.has(group.groupId)) {
+      await removeCardFromGroup(userId, languageId, cardId, group.groupId, database as never);
+    }
+  }
+}
+
+export async function loadCardLibraryData(
+  userId: string,
+  languageId: string,
+  url: URL,
+  database: DatabaseClient,
+  deps: LoaderDeps = defaultLoaderDeps,
+): Promise<CardLibraryData> {
+  await assertUserHasLanguage(userId, languageId, database, deps);
+
+  const filters = parseFilters(url);
+  const [items, availableGroups] = await Promise.all([
+    deps.listActiveCards(
+      userId,
+      languageId,
+      {
+        search: filters.searchText,
+        groupIds: filters.groupIds,
+        cardType: filters.cardType,
+      },
+      database as never,
+    ),
+    deps.listGroupsWithActiveCardCounts(userId, languageId, database as never),
+  ]);
+
+  return {
+    items: items.map((item) => mapCardListItem(item)),
+    totalCount: items.length,
+    filteredCardIds: items.map((item) => item.cardId),
+    filters,
+    availableGroups: availableGroups.map((group) => mapGroupFilterOption(group)),
+  };
+}
+
+export async function loadGroupDetailData(
+  userId: string,
+  languageId: string,
+  groupId: unknown,
+  url: URL,
+  database: DatabaseClient,
+  deps: LoaderDeps = defaultLoaderDeps,
+): Promise<GroupDetailData> {
+  await assertUserHasLanguage(userId, languageId, database, deps);
+
+  const parsedGroupId = parseGroupId(groupId);
+  const filters = parseFilters(url);
+  const [group, items, availableGroups] = await Promise.all([
+    deps.getGroupWithActiveCardCount(userId, languageId, parsedGroupId, database as never),
+    deps.listActiveCardsInGroup(
+      userId,
+      languageId,
+      parsedGroupId,
+      {
+        search: filters.searchText,
+        cardType: filters.cardType,
+      },
+      database as never,
+    ),
+    deps.listGroupsWithActiveCardCounts(userId, languageId, database as never),
+  ]);
+
+  if (!group) {
+    throw new CardLibraryRequestError(404, 'Group not found.');
+  }
+
+  return {
+    group: {
+      groupId: group.groupId,
+      groupName: group.groupName,
+      description: group.description ?? null,
+      activeCardCount: group.activeCardCount,
+    },
+    cards: {
+      items: items.map((item) => mapCardListItem(item)),
+      totalCount: items.length,
+      filteredCardIds: items.map((item) => item.cardId),
+      filters,
+      availableGroups: availableGroups.map((availableGroup) => mapGroupFilterOption(availableGroup)),
+    },
+  };
+}
+
+export async function loadActiveCardDetailData(
+  userId: string,
+  languageId: string,
+  cardId: unknown,
+  database: DatabaseClient,
+  deps: LoaderDeps = defaultLoaderDeps,
+): Promise<{
+  card: CardLibraryCardDetailData;
+  availableGroups: CardLibraryGroupData[];
+}> {
+  await assertUserHasLanguage(userId, languageId, database, deps);
+
+  const parsedCardId = parseCardId(cardId);
+  const [card, availableGroups] = await Promise.all([
+    deps.getActiveCardWithGroups(userId, languageId, parsedCardId, database as never),
+    deps.getGroups(userId, languageId, database as never),
+  ]);
+
+  if (!card) {
+    throw new CardLibraryRequestError(404, 'Active card not found.');
+  }
+
+  return {
+    card: mapActiveCardDetail(card),
+    availableGroups: availableGroups.map((group) => mapGroupSummary(group)),
+  };
+}
+
+export async function updateCardLibraryCardForLanguage(
+  userId: string,
+  languageId: string,
+  cardId: unknown,
+  input: unknown,
+  database: DatabaseClient,
+) {
+  await assertUserHasLanguage(userId, languageId, database);
+
+  const parsedCardId = parseCardId(cardId);
+  const parsedInput = cardEntryDraftCardUpdateSchema.safeParse(input);
+
+  if (!parsedInput.success) {
+    throw new CardLibraryRequestError(
+      400,
+      parsedInput.error.issues[0]?.message ?? 'Active card update is invalid.',
+    );
+  }
+
+  const resolvedGroups = await resolveGroupSelections(
+    userId,
+    languageId,
+    parsedInput.data.groups,
+    database,
+  );
+
+  const updatedCard = await updateActiveCard(
+    userId,
+    languageId,
+    parsedCardId,
+    {
+      content: parsedInput.data.content,
+      meaning: parsedInput.data.meaning,
+      examples: parsedInput.data.examples,
+      mnemonics: parsedInput.data.mnemonics,
+      llmInstructions: parsedInput.data.llmInstructions,
+    },
+    database as never,
+  );
+
+  if (!updatedCard) {
+    throw new CardLibraryRequestError(404, 'Active card not found.');
+  }
+
+  await syncActiveCardGroups(userId, languageId, parsedCardId, resolvedGroups, database);
+
+  return loadActiveCardDetailData(userId, languageId, parsedCardId, database);
+}
+
+export async function bulkAssignCardLibraryCardsToGroupForLanguage(
+  userId: string,
+  languageId: string,
+  cardIds: unknown,
+  groupId: unknown,
+  database: DatabaseClient,
+) {
+  await assertUserHasLanguage(userId, languageId, database);
+
+  const parsedCardIds = parseCardIds(cardIds);
+  const parsedGroupId = parseGroupId(groupId);
+  const group = await getGroupWithActiveCardCount(userId, languageId, parsedGroupId, database as never);
+
+  if (!group) {
+    throw new CardLibraryRequestError(404, 'Group not found.');
+  }
+
+  return bulkAssignActiveCardsToGroup(
+    userId,
+    languageId,
+    parsedCardIds,
+    parsedGroupId,
+    database as never,
+  );
+}
+
+export async function deleteCardLibraryCardsForLanguage(
+  userId: string,
+  languageId: string,
+  cardIds: unknown,
+  database: DatabaseClient,
+) {
+  await assertUserHasLanguage(userId, languageId, database);
+
+  return softDeleteActiveCards(
+    userId,
+    languageId,
+    parseCardIds(cardIds),
+    database as never,
+  );
+}

--- a/apps/web/src/routes/[lang]/cards/+page.server.ts
+++ b/apps/web/src/routes/[lang]/cards/+page.server.ts
@@ -1,0 +1,20 @@
+import { redirect } from '@sveltejs/kit';
+import { getDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import { loadCardLibraryData } from '$lib/server/cards.js';
+import type { PageServerLoad } from './$types.js';
+
+export const load: PageServerLoad = async (event) => {
+  const { session } = await event.parent();
+  const languageCode = event.params.lang;
+
+  if (!session?.user?.id || !languageCode) {
+    throw redirect(303, '/');
+  }
+
+  const database = getDb(env.DATABASE_URL);
+
+  return {
+    library: await loadCardLibraryData(session.user.id, languageCode, event.url, database),
+  };
+};

--- a/apps/web/src/routes/[lang]/cards/groups/[groupId]/+page.server.ts
+++ b/apps/web/src/routes/[lang]/cards/groups/[groupId]/+page.server.ts
@@ -1,0 +1,29 @@
+import { error, redirect } from '@sveltejs/kit';
+import { getDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import { CardLibraryRequestError, loadGroupDetailData } from '$lib/server/cards.js';
+import type { PageServerLoad } from './$types.js';
+
+export const load: PageServerLoad = async (event) => {
+  const { session } = await event.parent();
+  const languageCode = event.params.lang;
+  const groupId = event.params.groupId;
+
+  if (!session?.user?.id || !languageCode || !groupId) {
+    throw redirect(303, '/');
+  }
+
+  const database = getDb(env.DATABASE_URL);
+
+  try {
+    return {
+      groupDetail: await loadGroupDetailData(session.user.id, languageCode, groupId, event.url, database),
+    };
+  } catch (requestError) {
+    if (requestError instanceof CardLibraryRequestError) {
+      throw error(requestError.status, requestError.message);
+    }
+
+    throw requestError;
+  }
+};

--- a/apps/web/src/routes/[lang]/cards/groups/[groupId]/+page.svelte
+++ b/apps/web/src/routes/[lang]/cards/groups/[groupId]/+page.svelte
@@ -1,0 +1,31 @@
+<svelte:head>
+  <title>Group Detail – StudyPuck</title>
+</svelte:head>
+
+<section class="center stack app-screen" style="--stack-space: var(--space-5)">
+  <header class="stack" style="--stack-space: var(--space-2)">
+    <p class="screen-eyebrow text-muted">Cards</p>
+    <h1>{data.groupDetail.group.groupName}</h1>
+    <p>This placeholder route keeps the future Group Detail loader wired while the full surface is built.</p>
+  </header>
+</section>
+
+<script lang="ts">
+  import type { PageData } from './$types.js';
+
+  let { data }: { data: PageData } = $props();
+</script>
+
+<style>
+  .app-screen {
+    --center-max: 60rem;
+    padding-inline: var(--space-5);
+  }
+
+  .screen-eyebrow {
+    font-family: var(--font-ui);
+    font-size: var(--font-size-ui);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
+  }
+</style>

--- a/packages/database/src/cards.ts
+++ b/packages/database/src/cards.ts
@@ -11,8 +11,104 @@ import { cards, groups, cardGroups, type Card, type NewCard, type Group, type Ne
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyDb = PgDatabase<any, any, any>;
 
+export type SupportedCardType = 'word' | 'pattern' | 'complex_prompt';
+
+export type ActiveCardGroupSummary = Pick<Group, 'groupId' | 'groupName'>;
+
+export type ActiveCardFilters = {
+  search?: string;
+  groupIds?: string[];
+  cardType?: SupportedCardType | null;
+  limit?: number;
+  offset?: number;
+};
+
+export type ActiveCardListItem = Pick<Card, 'cardId' | 'content' | 'meaning' | 'cardType' | 'updatedAt'> & {
+  groups: ActiveCardGroupSummary[];
+};
+
+export type ActiveCardDetail = Card & {
+  groups: ActiveCardGroupSummary[];
+};
+
+export type GroupWithActiveCardCount = Group & {
+  activeCardCount: number;
+};
+
 function getConn(database?: AnyDb) {
   return database ?? (db as AnyDb);
+}
+
+function normalizeSearchTerm(search?: string | null): string | null {
+  const trimmed = search?.trim() ?? '';
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeGroupIds(groupIds?: string[] | null): string[] {
+  return [...new Set((groupIds ?? []).map((groupId) => groupId.trim()).filter(Boolean))];
+}
+
+function mapGroupSummary(group: Pick<Group, 'groupId' | 'groupName'>): ActiveCardGroupSummary {
+  return {
+    groupId: group.groupId,
+    groupName: group.groupName,
+  };
+}
+
+function escapeLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, '\\$&');
+}
+
+function buildSearchCondition(search: string) {
+  const likeQuery = `%${escapeLikePattern(search)}%`;
+
+  return sql`(
+    ${cards.content} ILIKE ${likeQuery} ESCAPE '\'
+    OR COALESCE(${cards.meaning}, '') ILIKE ${likeQuery} ESCAPE '\'
+    OR COALESCE(${cards.examples}::text, '') ILIKE ${likeQuery} ESCAPE '\'
+    OR COALESCE(${cards.mnemonics}::text, '') ILIKE ${likeQuery} ESCAPE '\'
+  )`;
+}
+
+async function findCardIdsInAnyGroup(
+  userId: string,
+  languageId: string,
+  groupIds: string[],
+  database?: AnyDb,
+): Promise<string[]> {
+  if (groupIds.length === 0) {
+    return [];
+  }
+
+  const rows = await getConn(database)
+    .select({ cardId: cardGroups.cardId })
+    .from(cardGroups)
+    .where(and(
+      eq(cardGroups.userId, userId),
+      eq(cardGroups.languageId, languageId),
+      inArray(cardGroups.groupId, groupIds),
+    ));
+
+  return [...new Set(rows.map((row) => row.cardId))];
+}
+
+async function attachGroupsToCards(
+  userId: string,
+  languageId: string,
+  rows: Array<Pick<Card, 'cardId' | 'content' | 'meaning' | 'cardType' | 'updatedAt'>>,
+  database?: AnyDb,
+): Promise<ActiveCardListItem[]> {
+  const groupsByCardId = await getCardGroupsForCards(
+    userId,
+    languageId,
+    rows.map((row) => row.cardId),
+    database,
+  );
+
+  return rows.map((row) => ({
+    ...row,
+    groups: (groupsByCardId.get(row.cardId) ?? []).map((group) => mapGroupSummary(group)),
+  }));
 }
 
 // === Card Operations ===
@@ -475,4 +571,284 @@ export async function getCardGroupsForCards(
   }
 
   return groupsByCardId;
+}
+
+export async function listActiveCards(
+  userId: string,
+  languageId: string,
+  filters: ActiveCardFilters = {},
+  database?: AnyDb,
+): Promise<ActiveCardListItem[]> {
+  const conn = getConn(database);
+  const search = normalizeSearchTerm(filters.search);
+  const groupIds = normalizeGroupIds(filters.groupIds);
+  const matchingCardIds = groupIds.length > 0
+    ? await findCardIdsInAnyGroup(userId, languageId, groupIds, database)
+    : null;
+
+  if (matchingCardIds !== null && matchingCardIds.length === 0) {
+    return [];
+  }
+
+  const conditions = [
+    eq(cards.userId, userId),
+    eq(cards.languageId, languageId),
+    eq(cards.status, 'active'),
+  ];
+
+  if (search) {
+    conditions.push(buildSearchCondition(search));
+  }
+
+  if (filters.cardType) {
+    conditions.push(eq(cards.cardType, filters.cardType));
+  }
+
+  if (matchingCardIds !== null) {
+    conditions.push(inArray(cards.cardId, matchingCardIds));
+  }
+
+  const baseQuery = conn
+    .select({
+      cardId: cards.cardId,
+      content: cards.content,
+      meaning: cards.meaning,
+      cardType: cards.cardType,
+      updatedAt: cards.updatedAt,
+    })
+    .from(cards)
+    .where(and(...conditions))
+    .orderBy(desc(cards.updatedAt));
+
+  let rows: Awaited<typeof baseQuery>;
+
+  if (typeof filters.offset === 'number' && typeof filters.limit === 'number') {
+    rows = await baseQuery.offset(filters.offset).limit(filters.limit);
+  } else if (typeof filters.offset === 'number') {
+    rows = await baseQuery.offset(filters.offset);
+  } else if (typeof filters.limit === 'number') {
+    rows = await baseQuery.limit(filters.limit);
+  } else {
+    rows = await baseQuery;
+  }
+
+  return attachGroupsToCards(userId, languageId, rows, database);
+}
+
+export async function listActiveCardsInGroup(
+  userId: string,
+  languageId: string,
+  groupId: string,
+  filters: Omit<ActiveCardFilters, 'groupIds'> = {},
+  database?: AnyDb,
+): Promise<ActiveCardListItem[]> {
+  return listActiveCards(
+    userId,
+    languageId,
+    {
+      ...filters,
+      groupIds: [groupId],
+    },
+    database,
+  );
+}
+
+export async function getActiveCardWithGroups(
+  userId: string,
+  languageId: string,
+  cardId: string,
+  database?: AnyDb,
+): Promise<ActiveCardDetail | null> {
+  const result = await getConn(database)
+    .select()
+    .from(cards)
+    .where(and(
+      eq(cards.userId, userId),
+      eq(cards.languageId, languageId),
+      eq(cards.cardId, cardId),
+      eq(cards.status, 'active'),
+    ))
+    .limit(1);
+
+  const card = result[0] ?? null;
+
+  if (!card) {
+    return null;
+  }
+
+  const groups = await getCardGroups(userId, languageId, cardId, database);
+
+  return {
+    ...card,
+    groups: groups.map((group) => mapGroupSummary(group)),
+  };
+}
+
+export async function updateActiveCard(
+  userId: string,
+  languageId: string,
+  cardId: string,
+  updates: Partial<Omit<NewCard, 'userId' | 'languageId' | 'cardId' | 'status'>>,
+  database?: AnyDb,
+): Promise<Card | null> {
+  const result = await getConn(database)
+    .update(cards)
+    .set({
+      ...updates,
+      updatedAt: new Date(),
+    })
+    .where(and(
+      eq(cards.userId, userId),
+      eq(cards.languageId, languageId),
+      eq(cards.cardId, cardId),
+      eq(cards.status, 'active'),
+    ))
+    .returning();
+
+  return result[0] ?? null;
+}
+
+export async function softDeleteActiveCards(
+  userId: string,
+  languageId: string,
+  cardIds: string[],
+  database?: AnyDb,
+): Promise<string[]> {
+  const normalizedCardIds = [...new Set(cardIds.map((cardId) => cardId.trim()).filter(Boolean))];
+
+  if (normalizedCardIds.length === 0) {
+    return [];
+  }
+
+  const now = new Date();
+  const deletedCards = await getConn(database)
+    .update(cards)
+    .set({
+      status: 'deleted',
+      deletedAt: now,
+      updatedAt: now,
+    })
+    .where(and(
+      eq(cards.userId, userId),
+      eq(cards.languageId, languageId),
+      eq(cards.status, 'active'),
+      inArray(cards.cardId, normalizedCardIds),
+    ))
+    .returning({ cardId: cards.cardId });
+
+  return deletedCards.map((card) => card.cardId);
+}
+
+export async function bulkAssignActiveCardsToGroup(
+  userId: string,
+  languageId: string,
+  cardIds: string[],
+  groupId: string,
+  database?: AnyDb,
+): Promise<string[]> {
+  const normalizedCardIds = [...new Set(cardIds.map((cardId) => cardId.trim()).filter(Boolean))];
+
+  if (normalizedCardIds.length === 0) {
+    return [];
+  }
+
+  const activeCards = await getConn(database)
+    .select({ cardId: cards.cardId })
+    .from(cards)
+    .where(and(
+      eq(cards.userId, userId),
+      eq(cards.languageId, languageId),
+      eq(cards.status, 'active'),
+      inArray(cards.cardId, normalizedCardIds),
+    ));
+
+  const activeCardIds = activeCards.map((card) => card.cardId);
+
+  if (activeCardIds.length === 0) {
+    return [];
+  }
+
+  await getConn(database)
+    .insert(cardGroups)
+    .values(
+      activeCardIds.map((cardId) => ({
+        userId,
+        languageId,
+        cardId,
+        groupId,
+        assignedAt: new Date(),
+      })),
+    )
+    .onConflictDoNothing();
+
+  return activeCardIds;
+}
+
+export async function listGroupsWithActiveCardCounts(
+  userId: string,
+  languageId: string,
+  database?: AnyDb,
+): Promise<GroupWithActiveCardCount[]> {
+  const [allGroups, countRows] = await Promise.all([
+    getGroups(userId, languageId, database),
+    getConn(database)
+      .select({
+        groupId: cardGroups.groupId,
+        activeCardCount: sql<number>`cast(count(*) as integer)`,
+      })
+      .from(cardGroups)
+      .innerJoin(cards, and(
+        eq(cards.userId, cardGroups.userId),
+        eq(cards.languageId, cardGroups.languageId),
+        eq(cards.cardId, cardGroups.cardId),
+      ))
+      .where(and(
+        eq(cardGroups.userId, userId),
+        eq(cardGroups.languageId, languageId),
+        eq(cards.status, 'active'),
+      ))
+      .groupBy(cardGroups.groupId),
+  ]);
+
+  const countsByGroupId = new Map(countRows.map((row) => [row.groupId, row.activeCardCount]));
+
+  return allGroups.map((group) => ({
+    ...group,
+    activeCardCount: countsByGroupId.get(group.groupId) ?? 0,
+  }));
+}
+
+export async function getGroupWithActiveCardCount(
+  userId: string,
+  languageId: string,
+  groupId: string,
+  database?: AnyDb,
+): Promise<GroupWithActiveCardCount | null> {
+  const group = await getGroup(userId, languageId, groupId, database);
+
+  if (!group) {
+    return null;
+  }
+
+  const [countRow] = await getConn(database)
+    .select({
+      activeCardCount: sql<number>`cast(count(*) as integer)`,
+    })
+    .from(cardGroups)
+    .innerJoin(cards, and(
+      eq(cards.userId, cardGroups.userId),
+      eq(cards.languageId, cardGroups.languageId),
+      eq(cards.cardId, cardGroups.cardId),
+    ))
+    .where(and(
+      eq(cardGroups.userId, userId),
+      eq(cardGroups.languageId, languageId),
+      eq(cardGroups.groupId, groupId),
+      eq(cards.status, 'active'),
+    ));
+
+  return {
+    ...group,
+    activeCardCount: countRow?.activeCardCount ?? 0,
+  };
 }

--- a/packages/database/src/tests/cards.test.ts
+++ b/packages/database/src/tests/cards.test.ts
@@ -1,0 +1,305 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import postgres from 'postgres';
+import { eq } from 'drizzle-orm';
+import { setupTestDatabase, cleanupTestDatabase, resetTestTables, type TestDb } from '../test-utils.js';
+import { cardGroups, cards, groups, studyLanguages, users } from '../schema.js';
+import {
+  bulkAssignActiveCardsToGroup,
+  getActiveCardWithGroups,
+  getGroupWithActiveCardCount,
+  listActiveCards,
+  listActiveCardsInGroup,
+  listGroupsWithActiveCardCounts,
+  softDeleteActiveCards,
+  updateActiveCard,
+} from '../cards.js';
+
+const TEST_USER = { userId: 'auth0|cards-user', email: 'cards@example.com' };
+const TEST_LANG = { userId: TEST_USER.userId, languageId: 'zh', languageName: 'Chinese' };
+
+describe('Card Library database operations', () => {
+  let db: TestDb;
+  let sql: ReturnType<typeof postgres>;
+
+  beforeAll(async () => {
+    ({ db, sql } = await setupTestDatabase());
+  });
+
+  afterAll(async () => {
+    if (sql) {
+      await cleanupTestDatabase(sql);
+    }
+  });
+
+  beforeEach(async () => {
+    await resetTestTables(db);
+    await db.insert(users).values(TEST_USER);
+    await db.insert(studyLanguages).values(TEST_LANG);
+  });
+
+  async function seedLibrary() {
+    await db.insert(groups).values([
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        groupId: 'group-greetings',
+        groupName: 'Greetings',
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        groupId: 'group-food',
+        groupName: 'Food',
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        groupId: 'group-chat',
+        groupName: 'Chat',
+      },
+    ]);
+
+    await db.insert(cards).values([
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-content',
+        content: '谈论',
+        status: 'active',
+        cardType: 'word',
+        meaning: 'to discuss',
+        updatedAt: new Date('2026-04-01T00:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-meaning',
+        content: '聊天',
+        status: 'active',
+        cardType: 'pattern',
+        meaning: 'to chat casually',
+        updatedAt: new Date('2026-04-02T00:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-examples',
+        content: '吃饭',
+        status: 'active',
+        cardType: 'word',
+        examples: ['我们一起吃饭。'],
+        updatedAt: new Date('2026-04-03T00:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-mnemonics',
+        content: '东西 vs 事情',
+        status: 'active',
+        cardType: 'complex_prompt',
+        mnemonics: ['Food memory hook'],
+        updatedAt: new Date('2026-04-04T00:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-wildcards',
+        content: '100% 确定',
+        status: 'active',
+        cardType: 'pattern',
+        meaning: 'contains_under_score',
+        examples: ['Use \\ literally here.'],
+        updatedAt: new Date('2026-04-04T12:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-draft',
+        content: '草稿',
+        status: 'draft',
+        updatedAt: new Date('2026-04-05T00:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-deleted',
+        content: '已删除',
+        status: 'deleted',
+        deletedAt: new Date('2026-04-06T00:00:00.000Z'),
+        updatedAt: new Date('2026-04-06T00:00:00.000Z'),
+      },
+    ]);
+
+    await db.insert(cardGroups).values([
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-content',
+        groupId: 'group-greetings',
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-meaning',
+        groupId: 'group-chat',
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-examples',
+        groupId: 'group-food',
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-draft',
+        groupId: 'group-greetings',
+      },
+    ]);
+  }
+
+  it('lists only active cards in last-modified-desc order and searches across all study fields', async () => {
+    await seedLibrary();
+
+    const allCards = await listActiveCards(TEST_USER.userId, TEST_LANG.languageId, {}, db);
+    const meaningMatch = await listActiveCards(TEST_USER.userId, TEST_LANG.languageId, { search: 'casually' }, db);
+    const exampleMatch = await listActiveCards(TEST_USER.userId, TEST_LANG.languageId, { search: '一起吃饭' }, db);
+    const mnemonicMatch = await listActiveCards(TEST_USER.userId, TEST_LANG.languageId, { search: 'memory hook' }, db);
+
+    expect(allCards.map((card) => card.cardId)).toEqual([
+      'card-wildcards',
+      'card-mnemonics',
+      'card-examples',
+      'card-meaning',
+      'card-content',
+    ]);
+    expect(meaningMatch.map((card) => card.cardId)).toEqual(['card-meaning']);
+    expect(exampleMatch.map((card) => card.cardId)).toEqual(['card-examples']);
+    expect(mnemonicMatch.map((card) => card.cardId)).toEqual(['card-mnemonics']);
+    expect(allCards.every((card) => card.cardId !== 'card-draft' && card.cardId !== 'card-deleted')).toBe(true);
+  });
+
+  it('treats SQL LIKE wildcard characters as literal search input', async () => {
+    await seedLibrary();
+
+    const percentMatch = await listActiveCards(TEST_USER.userId, TEST_LANG.languageId, { search: '%' }, db);
+    const underscoreMatch = await listActiveCards(TEST_USER.userId, TEST_LANG.languageId, { search: '_' }, db);
+    const slashMatch = await listActiveCards(TEST_USER.userId, TEST_LANG.languageId, { search: '\\' }, db);
+
+    expect(percentMatch.map((card) => card.cardId)).toEqual(['card-wildcards']);
+    expect(underscoreMatch.map((card) => card.cardId)).toEqual(['card-wildcards']);
+    expect(slashMatch.map((card) => card.cardId)).toEqual(['card-wildcards']);
+  });
+
+  it('supports OR group filtering, card type filtering, and scoped group detail lists', async () => {
+    await seedLibrary();
+
+    const groupedCards = await listActiveCards(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      { groupIds: ['group-greetings', 'group-food'] },
+      db,
+    );
+    const typedCards = await listActiveCards(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      { cardType: 'word' },
+      db,
+    );
+    const foodCards = await listActiveCardsInGroup(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      'group-food',
+      { search: '吃饭' },
+      db,
+    );
+
+    expect(groupedCards.map((card) => card.cardId)).toEqual(['card-examples', 'card-content']);
+    expect(typedCards.map((card) => card.cardId)).toEqual(['card-examples', 'card-content']);
+    expect(foodCards.map((card) => card.cardId)).toEqual(['card-examples']);
+  });
+
+  it('loads active card detail with groups and excludes non-active cards', async () => {
+    await seedLibrary();
+
+    const activeCard = await getActiveCardWithGroups(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      'card-content',
+      db,
+    );
+    const draftCard = await getActiveCardWithGroups(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      'card-draft',
+      db,
+    );
+
+    expect(activeCard?.cardId).toBe('card-content');
+    expect(activeCard?.groups).toEqual([{ groupId: 'group-greetings', groupName: 'Greetings' }]);
+    expect(draftCard).toBeNull();
+  });
+
+  it('reports group counts using only active cards', async () => {
+    await seedLibrary();
+
+    const groupSummaries = await listGroupsWithActiveCardCounts(TEST_USER.userId, TEST_LANG.languageId, db);
+    const greetings = await getGroupWithActiveCardCount(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      'group-greetings',
+      db,
+    );
+
+    expect(groupSummaries.map((group) => [group.groupId, group.activeCardCount])).toEqual([
+      ['group-chat', 1],
+      ['group-food', 1],
+      ['group-greetings', 1],
+    ]);
+    expect(greetings?.activeCardCount).toBe(1);
+  });
+
+  it('updates active cards, bulk-assigns memberships, and soft-deletes only active cards', async () => {
+    await seedLibrary();
+
+    const updated = await updateActiveCard(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      'card-content',
+      { meaning: 'to talk over' },
+      db,
+    );
+    const assignedCardIds = await bulkAssignActiveCardsToGroup(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      ['card-content', 'card-deleted'],
+      'group-food',
+      db,
+    );
+    const deletedCardIds = await softDeleteActiveCards(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      ['card-content', 'card-meaning', 'card-deleted'],
+      db,
+    );
+
+    const [storedContentCard] = await db
+      .select()
+      .from(cards)
+      .where(eq(cards.cardId, 'card-content'));
+    const foodCards = await listActiveCardsInGroup(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      'group-food',
+      {},
+      db,
+    );
+
+    expect(updated?.meaning).toBe('to talk over');
+    expect(assignedCardIds).toEqual(['card-content']);
+    expect(deletedCardIds).toEqual(['card-content', 'card-meaning']);
+    expect(storedContentCard.status).toBe('deleted');
+    expect(storedContentCard.deletedAt).not.toBeNull();
+    expect(foodCards.map((card) => card.cardId)).toEqual(['card-examples']);
+  });
+});

--- a/scripts/run-database-package-branch-tests.mjs
+++ b/scripts/run-database-package-branch-tests.mjs
@@ -5,6 +5,7 @@ import {
 	createBranchName,
 	deleteBranch,
 	getExpirationTimestamp,
+	getConnectionOptions,
 	getNeonBranchEnv,
 	runCommandStreaming,
 	runNeon,


### PR DESCRIPTION
## Summary
- add the Card Library backend/server contracts for active-card lists, group-scoped lists, detail loading, and group counts
- wire Cards and Group Detail route loaders plus placeholder group detail page plumbing
- add database and web tests covering filters, counts, active-only behavior, and literal LIKE wildcard escaping
- fix the secure database branch-test harness import so branch-backed database tests run

## Testing
- pnpm turbo test lint build --filter=web
- pnpm test:db:branch:secure

Closes #139