### PR TITLE
Implement shared active-card drawer

### DIFF
--- a/apps/web/src/lib/components/cards/ActiveCardDrawer.svelte
+++ b/apps/web/src/lib/components/cards/ActiveCardDrawer.svelte
@@ -1,0 +1,1086 @@
+<script lang="ts">
+  import { createEventDispatcher, onDestroy, tick } from 'svelte';
+  import CardListStatusBadge from '$lib/components/card-list/CardListStatusBadge.svelte';
+  import type { CardLibraryCardDetailData, CardLibraryGroupData } from '$lib/server/cards.js';
+
+  type EditableListField = 'examples' | 'mnemonics';
+  type SaveState = 'idle' | 'saving' | 'saved' | 'error';
+
+  const dispatch = createEventDispatcher<{
+    updated: {
+      card: CardLibraryCardDetailData;
+      availableGroups: CardLibraryGroupData[];
+    };
+    deleted: {
+      cardId: string;
+    };
+    close: void;
+    previous: void;
+    next: void;
+  }>();
+
+  export let lang: string;
+  export let card: CardLibraryCardDetailData;
+  export let availableGroups: CardLibraryGroupData[] = [];
+  export let selectedIndex = 0;
+  export let totalCount = 1;
+  export let hasPrevious = false;
+  export let hasNext = false;
+  export let disabled = false;
+
+  let draft = structuredClone(card);
+  let previousCard = card;
+  let lastSavedPayload = '';
+  let saveState: SaveState = 'idle';
+  let saveError: string | null = null;
+  let saveToken = 0;
+  let saveRequest: Promise<boolean> | null = null;
+  let pendingPayloadSignature: string | null = null;
+  let savedIndicatorTimer: ReturnType<typeof setTimeout> | null = null;
+  let groupQuery = '';
+  let groupMenuOpen = false;
+  let deleteConfirmOpen = false;
+  let removePending = false;
+  let drawerElement: HTMLElement | null = null;
+  let groupFieldElement: HTMLDivElement | null = null;
+  let groupSearchInput: HTMLInputElement | null = null;
+  let llmInstructionsOpen = Boolean(card.llmInstructions);
+
+  function normalizeList(values: string[]) {
+    return values.map((value) => value.trim()).filter(Boolean);
+  }
+
+  function serializePayload(payload: ReturnType<typeof buildPayload>) {
+    return JSON.stringify(payload);
+  }
+
+  function buildPayloadFromCard(source: CardLibraryCardDetailData) {
+    return {
+      content: source.content,
+      meaning: source.meaning ?? '',
+      examples: normalizeList(source.examples),
+      mnemonics: normalizeList(source.mnemonics),
+      llmInstructions: source.llmInstructions ?? '',
+      groups: source.groups.map((group) => ({
+        groupId: group.groupId?.trim() ? group.groupId : null,
+        groupName: group.groupName,
+      })),
+    };
+  }
+
+  function buildPayload() {
+    return buildPayloadFromCard(draft);
+  }
+
+  function clearSavedIndicatorTimer() {
+    if (!savedIndicatorTimer) {
+      return;
+    }
+
+    clearTimeout(savedIndicatorTimer);
+    savedIndicatorTimer = null;
+  }
+
+  function scheduleSavedIndicatorReset() {
+    clearSavedIndicatorTimer();
+    savedIndicatorTimer = setTimeout(() => {
+      saveState = 'idle';
+    }, 2_000);
+  }
+
+  function closeGroupMenu() {
+    groupMenuOpen = false;
+    groupQuery = '';
+  }
+
+  async function openGroupMenu() {
+    if (disabled) {
+      return;
+    }
+
+    groupMenuOpen = true;
+    await tick();
+    groupSearchInput?.focus();
+  }
+
+  function handleGroupFieldFocusOut(event: FocusEvent) {
+    const nextFocused = event.relatedTarget;
+
+    if (!(nextFocused instanceof Node) || !groupFieldElement?.contains(nextFocused)) {
+      closeGroupMenu();
+    }
+  }
+
+  function handleGroupSearchKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeGroupMenu();
+    }
+  }
+
+  $: normalizedGroupQuery = groupQuery.trim().toLocaleLowerCase();
+  $: selectedGroupIds = new Set(draft.groups.map((group) => group.groupId));
+  $: filteredGroups = availableGroups.filter(
+    (group) =>
+      !selectedGroupIds.has(group.groupId) &&
+      group.groupName.toLocaleLowerCase().includes(normalizedGroupQuery)
+  );
+  $: canCreateGroup =
+    normalizedGroupQuery.length > 0 &&
+    !availableGroups.some((group) => group.groupName.trim().toLocaleLowerCase() === normalizedGroupQuery);
+  $: signpostLabel =
+    saveState === 'saving'
+      ? 'Saving...'
+      : saveState === 'saved'
+        ? 'Saved ✓'
+        : saveState === 'error'
+          ? 'Save failed'
+          : '';
+
+  $: if (card !== previousCard) {
+    draft = structuredClone(card);
+    previousCard = card;
+    lastSavedPayload = serializePayload(buildPayloadFromCard(card));
+    llmInstructionsOpen = Boolean(card.llmInstructions);
+    groupQuery = '';
+    groupMenuOpen = false;
+    deleteConfirmOpen = false;
+    removePending = false;
+    saveState = 'idle';
+    saveError = null;
+    saveToken++;
+    saveRequest = null;
+    pendingPayloadSignature = null;
+  }
+
+  $: if (!lastSavedPayload) {
+    lastSavedPayload = serializePayload(buildPayloadFromCard(card));
+  }
+
+  async function persistDraft(): Promise<boolean> {
+    if (disabled) {
+      return false;
+    }
+
+    const payload = buildPayload();
+    const payloadSignature = serializePayload(payload);
+
+    if (payloadSignature === lastSavedPayload) {
+      if (saveState === 'error') {
+        saveState = 'idle';
+        saveError = null;
+      }
+
+      return true;
+    }
+
+    if (saveRequest && pendingPayloadSignature === payloadSignature) {
+      return saveRequest;
+    }
+
+    clearSavedIndicatorTimer();
+    saveState = 'saving';
+    saveError = null;
+
+    const currentSaveToken = ++saveToken;
+    pendingPayloadSignature = payloadSignature;
+
+    const request = (async () => {
+      try {
+        const response = await fetch(`/${lang}/cards/${card.cardId}`, {
+          method: 'PATCH',
+          headers: {
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify(payload),
+        });
+
+        const data = (await response.json().catch(() => null)) as
+          | {
+              card?: CardLibraryCardDetailData;
+              availableGroups?: CardLibraryGroupData[];
+              message?: string;
+            }
+          | null;
+
+        if (!response.ok || !data?.card || !data.availableGroups) {
+          throw new Error(data?.message ?? 'The card could not be saved right now.');
+        }
+
+        if (currentSaveToken !== saveToken) {
+          return false;
+        }
+
+        draft = data.card;
+        lastSavedPayload = serializePayload(buildPayloadFromCard(data.card));
+        saveState = 'saved';
+        dispatch('updated', {
+          card: data.card,
+          availableGroups: data.availableGroups,
+        });
+        scheduleSavedIndicatorReset();
+        return true;
+      } catch (error) {
+        if (currentSaveToken !== saveToken) {
+          return false;
+        }
+
+        saveState = 'error';
+        saveError = error instanceof Error ? error.message : 'The card could not be saved right now.';
+        return false;
+      } finally {
+        if (pendingPayloadSignature === payloadSignature) {
+          saveRequest = null;
+          pendingPayloadSignature = null;
+        }
+      }
+    })();
+
+    saveRequest = request;
+    return request;
+  }
+
+  function updateListValue(field: EditableListField, index: number, value: string) {
+    const nextValues = [...draft[field]];
+    nextValues[index] = value;
+    draft = {
+      ...draft,
+      [field]: nextValues,
+    };
+  }
+
+  function addListValue(field: EditableListField) {
+    saveToken++;
+    draft = {
+      ...draft,
+      [field]: [...draft[field], ''],
+    };
+  }
+
+  async function removeListValue(field: EditableListField, index: number) {
+    draft = {
+      ...draft,
+      [field]: draft[field].filter((_, currentIndex) => currentIndex !== index),
+    };
+
+    await persistDraft();
+  }
+
+  async function toggleGroup(group: CardLibraryGroupData) {
+    if (disabled) {
+      return;
+    }
+
+    draft = {
+      ...draft,
+      groups: [...draft.groups, group].sort((left, right) => left.groupName.localeCompare(right.groupName)),
+    };
+
+    closeGroupMenu();
+    await persistDraft();
+  }
+
+  async function createGroupFromQuery() {
+    if (disabled || !canCreateGroup) {
+      return;
+    }
+
+    draft = {
+      ...draft,
+      groups: [
+        ...draft.groups,
+        {
+          groupId: '',
+          groupName: groupQuery.trim(),
+        },
+      ],
+    };
+
+    closeGroupMenu();
+    await persistDraft();
+  }
+
+  async function removeGroup(groupId: string) {
+    if (disabled) {
+      return;
+    }
+
+    draft = {
+      ...draft,
+      groups: draft.groups.filter((group) => group.groupId !== groupId),
+    };
+
+    await persistDraft();
+  }
+
+  async function handleClose() {
+    deleteConfirmOpen = false;
+
+    if (await persistDraft()) {
+      dispatch('close');
+    }
+  }
+
+  async function handleNavigate(direction: 'previous' | 'next') {
+    deleteConfirmOpen = false;
+
+    if (await persistDraft()) {
+      dispatch(direction);
+    }
+  }
+
+  async function confirmDelete() {
+    if (disabled || removePending) {
+      return;
+    }
+
+    removePending = true;
+
+    try {
+      const response = await fetch(`/${lang}/cards/${card.cardId}`, {
+        method: 'DELETE',
+      });
+
+      const data = (await response.json().catch(() => null)) as
+        | {
+            deletedCardIds?: string[];
+            message?: string;
+          }
+        | null;
+
+      if (!response.ok || !data?.deletedCardIds?.includes(card.cardId)) {
+        throw new Error(data?.message ?? 'The card could not be removed right now.');
+      }
+
+      dispatch('deleted', {
+        cardId: card.cardId,
+      });
+    } catch (error) {
+      saveState = 'error';
+      saveError = error instanceof Error ? error.message : 'The card could not be removed right now.';
+    } finally {
+      removePending = false;
+      deleteConfirmOpen = false;
+    }
+  }
+
+  function handleWindowKeydown(event: KeyboardEvent) {
+    if (event.key !== 'Escape') {
+      return;
+    }
+
+    event.preventDefault();
+
+    if (deleteConfirmOpen) {
+      deleteConfirmOpen = false;
+      return;
+    }
+
+    void handleClose();
+  }
+
+  function handleDrawerKeydown(event: KeyboardEvent) {
+    if (event.key !== 'Tab' || !drawerElement) {
+      return;
+    }
+
+    const focusableElements = Array.from(
+      drawerElement.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], textarea:not([disabled]), input:not([disabled]), details summary'
+      )
+    );
+
+    if (focusableElements.length === 0) {
+      return;
+    }
+
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    if (event.shiftKey && document.activeElement === firstElement) {
+      event.preventDefault();
+      lastElement?.focus();
+      return;
+    }
+
+    if (!event.shiftKey && document.activeElement === lastElement) {
+      event.preventDefault();
+      firstElement?.focus();
+    }
+  }
+
+  function autoResize(node: HTMLTextAreaElement) {
+    const resize = () => {
+      node.style.height = 'auto';
+      node.style.height = `${node.scrollHeight}px`;
+    };
+
+    resize();
+    node.addEventListener('input', resize);
+
+    return {
+      update: resize,
+      destroy() {
+        node.removeEventListener('input', resize);
+      },
+    };
+  }
+
+  onDestroy(() => {
+    clearSavedIndicatorTimer();
+  });
+</script>
+
+<svelte:window on:keydown={handleWindowKeydown} />
+
+<button
+  type="button"
+  class="active-card-drawer__backdrop"
+  aria-label="Close card detail drawer"
+  on:click={() => void handleClose()}
+></button>
+
+<div
+  bind:this={drawerElement}
+  class="active-card-drawer stack"
+  style="--stack-space: var(--space-4)"
+  role="dialog"
+  tabindex="-1"
+  aria-modal="true"
+  aria-labelledby="active-card-drawer-title"
+  on:keydown={handleDrawerKeydown}
+>
+  <header class="active-card-drawer__header stack" style="--stack-space: var(--space-3)">
+    <div class="active-card-drawer__header-row">
+      <div class="active-card-drawer__nav cluster">
+        <button
+          type="button"
+          class="active-card-drawer__nav-button"
+          disabled={!hasPrevious || disabled || removePending}
+          aria-label="Previous card"
+          on:click={() => void handleNavigate('previous')}
+        >
+          ←
+        </button>
+        <button
+          type="button"
+          class="active-card-drawer__nav-button"
+          disabled={!hasNext || disabled || removePending}
+          aria-label="Next card"
+          on:click={() => void handleNavigate('next')}
+        >
+          →
+        </button>
+        <p id="active-card-drawer-title" class="active-card-drawer__position">
+          Card {selectedIndex + 1} of {totalCount}
+        </p>
+      </div>
+
+      <div class="active-card-drawer__status-wrap stack" style="--stack-space: var(--space-1)">
+        <p class={`active-card-drawer__status active-card-drawer__status--${saveState}`} aria-live="polite">
+          {signpostLabel || ' '}
+        </p>
+        <button
+          type="button"
+          class="active-card-drawer__close"
+          aria-label="Close drawer"
+          disabled={disabled || removePending}
+          on:click={() => void handleClose()}
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+
+    {#if saveError}
+      <p class="active-card-drawer__error">{saveError}</p>
+    {/if}
+  </header>
+
+  <div class="active-card-drawer__body stack" style="--stack-space: var(--space-4)">
+    <CardListStatusBadge label="Active" tone="active" />
+
+    <label class="active-card-drawer__field stack" style="--stack-space: var(--space-2)">
+      <span class="active-card-drawer__label">Content</span>
+      <textarea
+        use:autoResize
+        class="active-card-drawer__textarea"
+        rows="2"
+        bind:value={draft.content}
+        placeholder="Card content..."
+        disabled={disabled || removePending}
+        on:blur={() => void persistDraft()}
+      ></textarea>
+    </label>
+
+    <label class="active-card-drawer__field stack" style="--stack-space: var(--space-2)">
+      <span class="active-card-drawer__label">Meaning</span>
+      <textarea
+        use:autoResize
+        class="active-card-drawer__textarea"
+        rows="2"
+        value={draft.meaning ?? ''}
+        placeholder="Meaning..."
+        disabled={disabled || removePending}
+        on:input={(event) => {
+          draft = {
+            ...draft,
+            meaning: event.currentTarget.value,
+          };
+        }}
+        on:blur={() => void persistDraft()}
+      ></textarea>
+    </label>
+
+    <div
+      class="active-card-drawer__field stack"
+      style="--stack-space: var(--space-2)"
+      bind:this={groupFieldElement}
+      on:focusout={handleGroupFieldFocusOut}
+    >
+      <div class="cluster active-card-drawer__field-head">
+        <span class="active-card-drawer__label">Groups</span>
+        <button
+          type="button"
+          class="active-card-drawer__inline-action"
+          disabled={disabled || removePending}
+          aria-expanded={groupMenuOpen}
+          on:click={() => void (groupMenuOpen ? closeGroupMenu() : openGroupMenu())}
+        >
+          + Add group
+        </button>
+      </div>
+
+      <div class="active-card-drawer__group-chips cluster">
+        {#if draft.groups.length === 0}
+          <p class="active-card-drawer__empty-inline">No groups yet.</p>
+        {:else}
+          {#each draft.groups as group}
+            <button
+              type="button"
+              class="active-card-drawer__group-chip"
+              disabled={disabled || removePending}
+              on:click={() => void removeGroup(group.groupId)}
+            >
+              {group.groupName}
+              <span aria-hidden="true">✕</span>
+            </button>
+          {/each}
+        {/if}
+      </div>
+
+      {#if groupMenuOpen}
+        <div class="active-card-drawer__group-menu stack" style="--stack-space: var(--space-2)">
+          <input
+            type="text"
+            class="active-card-drawer__group-search"
+            bind:this={groupSearchInput}
+            bind:value={groupQuery}
+            placeholder="Search groups..."
+            disabled={disabled || removePending}
+            on:keydown={handleGroupSearchKeydown}
+          />
+
+          <div class="active-card-drawer__group-options stack" style="--stack-space: var(--space-1)">
+            {#if filteredGroups.length === 0 && !canCreateGroup}
+              <p class="active-card-drawer__empty-inline">No matching groups.</p>
+            {/if}
+
+            {#each filteredGroups as group}
+              <button
+                type="button"
+                class="active-card-drawer__group-option"
+                disabled={disabled || removePending}
+                on:click={() => void toggleGroup(group)}
+              >
+                {group.groupName}
+              </button>
+            {/each}
+
+            {#if canCreateGroup}
+              <button
+                type="button"
+                class="active-card-drawer__create-group"
+                disabled={disabled || removePending}
+                on:click={() => void createGroupFromQuery()}
+              >
+                + Create "{groupQuery.trim()}"
+              </button>
+            {/if}
+          </div>
+        </div>
+      {/if}
+    </div>
+
+    <div class="active-card-drawer__field stack" style="--stack-space: var(--space-2)">
+      <div class="cluster active-card-drawer__field-head">
+        <span class="active-card-drawer__label">Example sentences</span>
+        <button
+          type="button"
+          class="active-card-drawer__inline-action"
+          disabled={disabled || removePending}
+          on:click={() => addListValue('examples')}
+        >
+          + Add
+        </button>
+      </div>
+
+      <div class="stack" style="--stack-space: var(--space-2)">
+        {#if draft.examples.length === 0}
+          <p class="active-card-drawer__empty-inline">No example sentences yet.</p>
+        {/if}
+
+        {#each draft.examples as example, index}
+          <div class="active-card-drawer__list-row">
+            <textarea
+              use:autoResize
+              class="active-card-drawer__list-input"
+              rows="2"
+              value={example}
+              placeholder="Example sentence..."
+              disabled={disabled || removePending}
+              on:input={(event) => updateListValue('examples', index, event.currentTarget.value)}
+              on:blur={() => void persistDraft()}
+            ></textarea>
+            <button
+              type="button"
+              class="active-card-drawer__remove-list-item"
+              aria-label="Remove example sentence"
+              disabled={disabled || removePending}
+              on:click={() => void removeListValue('examples', index)}
+            >
+              Remove
+            </button>
+          </div>
+        {/each}
+      </div>
+    </div>
+
+    <div class="active-card-drawer__field stack" style="--stack-space: var(--space-2)">
+      <div class="cluster active-card-drawer__field-head">
+        <span class="active-card-drawer__label">Mnemonics</span>
+        <button
+          type="button"
+          class="active-card-drawer__inline-action"
+          disabled={disabled || removePending}
+          on:click={() => addListValue('mnemonics')}
+        >
+          + Add
+        </button>
+      </div>
+
+      <div class="stack" style="--stack-space: var(--space-2)">
+        {#if draft.mnemonics.length === 0}
+          <p class="active-card-drawer__empty-inline">No mnemonics yet.</p>
+        {/if}
+
+        {#each draft.mnemonics as mnemonic, index}
+          <div class="active-card-drawer__list-row">
+            <textarea
+              use:autoResize
+              class="active-card-drawer__list-input"
+              rows="2"
+              value={mnemonic}
+              placeholder="Mnemonic..."
+              disabled={disabled || removePending}
+              on:input={(event) => updateListValue('mnemonics', index, event.currentTarget.value)}
+              on:blur={() => void persistDraft()}
+            ></textarea>
+            <button
+              type="button"
+              class="active-card-drawer__remove-list-item"
+              aria-label="Remove mnemonic"
+              disabled={disabled || removePending}
+              on:click={() => void removeListValue('mnemonics', index)}
+            >
+              Remove
+            </button>
+          </div>
+        {/each}
+      </div>
+    </div>
+
+    <details class="active-card-drawer__llm" bind:open={llmInstructionsOpen}>
+      <summary class="active-card-drawer__llm-summary">LLM instructions</summary>
+      <div class="stack" style="--stack-space: var(--space-2)">
+        <textarea
+          use:autoResize
+          class="active-card-drawer__textarea"
+          rows="2"
+          value={draft.llmInstructions ?? ''}
+          placeholder="Optional guidance for future LLM work on this card..."
+          disabled={disabled || removePending}
+          on:input={(event) => {
+            draft = {
+              ...draft,
+              llmInstructions: event.currentTarget.value,
+            };
+          }}
+          on:blur={() => void persistDraft()}
+        ></textarea>
+      </div>
+    </details>
+  </div>
+
+  <footer class="active-card-drawer__footer">
+    <button
+      type="button"
+      class="active-card-drawer__delete"
+      disabled={disabled || removePending}
+      on:click={() => {
+        deleteConfirmOpen = true;
+      }}
+    >
+      {removePending ? 'Deleting…' : 'Delete card'}
+    </button>
+  </footer>
+
+  {#if deleteConfirmOpen}
+    <div class="active-card-drawer__confirm-backdrop">
+      <div class="active-card-drawer__confirm stack" style="--stack-space: var(--space-3)" role="alertdialog" aria-modal="true">
+        <h2>Delete "{draft.content}"?</h2>
+        <p>This card will be permanently deleted and removed from all groups. This cannot be undone.</p>
+        <div class="active-card-drawer__confirm-actions cluster">
+          <button
+            type="button"
+            class="active-card-drawer__confirm-cancel"
+            disabled={removePending}
+            on:click={() => {
+              deleteConfirmOpen = false;
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            class="active-card-drawer__confirm-delete"
+            disabled={removePending}
+            on:click={() => void confirmDelete()}
+          >
+            {removePending ? 'Deleting…' : 'Delete card'}
+          </button>
+        </div>
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .active-card-drawer__backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 52;
+    border: 0;
+    background: color-mix(in srgb, var(--neutral-900) 18%, transparent);
+  }
+
+  .active-card-drawer {
+    position: fixed;
+    inset-block: 0;
+    inset-inline-end: 0;
+    z-index: 53;
+    inline-size: min(36rem, 100vw);
+    padding: var(--space-4);
+    border-inline-start: 1px solid var(--color-border);
+    background: var(--color-surface-raised);
+    box-shadow: var(--shadow-lg);
+    overflow: auto;
+  }
+
+  .active-card-drawer__header {
+    position: sticky;
+    inset-block-start: calc(var(--space-4) * -1);
+    padding-block-start: var(--space-4);
+    padding-block-end: var(--space-2);
+    border-block-end: 1px solid var(--color-border);
+    background: var(--color-surface-raised);
+    z-index: 1;
+  }
+
+  .active-card-drawer__header-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  .active-card-drawer__nav {
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .active-card-drawer__nav-button,
+  .active-card-drawer__close,
+  .active-card-drawer__inline-action,
+  .active-card-drawer__delete,
+  .active-card-drawer__confirm-cancel,
+  .active-card-drawer__confirm-delete,
+  .active-card-drawer__remove-list-item,
+  .active-card-drawer__group-chip,
+  .active-card-drawer__group-option,
+  .active-card-drawer__create-group,
+  .active-card-drawer__group-search,
+  .active-card-drawer__textarea,
+  .active-card-drawer__list-input {
+    font-family: var(--font-ui);
+  }
+
+  .active-card-drawer__nav-button,
+  .active-card-drawer__close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    inline-size: 2.5rem;
+    min-block-size: 2.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text-primary);
+  }
+
+  .active-card-drawer__position {
+    margin: 0;
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+  }
+
+  .active-card-drawer__status-wrap {
+    align-items: flex-end;
+  }
+
+  .active-card-drawer__status {
+    min-block-size: 1.25rem;
+    margin: 0;
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+  }
+
+  .active-card-drawer__status--error,
+  .active-card-drawer__error,
+  .active-card-drawer__delete,
+  .active-card-drawer__confirm-delete {
+    color: var(--color-danger-text);
+  }
+
+  .active-card-drawer__error {
+    margin: 0;
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+  }
+
+  .active-card-drawer__body {
+    padding-block-start: var(--space-2);
+    padding-block-end: var(--space-5);
+  }
+
+  .active-card-drawer__field-head {
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2);
+  }
+
+  .active-card-drawer__label {
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-caption);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .active-card-drawer__inline-action,
+  .active-card-drawer__remove-list-item,
+  .active-card-drawer__delete,
+  .active-card-drawer__confirm-cancel,
+  .active-card-drawer__confirm-delete,
+  .active-card-drawer__group-option,
+  .active-card-drawer__create-group {
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+  }
+
+  .active-card-drawer__textarea,
+  .active-card-drawer__list-input,
+  .active-card-drawer__group-search {
+    inline-size: 100%;
+    min-block-size: 2.75rem;
+    padding: var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text-primary);
+    resize: none;
+  }
+
+  .active-card-drawer__empty-inline {
+    margin: 0;
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+  }
+
+  .active-card-drawer__group-chips,
+  .active-card-drawer__confirm-actions {
+    gap: var(--space-2);
+  }
+
+  .active-card-drawer__group-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: 0.35rem 0.6rem;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--radius-pill, 999px);
+    background: var(--color-surface-subtle);
+    color: var(--color-text-secondary);
+  }
+
+  .active-card-drawer__group-menu {
+    padding: var(--space-3);
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+  }
+
+  .active-card-drawer__group-option,
+  .active-card-drawer__create-group {
+    display: block;
+    inline-size: 100%;
+    padding: var(--space-2) var(--space-1);
+    border-radius: var(--radius-sm);
+    color: var(--color-text-primary);
+    text-align: start;
+  }
+
+  .active-card-drawer__create-group {
+    color: var(--color-primary-text);
+    font-weight: 600;
+  }
+
+  .active-card-drawer__list-row {
+    display: grid;
+    gap: var(--space-2);
+  }
+
+  .active-card-drawer__remove-list-item {
+    justify-self: start;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-small);
+    text-decoration: underline;
+  }
+
+  .active-card-drawer__llm {
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+  }
+
+  .active-card-drawer__llm-summary {
+    cursor: pointer;
+    padding: var(--space-3);
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+    font-weight: 600;
+  }
+
+  .active-card-drawer__llm :global(textarea) {
+    margin: 0 var(--space-3) var(--space-3);
+    inline-size: calc(100% - (var(--space-3) * 2));
+  }
+
+  .active-card-drawer__footer {
+    padding-block-start: var(--space-3);
+    border-block-start: 1px solid var(--color-border-subtle);
+  }
+
+  .active-card-drawer__delete {
+    padding: 0;
+    font-weight: 600;
+  }
+
+  .active-card-drawer__confirm-backdrop {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    padding: var(--space-4);
+    background: color-mix(in srgb, var(--neutral-900) 28%, transparent);
+  }
+
+  .active-card-drawer__confirm {
+    inline-size: min(100%, 22rem);
+    padding: var(--space-4);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface-raised);
+    box-shadow: var(--shadow-lg);
+  }
+
+  .active-card-drawer__confirm h2,
+  .active-card-drawer__confirm p {
+    margin: 0;
+  }
+
+  .active-card-drawer__confirm-cancel,
+  .active-card-drawer__confirm-delete {
+    min-block-size: 2.75rem;
+    padding-inline: var(--space-4);
+    border-radius: var(--radius-md);
+  }
+
+  .active-card-drawer__confirm-cancel {
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text-secondary);
+  }
+
+  .active-card-drawer__confirm-delete {
+    border: 1px solid var(--color-danger-text);
+    background: color-mix(in srgb, var(--color-danger-text) 10%, var(--color-surface));
+  }
+
+  .active-card-drawer__nav-button:disabled,
+  .active-card-drawer__close:disabled,
+  .active-card-drawer__inline-action:disabled,
+  .active-card-drawer__delete:disabled,
+  .active-card-drawer__confirm-cancel:disabled,
+  .active-card-drawer__confirm-delete:disabled,
+  .active-card-drawer__remove-list-item:disabled,
+  .active-card-drawer__group-chip:disabled,
+  .active-card-drawer__group-option:disabled,
+  .active-card-drawer__create-group:disabled,
+  .active-card-drawer__group-search:disabled,
+  .active-card-drawer__textarea:disabled,
+  .active-card-drawer__list-input:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
+  .active-card-drawer__nav-button:focus-visible,
+  .active-card-drawer__close:focus-visible,
+  .active-card-drawer__inline-action:focus-visible,
+  .active-card-drawer__delete:focus-visible,
+  .active-card-drawer__confirm-cancel:focus-visible,
+  .active-card-drawer__confirm-delete:focus-visible,
+  .active-card-drawer__remove-list-item:focus-visible,
+  .active-card-drawer__group-chip:focus-visible,
+  .active-card-drawer__group-option:focus-visible,
+  .active-card-drawer__create-group:focus-visible,
+  .active-card-drawer__group-search:focus-visible,
+  .active-card-drawer__textarea:focus-visible,
+  .active-card-drawer__list-input:focus-visible,
+  .active-card-drawer__llm-summary:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  @media (max-width: 63.99rem) {
+    .active-card-drawer {
+      inline-size: 100vw;
+      border-inline-start: 0;
+      padding-block-end: calc(var(--space-5) + env(safe-area-inset-bottom));
+    }
+  }
+</style>

--- a/apps/web/src/lib/components/cards/ActiveCardDrawer.test.ts
+++ b/apps/web/src/lib/components/cards/ActiveCardDrawer.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import ActiveCardDrawer from './ActiveCardDrawer.svelte';
+import type { CardLibraryCardDetailData, CardLibraryGroupData } from '$lib/server/cards.js';
+
+function createCard(overrides: Partial<CardLibraryCardDetailData> = {}): CardLibraryCardDetailData {
+  return {
+    cardId: 'card-1',
+    content: '谈论',
+    meaning: 'to discuss',
+    cardType: 'pattern',
+    examples: [],
+    mnemonics: [],
+    llmInstructions: null,
+    updatedAtIso: '2026-05-01T12:00:00.000Z',
+    groups: [],
+    ...overrides,
+  };
+}
+
+function createGroup(overrides: Partial<CardLibraryGroupData> = {}): CardLibraryGroupData {
+  return {
+    groupId: 'group-1',
+    groupName: 'Conversation',
+    ...overrides,
+  };
+}
+
+describe('ActiveCardDrawer', () => {
+  it('saves edited card content through the active-card PATCH endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        card: createCard({ meaning: 'to talk about in a more formal register' }),
+        availableGroups: [createGroup()],
+      }),
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(ActiveCardDrawer, {
+      props: {
+        lang: 'zh',
+        card: createCard(),
+        availableGroups: [createGroup()],
+        selectedIndex: 0,
+        totalCount: 1,
+      },
+    });
+
+    const meaningField = screen.getByDisplayValue('to discuss');
+    await fireEvent.input(meaningField, {
+      currentTarget: {
+        value: 'to talk about in a more formal register',
+      },
+      target: {
+        value: 'to talk about in a more formal register',
+      },
+    });
+    await fireEvent.blur(meaningField);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/zh/cards/card-1', {
+        method: 'PATCH',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          content: '谈论',
+          meaning: 'to talk about in a more formal register',
+          examples: [],
+          mnemonics: [],
+          llmInstructions: '',
+          groups: [],
+        }),
+      });
+    });
+
+    expect(await screen.findByText('Saved ✓')).toBeTruthy();
+  });
+
+  it('requires confirmation before deleting and emits the deleted event after success', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        deletedCardIds: ['card-1'],
+      }),
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(ActiveCardDrawer, {
+      props: {
+        lang: 'zh',
+        card: createCard(),
+        availableGroups: [],
+        selectedIndex: 0,
+        totalCount: 1,
+      },
+    });
+
+    await fireEvent.click(screen.getAllByRole('button', { name: 'Delete card' })[0]);
+    expect(screen.getByText('Delete "谈论"?')).toBeTruthy();
+
+    await fireEvent.click(screen.getAllByRole('button', { name: 'Delete card' })[1]);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/zh/cards/card-1', {
+        method: 'DELETE',
+      });
+    });
+  });
+});

--- a/apps/web/src/routes/[lang]/cards/+page.server.ts
+++ b/apps/web/src/routes/[lang]/cards/+page.server.ts
@@ -1,7 +1,7 @@
-import { redirect } from '@sveltejs/kit';
+import { error, redirect } from '@sveltejs/kit';
 import { getDb } from '@studypuck/database';
 import { env } from '$env/dynamic/private';
-import { loadCardLibraryData } from '$lib/server/cards.js';
+import { CardLibraryRequestError, loadActiveCardDetailData, loadCardLibraryData } from '$lib/server/cards.js';
 import type { PageServerLoad } from './$types.js';
 
 export const load: PageServerLoad = async (event) => {
@@ -13,8 +13,29 @@ export const load: PageServerLoad = async (event) => {
   }
 
   const database = getDb(env.DATABASE_URL);
+  const selectedCardId = event.url.searchParams.get('card');
 
-  return {
-    library: await loadCardLibraryData(session.user.id, languageCode, event.url, database),
-  };
+  try {
+    const library = await loadCardLibraryData(session.user.id, languageCode, event.url, database);
+
+    if (selectedCardId && !library.filteredCardIds.includes(selectedCardId)) {
+      throw error(404, 'Active card not found in the current card view.');
+    }
+
+    const selectedCard = selectedCardId
+      ? await loadActiveCardDetailData(session.user.id, languageCode, selectedCardId, database)
+      : null;
+
+    return {
+      library,
+      selectedCard: selectedCard?.card ?? null,
+      selectedCardAvailableGroups: selectedCard?.availableGroups ?? [],
+    };
+  } catch (requestError) {
+    if (requestError instanceof CardLibraryRequestError) {
+      throw error(requestError.status, requestError.message);
+    }
+
+    throw requestError;
+  }
 };

--- a/apps/web/src/routes/[lang]/cards/+page.svelte
+++ b/apps/web/src/routes/[lang]/cards/+page.svelte
@@ -1,25 +1,300 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import ActiveCardDrawer from '$lib/components/cards/ActiveCardDrawer.svelte';
+  import CardListStatusBadge from '$lib/components/card-list/CardListStatusBadge.svelte';
+  import CardListTagChip from '$lib/components/card-list/CardListTagChip.svelte';
+  import type {
+    CardLibraryCardDetailData,
+    CardLibraryCardListItemData,
+    CardLibraryData,
+    CardLibraryGroupData,
+  } from '$lib/server/cards.js';
+  import type { PageData } from './$types.js';
+
+  export let data: PageData;
+
+  let library: CardLibraryData = data.library;
+  let selectedCard: CardLibraryCardDetailData | null = data.selectedCard;
+  let selectedCardAvailableGroups: CardLibraryGroupData[] = data.selectedCardAvailableGroups;
+  let previousLibraryData = data.library;
+  let previousSelectedCard = data.selectedCard;
+  let previousSelectedCardAvailableGroups = data.selectedCardAvailableGroups;
+
+  $: if (data.library !== previousLibraryData) {
+    library = data.library;
+    previousLibraryData = data.library;
+  }
+
+  $: if (data.selectedCard !== previousSelectedCard) {
+    selectedCard = data.selectedCard;
+    previousSelectedCard = data.selectedCard;
+  }
+
+  $: if (data.selectedCardAvailableGroups !== previousSelectedCardAvailableGroups) {
+    selectedCardAvailableGroups = data.selectedCardAvailableGroups;
+    previousSelectedCardAvailableGroups = data.selectedCardAvailableGroups;
+  }
+
+  $: selectedIndex = selectedCard ? library.filteredCardIds.indexOf(selectedCard.cardId) : -1;
+
+  function buildDrawerUrl(cardId: string | null) {
+    const nextUrl = new URL($page.url);
+
+    if (cardId) {
+      nextUrl.searchParams.set('card', cardId);
+    } else {
+      nextUrl.searchParams.delete('card');
+    }
+
+    return `${nextUrl.pathname}${nextUrl.search}`;
+  }
+
+  async function openCard(cardId: string) {
+    await goto(buildDrawerUrl(cardId), {
+      keepFocus: true,
+      noScroll: true,
+    });
+  }
+
+  async function navigateDrawer(cardId: string | null) {
+    await goto(buildDrawerUrl(cardId), {
+      keepFocus: true,
+      noScroll: true,
+      replaceState: true,
+    });
+  }
+
+  function sortLibraryItems(items: CardLibraryCardListItemData[]) {
+    return [...items].sort((left, right) => {
+      const leftTime = left.updatedAtIso ? Date.parse(left.updatedAtIso) : 0;
+      const rightTime = right.updatedAtIso ? Date.parse(right.updatedAtIso) : 0;
+      return rightTime - leftTime;
+    });
+  }
+
+  function mapDetailToListItem(card: CardLibraryCardDetailData): CardLibraryCardListItemData {
+    return {
+      cardId: card.cardId,
+      content: card.content,
+      meaning: card.meaning,
+      cardType: card.cardType,
+      updatedAtIso: card.updatedAtIso ?? new Date().toISOString(),
+      updatedAtLabel: 'Just now',
+      groups: card.groups,
+    };
+  }
+
+  function handleCardUpdated(event: CustomEvent<{ card: CardLibraryCardDetailData; availableGroups: CardLibraryGroupData[] }>) {
+    selectedCard = event.detail.card;
+    selectedCardAvailableGroups = event.detail.availableGroups;
+
+    const nextItem = mapDetailToListItem(event.detail.card);
+    const otherItems = library.items.filter((item) => item.cardId !== nextItem.cardId);
+    const nextItems = sortLibraryItems([nextItem, ...otherItems]);
+
+    library = {
+      ...library,
+      items: nextItems,
+      filteredCardIds: nextItems.map((item) => item.cardId),
+    };
+  }
+
+  function handleCardDeleted(event: CustomEvent<{ cardId: string }>) {
+    const nextItems = library.items.filter((item) => item.cardId !== event.detail.cardId);
+
+    library = {
+      ...library,
+      items: nextItems,
+      totalCount: nextItems.length,
+      filteredCardIds: nextItems.map((item) => item.cardId),
+    };
+
+    selectedCard = null;
+    void navigateDrawer(null);
+  }
+</script>
+
 <svelte:head>
   <title>Cards – StudyPuck</title>
 </svelte:head>
 
-<section class="center stack app-screen" style="--stack-space: var(--space-5)">
+<section class="cards-page stack" style="--stack-space: var(--space-5)">
   <header class="stack" style="--stack-space: var(--space-2)">
-    <p class="screen-eyebrow text-muted">Library</p>
+    <p class="cards-page__eyebrow">Library</p>
     <h1>Cards</h1>
-    <p>This placeholder route keeps the desktop sidebar and mobile More sheet navigation functional.</p>
+    <p>Open any active card to edit it in the shared drawer without leaving the current card set.</p>
   </header>
+
+  {#if library.items.length === 0}
+    <section class="cards-page__state stack" style="--stack-space: var(--space-2)">
+      <div class="cards-page__state-icon" aria-hidden="true">🃏</div>
+      <h2>No active cards yet</h2>
+      <p>Promote a draft card in Card Entry to start building your library.</p>
+    </section>
+  {:else}
+    <section class="cards-page__list stack" style="--stack-space: var(--space-3)">
+      <div class="cards-page__columns" aria-hidden="true">
+        <span>Card</span>
+        <span>Groups</span>
+        <span>Updated</span>
+      </div>
+
+      {#each library.items as item (item.cardId)}
+        <button type="button" class="cards-page__row" on:click={() => void openCard(item.cardId)}>
+          <div class="cards-page__content stack" style="--stack-space: var(--space-1)">
+            <div class="cluster cards-page__heading">
+              <CardListStatusBadge label="Active" tone="active" />
+              <h2>{item.content}</h2>
+            </div>
+
+            {#if item.meaning}
+              <p class="cards-page__meaning">{item.meaning}</p>
+            {/if}
+          </div>
+
+          <div class="cards-page__groups">
+            {#if item.groups.length === 0}
+              <span class="cards-page__empty-groups">No groups yet</span>
+            {:else}
+              {#each item.groups as group}
+                <CardListTagChip label={group.groupName} />
+              {/each}
+            {/if}
+          </div>
+
+          <span class="cards-page__updated">{item.updatedAtLabel}</span>
+        </button>
+      {/each}
+    </section>
+  {/if}
 </section>
 
+{#if selectedCard && selectedIndex >= 0}
+  <ActiveCardDrawer
+    lang={$page.params.lang ?? ''}
+    card={selectedCard}
+    availableGroups={selectedCardAvailableGroups}
+    selectedIndex={selectedIndex}
+    totalCount={library.filteredCardIds.length}
+    hasPrevious={selectedIndex > 0}
+    hasNext={selectedIndex < library.filteredCardIds.length - 1}
+    on:updated={handleCardUpdated}
+    on:deleted={handleCardDeleted}
+    on:close={() => void navigateDrawer(null)}
+    on:previous={() => void navigateDrawer(library.filteredCardIds[selectedIndex - 1] ?? null)}
+    on:next={() => void navigateDrawer(library.filteredCardIds[selectedIndex + 1] ?? null)}
+  />
+{/if}
+
 <style>
-  .app-screen {
-    --center-max: 60rem;
-    padding-inline: var(--space-5);
+  .cards-page {
+    padding: calc(var(--shell-header-height) + var(--space-5)) var(--space-4) var(--space-7);
   }
 
-  .screen-eyebrow {
+  .cards-page__eyebrow {
+    margin: 0;
+    color: var(--color-text-secondary);
     font-family: var(--font-ui);
-    font-size: var(--font-size-ui);
+    font-size: var(--font-size-caption);
     letter-spacing: var(--tracking-caps);
     text-transform: uppercase;
+  }
+
+  .cards-page h1,
+  .cards-page h2,
+  .cards-page p {
+    margin: 0;
+  }
+
+  .cards-page__state {
+    align-items: center;
+    justify-items: center;
+    padding: var(--space-6);
+    border: 1px dashed var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+    text-align: center;
+  }
+
+  .cards-page__state-icon {
+    font-size: 2rem;
+  }
+
+  .cards-page__columns {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(10rem, 1fr) auto;
+    gap: var(--space-3);
+    padding: 0 var(--space-4) var(--space-2);
+    color: var(--color-text-muted);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-caption);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .cards-page__row {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(10rem, 1fr) auto;
+    gap: var(--space-3);
+    align-items: start;
+    inline-size: 100%;
+    padding: var(--space-4);
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+    color: inherit;
+    text-align: start;
+    transition:
+      border-color var(--duration-fast) var(--ease-standard),
+      background var(--duration-fast) var(--ease-standard);
+  }
+
+  .cards-page__row:hover,
+  .cards-page__row:focus-visible {
+    border-color: var(--color-border);
+    background: color-mix(in srgb, var(--color-surface-raised) 45%, var(--color-surface));
+  }
+
+  .cards-page__heading {
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .cards-page__heading h2 {
+    font-size: var(--font-size-h4);
+  }
+
+  .cards-page__meaning,
+  .cards-page__updated,
+  .cards-page__empty-groups {
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+  }
+
+  .cards-page__groups {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+
+  .cards-page__row:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  @media (max-width: 900px) {
+    .cards-page {
+      padding-inline: var(--space-3);
+    }
+
+    .cards-page__columns {
+      display: none;
+    }
+
+    .cards-page__row {
+      grid-template-columns: 1fr;
+    }
   }
 </style>

--- a/apps/web/src/routes/[lang]/cards/[cardId]/+server.ts
+++ b/apps/web/src/routes/[lang]/cards/[cardId]/+server.ts
@@ -1,0 +1,92 @@
+import { error, json, type RequestHandler } from '@sveltejs/kit';
+import { withTransactionDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import {
+  CardLibraryRequestError,
+  deleteCardLibraryCardsForLanguage,
+  updateCardLibraryCardForLanguage,
+} from '$lib/server/cards.js';
+
+export const PATCH: RequestHandler = async (event) => {
+  const session = await event.locals.auth();
+  const userId = session?.user?.id;
+  const params = event.params as {
+    lang?: string;
+    cardId?: string;
+  };
+  const languageId = params.lang;
+  const cardId = params.cardId;
+
+  if (!userId || !languageId || !cardId) {
+    throw error(401, 'You must be signed in to edit this card.');
+  }
+
+  const databaseUrl = env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    throw error(500, 'The card service is not configured right now.');
+  }
+
+  let body: unknown;
+
+  try {
+    body = await event.request.json();
+  } catch {
+    throw error(400, 'The card update payload must be valid JSON.');
+  }
+
+  try {
+    const result = await withTransactionDb(
+      databaseUrl,
+      (database) => updateCardLibraryCardForLanguage(userId, languageId, cardId, body, database as never)
+    );
+
+    return json(result);
+  } catch (requestError) {
+    if (requestError instanceof CardLibraryRequestError) {
+      throw error(requestError.status, requestError.message);
+    }
+
+    console.error('Failed to update active card:', requestError);
+    throw error(500, 'The card could not be updated right now.');
+  }
+};
+
+export const DELETE: RequestHandler = async (event) => {
+  const session = await event.locals.auth();
+  const userId = session?.user?.id;
+  const params = event.params as {
+    lang?: string;
+    cardId?: string;
+  };
+  const languageId = params.lang;
+  const cardId = params.cardId;
+
+  if (!userId || !languageId || !cardId) {
+    throw error(401, 'You must be signed in to edit this card.');
+  }
+
+  const databaseUrl = env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    throw error(500, 'The card service is not configured right now.');
+  }
+
+  try {
+    const deletedCardIds = await withTransactionDb(
+      databaseUrl,
+      (database) => deleteCardLibraryCardsForLanguage(userId, languageId, [cardId], database as never)
+    );
+
+    return json({
+      deletedCardIds,
+    });
+  } catch (requestError) {
+    if (requestError instanceof CardLibraryRequestError) {
+      throw error(requestError.status, requestError.message);
+    }
+
+    console.error('Failed to delete active card:', requestError);
+    throw error(500, 'The card could not be removed right now.');
+  }
+};

--- a/apps/web/src/routes/[lang]/cards/groups/[groupId]/+page.server.ts
+++ b/apps/web/src/routes/[lang]/cards/groups/[groupId]/+page.server.ts
@@ -1,7 +1,7 @@
 import { error, redirect } from '@sveltejs/kit';
 import { getDb } from '@studypuck/database';
 import { env } from '$env/dynamic/private';
-import { CardLibraryRequestError, loadGroupDetailData } from '$lib/server/cards.js';
+import { CardLibraryRequestError, loadActiveCardDetailData, loadGroupDetailData } from '$lib/server/cards.js';
 import type { PageServerLoad } from './$types.js';
 
 export const load: PageServerLoad = async (event) => {
@@ -14,10 +14,23 @@ export const load: PageServerLoad = async (event) => {
   }
 
   const database = getDb(env.DATABASE_URL);
+  const selectedCardId = event.url.searchParams.get('card');
 
   try {
+    const groupDetail = await loadGroupDetailData(session.user.id, languageCode, groupId, event.url, database);
+
+    if (selectedCardId && !groupDetail.cards.filteredCardIds.includes(selectedCardId)) {
+      throw error(404, 'Active card not found in the current group view.');
+    }
+
+    const selectedCard = selectedCardId
+      ? await loadActiveCardDetailData(session.user.id, languageCode, selectedCardId, database)
+      : null;
+
     return {
-      groupDetail: await loadGroupDetailData(session.user.id, languageCode, groupId, event.url, database),
+      groupDetail,
+      selectedCard: selectedCard?.card ?? null,
+      selectedCardAvailableGroups: selectedCard?.availableGroups ?? [],
     };
   } catch (requestError) {
     if (requestError instanceof CardLibraryRequestError) {

--- a/apps/web/src/routes/[lang]/cards/groups/[groupId]/+page.svelte
+++ b/apps/web/src/routes/[lang]/cards/groups/[groupId]/+page.svelte
@@ -1,31 +1,304 @@
-<svelte:head>
-  <title>Group Detail – StudyPuck</title>
-</svelte:head>
-
-<section class="center stack app-screen" style="--stack-space: var(--space-5)">
-  <header class="stack" style="--stack-space: var(--space-2)">
-    <p class="screen-eyebrow text-muted">Cards</p>
-    <h1>{data.groupDetail.group.groupName}</h1>
-    <p>This placeholder route keeps the future Group Detail loader wired while the full surface is built.</p>
-  </header>
-</section>
-
 <script lang="ts">
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import ActiveCardDrawer from '$lib/components/cards/ActiveCardDrawer.svelte';
+  import CardListStatusBadge from '$lib/components/card-list/CardListStatusBadge.svelte';
+  import CardListTagChip from '$lib/components/card-list/CardListTagChip.svelte';
+  import type {
+    CardLibraryCardDetailData,
+    CardLibraryCardListItemData,
+    CardLibraryData,
+    CardLibraryGroupData,
+  } from '$lib/server/cards.js';
   import type { PageData } from './$types.js';
 
-  let { data }: { data: PageData } = $props();
-</script>
+  export let data: PageData;
 
-<style>
-  .app-screen {
-    --center-max: 60rem;
-    padding-inline: var(--space-5);
+  let cards: CardLibraryData = data.groupDetail.cards;
+  let selectedCard: CardLibraryCardDetailData | null = data.selectedCard;
+  let selectedCardAvailableGroups: CardLibraryGroupData[] = data.selectedCardAvailableGroups;
+  let previousCards = data.groupDetail.cards;
+  let previousSelectedCard = data.selectedCard;
+  let previousSelectedCardAvailableGroups = data.selectedCardAvailableGroups;
+
+  $: if (data.groupDetail.cards !== previousCards) {
+    cards = data.groupDetail.cards;
+    previousCards = data.groupDetail.cards;
   }
 
-  .screen-eyebrow {
+  $: if (data.selectedCard !== previousSelectedCard) {
+    selectedCard = data.selectedCard;
+    previousSelectedCard = data.selectedCard;
+  }
+
+  $: if (data.selectedCardAvailableGroups !== previousSelectedCardAvailableGroups) {
+    selectedCardAvailableGroups = data.selectedCardAvailableGroups;
+    previousSelectedCardAvailableGroups = data.selectedCardAvailableGroups;
+  }
+
+  $: selectedIndex = selectedCard ? cards.filteredCardIds.indexOf(selectedCard.cardId) : -1;
+
+  function buildDrawerUrl(cardId: string | null) {
+    const nextUrl = new URL($page.url);
+
+    if (cardId) {
+      nextUrl.searchParams.set('card', cardId);
+    } else {
+      nextUrl.searchParams.delete('card');
+    }
+
+    return `${nextUrl.pathname}${nextUrl.search}`;
+  }
+
+  async function openCard(cardId: string) {
+    await goto(buildDrawerUrl(cardId), {
+      keepFocus: true,
+      noScroll: true,
+    });
+  }
+
+  async function navigateDrawer(cardId: string | null) {
+    await goto(buildDrawerUrl(cardId), {
+      keepFocus: true,
+      noScroll: true,
+      replaceState: true,
+    });
+  }
+
+  function sortCards(items: CardLibraryCardListItemData[]) {
+    return [...items].sort((left, right) => {
+      const leftTime = left.updatedAtIso ? Date.parse(left.updatedAtIso) : 0;
+      const rightTime = right.updatedAtIso ? Date.parse(right.updatedAtIso) : 0;
+      return rightTime - leftTime;
+    });
+  }
+
+  function mapDetailToListItem(card: CardLibraryCardDetailData): CardLibraryCardListItemData {
+    return {
+      cardId: card.cardId,
+      content: card.content,
+      meaning: card.meaning,
+      cardType: card.cardType,
+      updatedAtIso: card.updatedAtIso ?? new Date().toISOString(),
+      updatedAtLabel: 'Just now',
+      groups: card.groups,
+    };
+  }
+
+  function handleCardUpdated(event: CustomEvent<{ card: CardLibraryCardDetailData; availableGroups: CardLibraryGroupData[] }>) {
+    selectedCard = event.detail.card;
+    selectedCardAvailableGroups = event.detail.availableGroups;
+
+    const nextItem = mapDetailToListItem(event.detail.card);
+    const otherItems = cards.items.filter((item) => item.cardId !== nextItem.cardId);
+    const nextItems = sortCards([nextItem, ...otherItems]);
+
+    cards = {
+      ...cards,
+      items: nextItems,
+      filteredCardIds: nextItems.map((item) => item.cardId),
+    };
+  }
+
+  function handleCardDeleted(event: CustomEvent<{ cardId: string }>) {
+    const nextItems = cards.items.filter((item) => item.cardId !== event.detail.cardId);
+
+    cards = {
+      ...cards,
+      items: nextItems,
+      totalCount: nextItems.length,
+      filteredCardIds: nextItems.map((item) => item.cardId),
+    };
+
+    selectedCard = null;
+    void navigateDrawer(null);
+  }
+</script>
+
+<svelte:head>
+  <title>{data.groupDetail.group.groupName} – StudyPuck</title>
+</svelte:head>
+
+<section class="group-detail-page stack" style="--stack-space: var(--space-5)">
+  <header class="stack" style="--stack-space: var(--space-2)">
+    <p class="group-detail-page__eyebrow">Cards</p>
+    <h1>{data.groupDetail.group.groupName}</h1>
+    {#if data.groupDetail.group.description}
+      <p>{data.groupDetail.group.description}</p>
+    {/if}
+    <p class="group-detail-page__count">
+      {data.groupDetail.group.activeCardCount} active {data.groupDetail.group.activeCardCount === 1 ? 'card' : 'cards'}
+    </p>
+  </header>
+
+  {#if cards.items.length === 0}
+    <section class="group-detail-page__state stack" style="--stack-space: var(--space-2)">
+      <div class="group-detail-page__state-icon" aria-hidden="true">📂</div>
+      <h2>No cards in this group yet</h2>
+      <p>Add cards to this group from the library once they are active.</p>
+    </section>
+  {:else}
+    <section class="group-detail-page__list stack" style="--stack-space: var(--space-3)">
+      <div class="group-detail-page__columns" aria-hidden="true">
+        <span>Card</span>
+        <span>Groups</span>
+        <span>Updated</span>
+      </div>
+
+      {#each cards.items as item (item.cardId)}
+        <button type="button" class="group-detail-page__row" on:click={() => void openCard(item.cardId)}>
+          <div class="group-detail-page__content stack" style="--stack-space: var(--space-1)">
+            <div class="cluster group-detail-page__heading">
+              <CardListStatusBadge label="Active" tone="active" />
+              <h2>{item.content}</h2>
+            </div>
+
+            {#if item.meaning}
+              <p class="group-detail-page__meaning">{item.meaning}</p>
+            {/if}
+          </div>
+
+          <div class="group-detail-page__groups">
+            {#if item.groups.length === 0}
+              <span class="group-detail-page__empty-groups">No groups yet</span>
+            {:else}
+              {#each item.groups as group}
+                <CardListTagChip label={group.groupName} />
+              {/each}
+            {/if}
+          </div>
+
+          <span class="group-detail-page__updated">{item.updatedAtLabel}</span>
+        </button>
+      {/each}
+    </section>
+  {/if}
+</section>
+
+{#if selectedCard && selectedIndex >= 0}
+  <ActiveCardDrawer
+    lang={$page.params.lang ?? ''}
+    card={selectedCard}
+    availableGroups={selectedCardAvailableGroups}
+    selectedIndex={selectedIndex}
+    totalCount={cards.filteredCardIds.length}
+    hasPrevious={selectedIndex > 0}
+    hasNext={selectedIndex < cards.filteredCardIds.length - 1}
+    on:updated={handleCardUpdated}
+    on:deleted={handleCardDeleted}
+    on:close={() => void navigateDrawer(null)}
+    on:previous={() => void navigateDrawer(cards.filteredCardIds[selectedIndex - 1] ?? null)}
+    on:next={() => void navigateDrawer(cards.filteredCardIds[selectedIndex + 1] ?? null)}
+  />
+{/if}
+
+<style>
+  .group-detail-page {
+    padding: calc(var(--shell-header-height) + var(--space-5)) var(--space-4) var(--space-7);
+  }
+
+  .group-detail-page__eyebrow,
+  .group-detail-page__count,
+  .group-detail-page__meaning,
+  .group-detail-page__updated,
+  .group-detail-page__empty-groups {
+    color: var(--color-text-secondary);
     font-family: var(--font-ui);
-    font-size: var(--font-size-ui);
+  }
+
+  .group-detail-page__eyebrow {
+    margin: 0;
+    font-size: var(--font-size-caption);
     letter-spacing: var(--tracking-caps);
     text-transform: uppercase;
+  }
+
+  .group-detail-page h1,
+  .group-detail-page h2,
+  .group-detail-page p {
+    margin: 0;
+  }
+
+  .group-detail-page__state {
+    align-items: center;
+    justify-items: center;
+    padding: var(--space-6);
+    border: 1px dashed var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+    text-align: center;
+  }
+
+  .group-detail-page__state-icon {
+    font-size: 2rem;
+  }
+
+  .group-detail-page__columns {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(10rem, 1fr) auto;
+    gap: var(--space-3);
+    padding: 0 var(--space-4) var(--space-2);
+    color: var(--color-text-muted);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-caption);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .group-detail-page__row {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(10rem, 1fr) auto;
+    gap: var(--space-3);
+    align-items: start;
+    inline-size: 100%;
+    padding: var(--space-4);
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+    color: inherit;
+    text-align: start;
+    transition:
+      border-color var(--duration-fast) var(--ease-standard),
+      background var(--duration-fast) var(--ease-standard);
+  }
+
+  .group-detail-page__row:hover,
+  .group-detail-page__row:focus-visible {
+    border-color: var(--color-border);
+    background: color-mix(in srgb, var(--color-surface-raised) 45%, var(--color-surface));
+  }
+
+  .group-detail-page__heading {
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .group-detail-page__heading h2 {
+    font-size: var(--font-size-h4);
+  }
+
+  .group-detail-page__groups {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+
+  .group-detail-page__row:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  @media (max-width: 900px) {
+    .group-detail-page {
+      padding-inline: var(--space-3);
+    }
+
+    .group-detail-page__columns {
+      display: none;
+    }
+
+    .group-detail-page__row {
+      grid-template-columns: 1fr;
+    }
   }
 </style>


### PR DESCRIPTION
## Summary
- add the shared active-card drawer component for Card Library and Group Detail
- wire `?card=` query-state loading plus active-card PATCH/DELETE endpoints for in-drawer editing
- cover the new drawer behavior with component tests and track shared-editor refactor follow-up in #172

## Testing
- pnpm turbo test lint build --filter=web
- pnpm test:db:branch:secure

Closes #140.