### PR TITLE
Build card library surface

### DIFF
--- a/apps/web/src/lib/cards/library.test.ts
+++ b/apps/web/src/lib/cards/library.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  cardLibraryTypeOptions,
+  formatCardLibraryGroupFilterLabel,
+  formatCardLibraryTypeFilterLabel,
+  getVisibleCardGroups,
+  sortCardLibraryGroups,
+} from './library.js';
+
+describe('formatCardLibraryGroupFilterLabel', () => {
+  it('formats default, single-select, and multi-select group labels', () => {
+    expect(formatCardLibraryGroupFilterLabel([])).toBe('All groups');
+    expect(formatCardLibraryGroupFilterLabel(['Greetings'])).toBe('Group: Greetings');
+    expect(formatCardLibraryGroupFilterLabel(['Greetings', 'Daily'])).toBe('Groups: 2');
+  });
+});
+
+describe('formatCardLibraryTypeFilterLabel', () => {
+  it('formats default and selected card-type labels', () => {
+    expect(formatCardLibraryTypeFilterLabel(null)).toBe('All types');
+    expect(formatCardLibraryTypeFilterLabel('pattern')).toBe('Type: Pattern');
+  });
+});
+
+describe('getVisibleCardGroups', () => {
+  it('limits visible groups and reports overflow count', () => {
+    expect(
+      getVisibleCardGroups(
+        [
+          { groupId: 'g1', groupName: 'Greetings' },
+          { groupId: 'g2', groupName: 'Daily' },
+          { groupId: 'g3', groupName: 'Food' },
+        ],
+        2,
+      ),
+    ).toEqual({
+      visibleGroups: [
+        { groupId: 'g1', groupName: 'Greetings' },
+        { groupId: 'g2', groupName: 'Daily' },
+      ],
+      overflowCount: 1,
+    });
+  });
+});
+
+describe('sortCardLibraryGroups', () => {
+  it('sorts group options alphabetically by group name', () => {
+    expect(
+      sortCardLibraryGroups([
+        { groupId: 'g2', groupName: 'Travel' },
+        { groupId: 'g1', groupName: 'Daily' },
+      ]),
+    ).toEqual([
+      { groupId: 'g1', groupName: 'Daily' },
+      { groupId: 'g2', groupName: 'Travel' },
+    ]);
+  });
+});
+
+describe('cardLibraryTypeOptions', () => {
+  it('exposes the supported card types for the filter UI', () => {
+    expect(cardLibraryTypeOptions.map((option) => option.value)).toEqual(['word', 'pattern', 'complex_prompt']);
+  });
+});

--- a/apps/web/src/lib/cards/library.ts
+++ b/apps/web/src/lib/cards/library.ts
@@ -1,0 +1,74 @@
+import type {
+  CardLibraryCardListItemData,
+  CardLibraryData,
+  CardLibraryGroupData,
+} from '$lib/server/cards.js';
+
+export type CardLibraryCardType = NonNullable<CardLibraryData['filters']['cardType']>;
+
+export const cardLibraryTypeOptions: Array<{
+  value: CardLibraryCardType;
+  label: string;
+}> = [
+  { value: 'word', label: 'Word' },
+  { value: 'pattern', label: 'Pattern' },
+  { value: 'complex_prompt', label: 'Complex prompt' },
+];
+
+export function formatCardLibraryGroupFilterLabel(selectedGroupNames: string[]): string {
+  if (selectedGroupNames.length === 0) {
+    return 'All groups';
+  }
+
+  if (selectedGroupNames.length === 1) {
+    return `Group: ${selectedGroupNames[0]}`;
+  }
+
+  return `Groups: ${selectedGroupNames.length}`;
+}
+
+export function formatCardLibraryTypeFilterLabel(selectedType: CardLibraryCardType | null): string {
+  if (!selectedType) {
+    return 'All types';
+  }
+
+  return `Type: ${cardLibraryTypeOptions.find((option) => option.value === selectedType)?.label ?? selectedType}`;
+}
+
+export function getVisibleCardGroups(groups: CardLibraryGroupData[], maxVisible = 2) {
+  return {
+    visibleGroups: groups.slice(0, maxVisible),
+    overflowCount: Math.max(groups.length - maxVisible, 0),
+  };
+}
+
+export function mapCardDetailToListItem(card: {
+  cardId: string;
+  content: string;
+  meaning: string | null;
+  cardType: string | null;
+  updatedAtIso: string | null;
+  groups: CardLibraryGroupData[];
+}): CardLibraryCardListItemData {
+  return {
+    cardId: card.cardId,
+    content: card.content,
+    meaning: card.meaning,
+    cardType: card.cardType,
+    updatedAtIso: card.updatedAtIso ?? new Date().toISOString(),
+    updatedAtLabel: 'Just now',
+    groups: card.groups,
+  };
+}
+
+export function sortCardLibraryItems(items: CardLibraryCardListItemData[]) {
+  return [...items].sort((left, right) => {
+    const leftTime = left.updatedAtIso ? Date.parse(left.updatedAtIso) : 0;
+    const rightTime = right.updatedAtIso ? Date.parse(right.updatedAtIso) : 0;
+    return rightTime - leftTime;
+  });
+}
+
+export function sortCardLibraryGroups<T extends { groupName: string }>(groups: T[]) {
+  return [...groups].sort((left, right) => left.groupName.localeCompare(right.groupName));
+}

--- a/apps/web/src/lib/components/CommandBar.test.ts
+++ b/apps/web/src/lib/components/CommandBar.test.ts
@@ -35,5 +35,5 @@ describe('CommandBar SSR', () => {
         },
       }),
     ).not.toThrow();
-  });
+  }, 10_000);
 });

--- a/apps/web/src/lib/components/card-list/CardListFilterBar.svelte
+++ b/apps/web/src/lib/components/card-list/CardListFilterBar.svelte
@@ -4,13 +4,22 @@
     groupName: string;
   };
 
+  type CardListTypeOption = {
+    value: string;
+    label: string;
+  };
+
   export let availableGroups: CardListGroupOption[] = [];
+  export let availableTypes: CardListTypeOption[] = [];
   export let searchLabel = 'Search';
   export let searchPlaceholder = 'Search...';
   export let searchQuery = '';
   export let groupFilterLabel = 'All groups';
+  export let typeFilterLabel = 'All types';
   export let selectedGroupIds: string[] = [];
+  export let selectedType: string | null = null;
   export let clearGroupLabel = 'Clear group filters';
+  export let clearTypeLabel = 'All types';
 
   function toggleGroup(groupId: string) {
     if (selectedGroupIds.includes(groupId)) {
@@ -23,6 +32,10 @@
 
   function clearGroupFilters() {
     selectedGroupIds = [];
+  }
+
+  function selectType(value: string | null) {
+    selectedType = value;
   }
 </script>
 
@@ -39,7 +52,10 @@
   </label>
 
   <details class="card-list-filter-bar__groups">
-    <summary class="card-list-filter-bar__groups-summary">
+    <summary
+      class:card-list-filter-bar__summary--active={selectedGroupIds.length > 0}
+      class="card-list-filter-bar__groups-summary"
+    >
       {groupFilterLabel}
       <span aria-hidden="true">▾</span>
     </summary>
@@ -61,12 +77,41 @@
       {/each}
     </div>
   </details>
+
+  {#if availableTypes.length > 0}
+    <details class="card-list-filter-bar__groups">
+      <summary
+        class:card-list-filter-bar__summary--active={selectedType !== null}
+        class="card-list-filter-bar__groups-summary"
+      >
+        {typeFilterLabel}
+        <span aria-hidden="true">▾</span>
+      </summary>
+
+      <div class="card-list-filter-bar__groups-menu stack" style="--stack-space: var(--space-2)">
+        <button type="button" class="card-list-filter-bar__clear" on:click={() => selectType(null)}>
+          {clearTypeLabel}
+        </button>
+
+        {#each availableTypes as typeOption}
+          <button
+            type="button"
+            class:selected={selectedType === typeOption.value}
+            class="card-list-filter-bar__type-option"
+            on:click={() => selectType(typeOption.value)}
+          >
+            {typeOption.label}
+          </button>
+        {/each}
+      </div>
+    </details>
+  {/if}
 </section>
 
 <style>
   .card-list-filter-bar {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr) auto auto;
     gap: var(--space-3);
   }
 
@@ -120,6 +165,12 @@
     list-style: none;
   }
 
+  .card-list-filter-bar__summary--active {
+    border-color: color-mix(in srgb, var(--color-primary-text) 40%, var(--color-border));
+    background: color-mix(in srgb, var(--color-primary-subtle) 12%, var(--color-surface));
+    color: var(--color-primary-text);
+  }
+
   .card-list-filter-bar__groups-summary::-webkit-details-marker {
     display: none;
   }
@@ -160,9 +211,27 @@
     font-family: var(--font-ui);
   }
 
+  .card-list-filter-bar__type-option {
+    justify-self: start;
+    padding: 0.25rem 0;
+    border: 0;
+    background: none;
+    color: var(--color-text-primary);
+    cursor: pointer;
+    font: inherit;
+    font-family: var(--font-ui);
+    text-align: start;
+  }
+
+  .card-list-filter-bar__type-option.selected {
+    color: var(--color-primary-text);
+    font-weight: 600;
+  }
+
   .card-list-filter-bar__search-input:focus-visible,
   .card-list-filter-bar__groups-summary:focus-visible,
-  .card-list-filter-bar__clear:focus-visible {
+  .card-list-filter-bar__clear:focus-visible,
+  .card-list-filter-bar__type-option:focus-visible {
     outline: none;
     border-color: color-mix(in srgb, var(--color-primary-text) 45%, var(--color-border));
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary-text) 18%, transparent);
@@ -170,7 +239,11 @@
 
   @media (max-width: 900px) {
     .card-list-filter-bar {
-      grid-template-columns: 1fr;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .card-list-filter-bar__search {
+      grid-column: 1 / -1;
     }
 
     .card-list-filter-bar__groups-summary {

--- a/apps/web/src/lib/components/card-list/CardListRow.svelte
+++ b/apps/web/src/lib/components/card-list/CardListRow.svelte
@@ -3,14 +3,84 @@
 
   const dispatch = createEventDispatcher<{
     toggleSelection: void;
+    activate: void;
+    longpress: void;
   }>();
 
   export let selected = false;
   export let checkboxLabel = 'Select card';
   export let rowTemplate = '1rem minmax(0, 2.25fr) minmax(9rem, 1fr) auto auto';
+  export let clickable = false;
+  export let mobileShowCheckbox = true;
+  export let hasActions = true;
+  export let longPressDuration = 500;
+
+  let longPressTimer: ReturnType<typeof setTimeout> | null = null;
+  let didTriggerLongPress = false;
+
+  function clearLongPressTimer() {
+    if (!longPressTimer) {
+      return;
+    }
+
+    clearTimeout(longPressTimer);
+    longPressTimer = null;
+  }
+
+  function shouldIgnoreActivate(target: EventTarget | null) {
+    return target instanceof Element && Boolean(target.closest('input, button, a, summary, [data-card-list-ignore-activate="true"]'));
+  }
+
+  function handleActivate(event: MouseEvent) {
+    if (!clickable || shouldIgnoreActivate(event.target)) {
+      didTriggerLongPress = false;
+      return;
+    }
+
+    if (didTriggerLongPress) {
+      didTriggerLongPress = false;
+      return;
+    }
+
+    dispatch('activate');
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (!clickable || shouldIgnoreActivate(event.target) || event.key !== 'Enter') {
+      return;
+    }
+
+    event.preventDefault();
+    dispatch('activate');
+  }
+
+  function handleTouchStart(event: TouchEvent) {
+    if (!clickable || shouldIgnoreActivate(event.target)) {
+      return;
+    }
+
+    didTriggerLongPress = false;
+    clearLongPressTimer();
+    longPressTimer = setTimeout(() => {
+      didTriggerLongPress = true;
+      dispatch('longpress');
+    }, longPressDuration);
+  }
 </script>
 
-<article class:selected class="card-list-row">
+<article
+  class:selected
+  class:card-list-row--clickable={clickable}
+  class:card-list-row--mobile-checkbox-hidden={!mobileShowCheckbox}
+  class="card-list-row"
+  tabindex={clickable ? 0 : undefined}
+  on:click={handleActivate}
+  on:keydown={handleKeydown}
+  on:touchstart={handleTouchStart}
+  on:touchend={clearLongPressTimer}
+  on:touchmove={clearLongPressTimer}
+  on:touchcancel={clearLongPressTimer}
+>
   <div class="card-list-row__track" style={`--card-list-row-template: ${rowTemplate}`}>
     <label class="card-list-row__checkbox">
       <input type="checkbox" checked={selected} on:change={() => dispatch('toggleSelection')} />
@@ -29,9 +99,11 @@
       <slot name="updated" />
     </div>
 
-    <div class="card-list-row__actions" aria-label="Row actions">
-      <slot name="actions" />
-    </div>
+    {#if hasActions}
+      <div class="card-list-row__actions" aria-label="Row actions">
+        <slot name="actions" />
+      </div>
+    {/if}
   </div>
 </article>
 
@@ -49,6 +121,10 @@
   .card-list-row.selected {
     border-color: color-mix(in srgb, var(--color-primary-text) 45%, var(--color-border));
     background: color-mix(in srgb, var(--color-primary-subtle) 12%, var(--color-surface));
+  }
+
+  .card-list-row--clickable {
+    cursor: pointer;
   }
 
   .card-list-row:hover,
@@ -156,6 +232,17 @@
 
     .card-list-row__checkbox {
       justify-content: start;
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .card-list-row--mobile-checkbox-hidden .card-list-row__checkbox {
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    .card-list-row--mobile-checkbox-hidden.selected .card-list-row__checkbox,
+    .card-list-row--mobile-checkbox-hidden:focus-within .card-list-row__checkbox {
       opacity: 1;
       pointer-events: auto;
     }

--- a/apps/web/src/lib/server/cards.test.ts
+++ b/apps/web/src/lib/server/cards.test.ts
@@ -171,6 +171,6 @@ describe('Card Library server helpers', () => {
   });
 
   it('formats relative card timestamps using compact labels', () => {
-    expect(formatCardLibraryRelativeTime(new Date('2026-04-10T12:00:00Z'), new Date('2026-04-12T12:00:00Z'))).toBe('2d ago');
+    expect(formatCardLibraryRelativeTime(new Date('2026-04-10T12:00:00Z'), new Date('2026-04-12T12:00:00Z'))).toBe('2d');
   });
 });

--- a/apps/web/src/lib/server/cards.ts
+++ b/apps/web/src/lib/server/cards.ts
@@ -221,35 +221,35 @@ export function formatCardLibraryRelativeTime(date: Date, now = new Date()): str
   const differenceInMinutes = Math.floor(differenceInSeconds / 60);
 
   if (differenceInMinutes < 60) {
-    return `${differenceInMinutes}m ago`;
+    return `${differenceInMinutes}m`;
   }
 
   const differenceInHours = Math.floor(differenceInMinutes / 60);
 
   if (differenceInHours < 24) {
-    return `${differenceInHours}h ago`;
+    return `${differenceInHours}h`;
   }
 
   const differenceInDays = Math.floor(differenceInHours / 24);
 
   if (differenceInDays < 7) {
-    return `${differenceInDays}d ago`;
+    return `${differenceInDays}d`;
   }
 
   const differenceInWeeks = Math.floor(differenceInDays / 7);
 
   if (differenceInWeeks < 5) {
-    return `${differenceInWeeks}w ago`;
+    return `${differenceInWeeks}w`;
   }
 
   const differenceInMonths = Math.floor(differenceInDays / 30);
 
   if (differenceInMonths < 12) {
-    return `${differenceInMonths}mo ago`;
+    return `${differenceInMonths}mo`;
   }
 
   const differenceInYears = Math.floor(differenceInDays / 365);
-  return `${differenceInYears}y ago`;
+  return `${differenceInYears}y`;
 }
 
 function mapGroupSummary(group: ActiveCardGroupSummary): CardLibraryGroupData {
@@ -265,6 +265,10 @@ function mapGroupFilterOption(group: GroupWithActiveCardCount): CardLibraryGroup
     groupName: group.groupName,
     activeCardCount: group.activeCardCount,
   };
+}
+
+function sortGroupsByName<T extends { groupName: string }>(groups: T[]) {
+  return [...groups].sort((left, right) => left.groupName.localeCompare(right.groupName));
 }
 
 function mapCardListItem(card: ActiveCardListItem, now = new Date()): CardLibraryCardListItemData {
@@ -421,7 +425,7 @@ export async function loadCardLibraryData(
     totalCount: items.length,
     filteredCardIds: items.map((item) => item.cardId),
     filters,
-    availableGroups: availableGroups.map((group) => mapGroupFilterOption(group)),
+    availableGroups: sortGroupsByName(availableGroups.map((group) => mapGroupFilterOption(group))),
   };
 }
 
@@ -468,7 +472,7 @@ export async function loadGroupDetailData(
       totalCount: items.length,
       filteredCardIds: items.map((item) => item.cardId),
       filters,
-      availableGroups: availableGroups.map((availableGroup) => mapGroupFilterOption(availableGroup)),
+      availableGroups: sortGroupsByName(availableGroups.map((availableGroup) => mapGroupFilterOption(availableGroup))),
     },
   };
 }
@@ -497,7 +501,7 @@ export async function loadActiveCardDetailData(
 
   return {
     card: mapActiveCardDetail(card),
-    availableGroups: availableGroups.map((group) => mapGroupSummary(group)),
+    availableGroups: sortGroupsByName(availableGroups.map((group) => mapGroupSummary(group))),
   };
 }
 

--- a/apps/web/src/routes/[lang]/cards/+page.svelte
+++ b/apps/web/src/routes/[lang]/cards/+page.svelte
@@ -1,9 +1,23 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
+  import { goto, invalidateAll } from '$app/navigation';
   import { page } from '$app/stores';
+  import { onDestroy, onMount } from 'svelte';
   import ActiveCardDrawer from '$lib/components/cards/ActiveCardDrawer.svelte';
-  import CardListStatusBadge from '$lib/components/card-list/CardListStatusBadge.svelte';
+  import CardListBulkActionBar from '$lib/components/card-list/CardListBulkActionBar.svelte';
+  import CardListColumns from '$lib/components/card-list/CardListColumns.svelte';
+  import CardListFilterBar from '$lib/components/card-list/CardListFilterBar.svelte';
+  import CardListRow from '$lib/components/card-list/CardListRow.svelte';
   import CardListTagChip from '$lib/components/card-list/CardListTagChip.svelte';
+  import {
+    cardLibraryTypeOptions,
+    formatCardLibraryGroupFilterLabel,
+    formatCardLibraryTypeFilterLabel,
+    getVisibleCardGroups,
+    mapCardDetailToListItem,
+    sortCardLibraryGroups,
+    sortCardLibraryItems,
+    type CardLibraryCardType,
+  } from '$lib/cards/library.js';
   import type {
     CardLibraryCardDetailData,
     CardLibraryCardListItemData,
@@ -14,12 +28,57 @@
 
   export let data: PageData;
 
+  type BulkAction = 'assign-group' | 'delete';
+  type ActionFeedback = {
+    title: string;
+    message: string;
+  };
+
   let library: CardLibraryData = data.library;
   let selectedCard: CardLibraryCardDetailData | null = data.selectedCard;
   let selectedCardAvailableGroups: CardLibraryGroupData[] = data.selectedCardAvailableGroups;
   let previousLibraryData = data.library;
   let previousSelectedCard = data.selectedCard;
   let previousSelectedCardAvailableGroups = data.selectedCardAvailableGroups;
+  let searchQuery = data.library.filters.searchText;
+  let selectedGroupIds = [...data.library.filters.groupIds];
+  let selectedType: CardLibraryCardType | null = data.library.filters.cardType;
+  let lastAppliedFilterState = '';
+  let lastRequestedFilterState = '';
+  let filterSyncTimer: ReturnType<typeof setTimeout> | null = null;
+  let selectedCardIds: string[] = [];
+  let isRefreshing = false;
+  let actionFeedback: ActionFeedback | null = null;
+  let pendingAction: { action: BulkAction; cardIds: string[] } | null = null;
+  let bulkAssignOpen = false;
+  let selectedBulkGroupId: string | null = null;
+  let isMobileViewport = false;
+  let viewportMediaQuery: MediaQueryList | null = null;
+
+  function serializeFilterState(nextSearchQuery: string, nextGroupIds: string[], nextType: CardLibraryCardType | null) {
+    return JSON.stringify({
+      searchQuery: nextSearchQuery.trim(),
+      groupIds: [...nextGroupIds],
+      type: nextType,
+    });
+  }
+
+  function syncViewportMode() {
+    isMobileViewport = viewportMediaQuery?.matches ?? false;
+  }
+
+  onMount(() => {
+    viewportMediaQuery = window.matchMedia('(max-width: 900px)');
+    syncViewportMode();
+    viewportMediaQuery.addEventListener('change', syncViewportMode);
+  });
+
+  onDestroy(() => {
+    filterSyncTimer && clearTimeout(filterSyncTimer);
+    viewportMediaQuery?.removeEventListener('change', syncViewportMode);
+  });
+
+  $: currentLang = $page.params.lang ?? '';
 
   $: if (data.library !== previousLibraryData) {
     library = data.library;
@@ -36,10 +95,76 @@
     previousSelectedCardAvailableGroups = data.selectedCardAvailableGroups;
   }
 
-  $: selectedIndex = selectedCard ? library.filteredCardIds.indexOf(selectedCard.cardId) : -1;
+  $: appliedFilterState = serializeFilterState(
+    library.filters.searchText,
+    library.filters.groupIds,
+    library.filters.cardType,
+  );
 
-  function buildDrawerUrl(cardId: string | null) {
+  $: if (appliedFilterState !== lastAppliedFilterState) {
+    searchQuery = library.filters.searchText;
+    selectedGroupIds = [...library.filters.groupIds];
+    selectedType = library.filters.cardType;
+    lastAppliedFilterState = appliedFilterState;
+    lastRequestedFilterState = appliedFilterState;
+    selectedCardIds = selectedCardIds.filter((cardId) => library.filteredCardIds.includes(cardId));
+  }
+
+  $: currentFilterState = serializeFilterState(searchQuery, selectedGroupIds, selectedType);
+
+  $: if (currentFilterState !== lastAppliedFilterState && currentFilterState !== lastRequestedFilterState) {
+    scheduleFilterNavigation(currentFilterState);
+  }
+
+  $: selectedIndex = selectedCard ? library.filteredCardIds.indexOf(selectedCard.cardId) : -1;
+  $: isSelectMode = selectedCardIds.length > 0;
+  $: sortedAvailableGroups = sortCardLibraryGroups(library.availableGroups);
+  $: selectedGroupNames = sortedAvailableGroups
+    .filter((group) => selectedGroupIds.includes(group.groupId))
+    .map((group) => group.groupName);
+  $: groupFilterLabel = formatCardLibraryGroupFilterLabel(selectedGroupNames);
+  $: typeFilterLabel = formatCardLibraryTypeFilterLabel(selectedType);
+  $: hasActiveFilters = searchQuery.trim().length > 0 || selectedGroupIds.length > 0 || selectedType !== null;
+
+  function scheduleFilterNavigation(nextFilterState: string) {
+    if (filterSyncTimer) {
+      clearTimeout(filterSyncTimer);
+    }
+
+    filterSyncTimer = setTimeout(() => {
+      lastRequestedFilterState = nextFilterState;
+      selectedCardIds = [];
+      bulkAssignOpen = false;
+      selectedBulkGroupId = null;
+      actionFeedback = null;
+      void goto(buildFilterUrl(), {
+        keepFocus: true,
+        noScroll: true,
+        replaceState: true,
+      });
+    }, 150);
+  }
+
+  function buildFilterUrl(cardId: string | null = null) {
     const nextUrl = new URL($page.url);
+
+    if (searchQuery.trim().length > 0) {
+      nextUrl.searchParams.set('q', searchQuery.trim());
+    } else {
+      nextUrl.searchParams.delete('q');
+    }
+
+    nextUrl.searchParams.delete('group');
+
+    for (const groupId of selectedGroupIds) {
+      nextUrl.searchParams.append('group', groupId);
+    }
+
+    if (selectedType) {
+      nextUrl.searchParams.set('type', selectedType);
+    } else {
+      nextUrl.searchParams.delete('type');
+    }
 
     if (cardId) {
       nextUrl.searchParams.set('card', cardId);
@@ -51,47 +176,139 @@
   }
 
   async function openCard(cardId: string) {
-    await goto(buildDrawerUrl(cardId), {
+    await goto(buildFilterUrl(cardId), {
       keepFocus: true,
       noScroll: true,
     });
   }
 
   async function navigateDrawer(cardId: string | null) {
-    await goto(buildDrawerUrl(cardId), {
+    await goto(buildFilterUrl(cardId), {
       keepFocus: true,
       noScroll: true,
       replaceState: true,
     });
   }
 
-  function sortLibraryItems(items: CardLibraryCardListItemData[]) {
-    return [...items].sort((left, right) => {
-      const leftTime = left.updatedAtIso ? Date.parse(left.updatedAtIso) : 0;
-      const rightTime = right.updatedAtIso ? Date.parse(right.updatedAtIso) : 0;
-      return rightTime - leftTime;
-    });
+  function clearFilters() {
+    searchQuery = '';
+    selectedGroupIds = [];
+    selectedType = null;
   }
 
-  function mapDetailToListItem(card: CardLibraryCardDetailData): CardLibraryCardListItemData {
-    return {
-      cardId: card.cardId,
-      content: card.content,
-      meaning: card.meaning,
-      cardType: card.cardType,
-      updatedAtIso: card.updatedAtIso ?? new Date().toISOString(),
-      updatedAtLabel: 'Just now',
-      groups: card.groups,
+  function toggleSelection(cardId: string) {
+    if (selectedCardIds.includes(cardId)) {
+      selectedCardIds = selectedCardIds.filter((selectedCardId) => selectedCardId !== cardId);
+      return;
+    }
+
+    selectedCardIds = [...selectedCardIds, cardId];
+  }
+
+  function clearSelection() {
+    selectedCardIds = [];
+    bulkAssignOpen = false;
+    selectedBulkGroupId = null;
+  }
+
+  function dismissActionFeedback() {
+    actionFeedback = null;
+  }
+
+  function handleRowActivate(cardId: string) {
+    if (isMobileViewport && isSelectMode) {
+      toggleSelection(cardId);
+      return;
+    }
+
+    void openCard(cardId);
+  }
+
+  function handleRowLongPress(cardId: string) {
+    if (!isMobileViewport) {
+      return;
+    }
+
+    if (!selectedCardIds.includes(cardId)) {
+      selectedCardIds = [...selectedCardIds, cardId];
+    }
+  }
+
+  function getMobileMeta(item: CardLibraryCardListItemData) {
+    const groupSummary = getVisibleCardGroups(item.groups);
+    const segments = [];
+
+    if (item.meaning) {
+      segments.push(item.meaning);
+    }
+
+    if (groupSummary.visibleGroups.length > 0) {
+      segments.push(
+        `${groupSummary.visibleGroups.map((group) => group.groupName).join(', ')}${groupSummary.overflowCount > 0 ? ` +${groupSummary.overflowCount}` : ''}`,
+      );
+    }
+
+    segments.push(item.updatedAtLabel);
+    return segments.join(' · ');
+  }
+
+  function isPending(action: BulkAction) {
+    return pendingAction?.action === action && pendingAction.cardIds.length === selectedCardIds.length;
+  }
+
+  async function applyCardsAction(action: BulkAction, options?: { groupId?: string }) {
+    if (selectedCardIds.length === 0 || !currentLang) {
+      return;
+    }
+
+    pendingAction = {
+      action,
+      cardIds: [...selectedCardIds],
     };
+    actionFeedback = null;
+
+    try {
+      const response = await fetch(`/${currentLang}/cards/actions`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          action,
+          cardIds: selectedCardIds,
+          groupId: options?.groupId ?? null,
+        }),
+      });
+
+      const responseBody = (await response.json().catch(() => null)) as { message?: string } | null;
+
+      if (!response.ok) {
+        throw new Error(responseBody?.message ?? 'The card action could not be completed right now.');
+      }
+
+      selectedCardIds = [];
+      bulkAssignOpen = false;
+      selectedBulkGroupId = null;
+      isRefreshing = true;
+      await invalidateAll();
+    } catch (error) {
+      actionFeedback = {
+        title: 'Action failed',
+        message: error instanceof Error ? error.message : 'The card action could not be completed right now.',
+      };
+    } finally {
+      isRefreshing = false;
+      pendingAction = null;
+    }
   }
 
   function handleCardUpdated(event: CustomEvent<{ card: CardLibraryCardDetailData; availableGroups: CardLibraryGroupData[] }>) {
     selectedCard = event.detail.card;
     selectedCardAvailableGroups = event.detail.availableGroups;
 
-    const nextItem = mapDetailToListItem(event.detail.card);
+    const nextItem = mapCardDetailToListItem(event.detail.card);
     const otherItems = library.items.filter((item) => item.cardId !== nextItem.cardId);
-    const nextItems = sortLibraryItems([nextItem, ...otherItems]);
+    const nextItems = sortCardLibraryItems([nextItem, ...otherItems]);
 
     library = {
       ...library,
@@ -120,59 +337,178 @@
 </svelte:head>
 
 <section class="cards-page stack" style="--stack-space: var(--space-5)">
-  <header class="stack" style="--stack-space: var(--space-2)">
-    <p class="cards-page__eyebrow">Library</p>
+  <header class="cards-page__header stack" style="--stack-space: var(--space-2)">
+    <p class="cards-page__eyebrow">Cards</p>
     <h1>Cards</h1>
-    <p>Open any active card to edit it in the shared drawer without leaving the current card set.</p>
   </header>
 
-  {#if library.items.length === 0}
-    <section class="cards-page__state stack" style="--stack-space: var(--space-2)">
-      <div class="cards-page__state-icon" aria-hidden="true">🃏</div>
-      <h2>No active cards yet</h2>
-      <p>Promote a draft card in Card Entry to start building your library.</p>
+  <CardListFilterBar
+    bind:searchQuery
+    bind:selectedGroupIds
+    bind:selectedType
+    availableGroups={sortedAvailableGroups}
+    availableTypes={cardLibraryTypeOptions}
+    searchLabel="Search cards"
+    searchPlaceholder="Search cards..."
+    groupFilterLabel={groupFilterLabel}
+    typeFilterLabel={typeFilterLabel}
+    clearGroupLabel="All groups"
+    clearTypeLabel="All types"
+  />
+
+  {#if isSelectMode}
+    <div class="cards-page__bulk-actions">
+      <CardListBulkActionBar
+        selectedCount={selectedCardIds.length}
+        itemLabelSingular="card"
+        itemLabelPlural="cards"
+        primaryActionLabel="Assign to group"
+        primaryActionPendingLabel="Assigning..."
+        secondaryActionLabel="Delete"
+        secondaryActionPendingLabel="Deleting..."
+        disabled={pendingAction !== null}
+        pendingAction={isPending('assign-group') ? 'primary' : isPending('delete') ? 'secondary' : null}
+        on:primary={() => {
+          if (sortedAvailableGroups.length === 0) {
+            actionFeedback = {
+              title: 'No groups available',
+              message: 'Create a group first before assigning cards to it.',
+            };
+            return;
+          }
+
+          bulkAssignOpen = true;
+          selectedBulkGroupId = sortedAvailableGroups[0]?.groupId ?? null;
+        }}
+        on:secondary={() => void applyCardsAction('delete')}
+        on:clear={clearSelection}
+      />
+    </div>
+  {/if}
+
+  {#if actionFeedback}
+    <section class="cards-page__feedback" role="status" aria-live="polite">
+      <div class="stack" style="--stack-space: var(--space-1)">
+        <p class="cards-page__feedback-title">{actionFeedback.title}</p>
+        <p>{actionFeedback.message}</p>
+      </div>
+
+      <button type="button" class="cards-page__feedback-dismiss" on:click={dismissActionFeedback}>Dismiss</button>
+    </section>
+  {/if}
+
+  {#if isRefreshing}
+    <section class="cards-page__state">
+      <h2>Refreshing cards…</h2>
+      <p>Updating the card library with your latest changes.</p>
+    </section>
+  {:else if library.items.length === 0 && !hasActiveFilters}
+    <section class="cards-page__state">
+      <div class="cards-page__state-icon" aria-hidden="true">📭</div>
+      <h2>No cards yet</h2>
+      <p>Start by adding your first card in Card Entry.</p>
+      <a class="cards-page__state-cta" href={`/${currentLang}/card-entry`}>Go to Card Entry</a>
+    </section>
+  {:else if library.items.length === 0}
+    <section class="cards-page__state">
+      <div class="cards-page__state-icon" aria-hidden="true">🔎</div>
+      <h2>No cards match your filters</h2>
+      <p>Try adjusting your search or clearing the active filters.</p>
+      <button type="button" class="cards-page__state-cta" on:click={clearFilters}>Clear filters</button>
     </section>
   {:else}
     <section class="cards-page__list stack" style="--stack-space: var(--space-3)">
-      <div class="cards-page__columns" aria-hidden="true">
-        <span>Card</span>
-        <span>Groups</span>
-        <span>Updated</span>
-      </div>
+      <CardListColumns
+        labels={['Prompt / Content', 'Groups', 'Updated']}
+        rowTemplate="1rem minmax(0, 2.2fr) minmax(10rem, 1fr) auto"
+      />
 
       {#each library.items as item (item.cardId)}
-        <button type="button" class="cards-page__row" on:click={() => void openCard(item.cardId)}>
-          <div class="cards-page__content stack" style="--stack-space: var(--space-1)">
-            <div class="cluster cards-page__heading">
-              <CardListStatusBadge label="Active" tone="active" />
-              <h2>{item.content}</h2>
-            </div>
+        {@const groupSummary = getVisibleCardGroups(item.groups)}
+
+        <CardListRow
+          selected={selectedCardIds.includes(item.cardId)}
+          checkboxLabel="Select card"
+          rowTemplate="1rem minmax(0, 2.2fr) minmax(10rem, 1fr) auto"
+          clickable
+          hasActions={false}
+          mobileShowCheckbox={!isMobileViewport || isSelectMode}
+          on:toggleSelection={() => toggleSelection(item.cardId)}
+          on:activate={() => handleRowActivate(item.cardId)}
+          on:longpress={() => handleRowLongPress(item.cardId)}
+        >
+          <div slot="content" class="cards-row__content stack" style="--stack-space: var(--space-1)">
+            <h2>{item.content}</h2>
 
             {#if item.meaning}
-              <p class="cards-page__meaning">{item.meaning}</p>
+              <p class="cards-row__meaning">{item.meaning}</p>
             {/if}
+
+            <p class="cards-row__mobile-meta">{getMobileMeta(item)}</p>
           </div>
 
-          <div class="cards-page__groups">
-            {#if item.groups.length === 0}
-              <span class="cards-page__empty-groups">No groups yet</span>
+          <div slot="groups" class="cards-row__groups">
+            {#if groupSummary.visibleGroups.length === 0}
+              <span class="cards-row__groups-empty">No groups yet</span>
             {:else}
-              {#each item.groups as group}
+              {#each groupSummary.visibleGroups as group}
                 <CardListTagChip label={group.groupName} />
               {/each}
+
+              {#if groupSummary.overflowCount > 0}
+                <span class="cards-row__groups-more">+{groupSummary.overflowCount} more</span>
+              {/if}
             {/if}
           </div>
 
-          <span class="cards-page__updated">{item.updatedAtLabel}</span>
-        </button>
+          <span slot="updated" class="cards-row__updated">{item.updatedAtLabel}</span>
+        </CardListRow>
       {/each}
     </section>
   {/if}
 </section>
 
+{#if bulkAssignOpen}
+  <div class="cards-page__dialog-backdrop">
+    <section class="cards-page__dialog stack" style="--stack-space: var(--space-3)">
+      <h2>Assign {selectedCardIds.length} {selectedCardIds.length === 1 ? 'card' : 'cards'} to a group</h2>
+
+      <div class="stack" style="--stack-space: var(--space-2)">
+        {#each sortedAvailableGroups as group}
+          <label class="cards-page__dialog-option">
+            <input type="radio" bind:group={selectedBulkGroupId} value={group.groupId} />
+            <span>{group.groupName}</span>
+          </label>
+        {/each}
+      </div>
+
+      <div class="cards-page__dialog-actions cluster">
+        <button
+          type="button"
+          class="cards-page__dialog-button"
+          on:click={() => {
+            bulkAssignOpen = false;
+            selectedBulkGroupId = null;
+          }}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="cards-page__dialog-button cards-page__dialog-button--primary"
+          disabled={!selectedBulkGroupId || pendingAction !== null}
+          on:click={() => void applyCardsAction('assign-group', { groupId: selectedBulkGroupId ?? undefined })}
+        >
+          {isPending('assign-group') ? 'Assigning…' : 'Assign cards'}
+        </button>
+      </div>
+    </section>
+  </div>
+{/if}
+
 {#if selectedCard && selectedIndex >= 0}
   <ActiveCardDrawer
-    lang={$page.params.lang ?? ''}
+    lang={currentLang}
     card={selectedCard}
     availableGroups={selectedCardAvailableGroups}
     selectedIndex={selectedIndex}
@@ -189,13 +525,20 @@
 
 <style>
   .cards-page {
-    padding: calc(var(--shell-header-height) + var(--space-5)) var(--space-4) var(--space-7);
+    padding: calc(var(--shell-header-height) + var(--space-5)) var(--space-4) calc(var(--space-7) + 4.5rem);
+  }
+
+  .cards-page__eyebrow,
+  .cards-page__feedback-title,
+  .cards-row__updated,
+  .cards-row__groups-empty,
+  .cards-row__groups-more {
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
   }
 
   .cards-page__eyebrow {
     margin: 0;
-    color: var(--color-text-secondary);
-    font-family: var(--font-ui);
     font-size: var(--font-size-caption);
     letter-spacing: var(--tracking-caps);
     text-transform: uppercase;
@@ -207,81 +550,163 @@
     margin: 0;
   }
 
-  .cards-page__state {
-    align-items: center;
-    justify-items: center;
-    padding: var(--space-6);
-    border: 1px dashed var(--color-border);
+  .cards-page__feedback,
+  .cards-page__state,
+  .cards-page__dialog {
+    border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
     background: var(--color-surface);
+  }
+
+  .cards-page__feedback {
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+    gap: var(--space-4);
+    padding: var(--space-3) var(--space-4);
+    border-color: color-mix(in srgb, var(--color-error-border) 65%, var(--color-border));
+    background: color-mix(in srgb, var(--color-error-bg) 18%, var(--color-surface));
+  }
+
+  .cards-page__feedback-title {
+    color: var(--color-error-text);
+    font-size: var(--font-size-small);
+    font-weight: 600;
+  }
+
+  .cards-page__feedback-dismiss,
+  .cards-page__state-cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.55rem 0.9rem;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text-primary);
+    cursor: pointer;
+    font-family: var(--font-ui);
+    text-decoration: none;
+  }
+
+  .cards-page__feedback-dismiss {
+    padding: 0;
+    border: 0;
+    background: none;
+    color: var(--color-text-secondary);
+    text-decoration: underline;
+  }
+
+  .cards-page__state {
+    padding: var(--space-5);
     text-align: center;
+    box-shadow: var(--shadow-sm);
   }
 
   .cards-page__state-icon {
+    margin-block-end: var(--space-3);
     font-size: 2rem;
   }
 
-  .cards-page__columns {
-    display: grid;
-    grid-template-columns: minmax(0, 2fr) minmax(10rem, 1fr) auto;
-    gap: var(--space-3);
-    padding: 0 var(--space-4) var(--space-2);
-    color: var(--color-text-muted);
+  .cards-page__bulk-actions {
+    position: sticky;
+    inset-block-start: calc(var(--shell-header-height) + var(--space-3));
+    z-index: 1;
+  }
+
+  .cards-row__content {
+    min-inline-size: 0;
+  }
+
+  .cards-row__content h2,
+  .cards-row__meaning,
+  .cards-row__mobile-meta {
+    overflow-wrap: anywhere;
+  }
+
+  .cards-row__content h2 {
+    display: -webkit-box;
+    overflow: hidden;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    font-size: var(--font-size-h4);
+    line-height: var(--leading-heading);
+  }
+
+  .cards-row__meaning {
+    display: -webkit-box;
+    overflow: hidden;
+    line-clamp: 1;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+    color: var(--color-text-secondary);
+    line-height: 1.45;
+  }
+
+  .cards-row__groups {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    align-items: center;
+  }
+
+  .cards-row__groups-more,
+  .cards-row__mobile-meta {
+    font-size: var(--font-size-small);
+  }
+
+  .cards-row__mobile-meta {
+    display: none;
+    color: var(--color-text-secondary);
     font-family: var(--font-ui);
-    font-size: var(--font-size-caption);
-    letter-spacing: var(--tracking-caps);
-    text-transform: uppercase;
   }
 
-  .cards-page__row {
+  .cards-page__dialog-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 30;
     display: grid;
-    grid-template-columns: minmax(0, 2fr) minmax(10rem, 1fr) auto;
-    gap: var(--space-3);
-    align-items: start;
-    inline-size: 100%;
+    place-items: center;
     padding: var(--space-4);
-    border: 1px solid var(--color-border-subtle);
-    border-radius: var(--radius-lg);
-    background: var(--color-surface);
-    color: inherit;
-    text-align: start;
-    transition:
-      border-color var(--duration-fast) var(--ease-standard),
-      background var(--duration-fast) var(--ease-standard);
+    background: color-mix(in srgb, var(--neutral-900) 18%, transparent);
   }
 
-  .cards-page__row:hover,
-  .cards-page__row:focus-visible {
-    border-color: var(--color-border);
-    background: color-mix(in srgb, var(--color-surface-raised) 45%, var(--color-surface));
+  .cards-page__dialog {
+    inline-size: min(100%, 28rem);
+    padding: var(--space-4);
+    box-shadow: var(--shadow-lg);
   }
 
-  .cards-page__heading {
+  .cards-page__dialog-option,
+  .cards-page__dialog-actions {
     align-items: center;
     gap: var(--space-2);
   }
 
-  .cards-page__heading h2 {
-    font-size: var(--font-size-h4);
-  }
-
-  .cards-page__meaning,
-  .cards-page__updated,
-  .cards-page__empty-groups {
-    color: var(--color-text-secondary);
-    font-family: var(--font-ui);
-    font-size: var(--font-size-small);
-  }
-
-  .cards-page__groups {
+  .cards-page__dialog-option {
     display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-2);
+    font-family: var(--font-ui);
   }
 
-  .cards-page__row:focus-visible {
-    outline: 2px solid var(--color-primary);
-    outline-offset: 2px;
+  .cards-page__dialog-actions {
+    justify-content: flex-end;
+  }
+
+  .cards-page__dialog-button {
+    min-block-size: 2.75rem;
+    padding-inline: var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text-primary);
+    font-family: var(--font-ui);
+  }
+
+  .cards-page__dialog-button--primary {
+    border-color: var(--color-primary);
+    background: var(--color-primary);
+    color: var(--color-text-inverse);
   }
 
   @media (max-width: 900px) {
@@ -289,12 +714,22 @@
       padding-inline: var(--space-3);
     }
 
-    .cards-page__columns {
+    .cards-page__bulk-actions {
+      position: fixed;
+      inset-inline: var(--space-3);
+      inset-block-end: calc(4.5rem + var(--space-2));
+      inset-block-start: auto;
+      z-index: 5;
+    }
+
+    .cards-row__meaning,
+    .cards-row__groups,
+    .cards-row__updated {
       display: none;
     }
 
-    .cards-page__row {
-      grid-template-columns: 1fr;
+    .cards-row__mobile-meta {
+      display: block;
     }
   }
 </style>

--- a/apps/web/src/routes/[lang]/cards/actions/+server.ts
+++ b/apps/web/src/routes/[lang]/cards/actions/+server.ts
@@ -1,0 +1,69 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { withTransactionDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import {
+  bulkAssignCardLibraryCardsToGroupForLanguage,
+  CardLibraryRequestError,
+  deleteCardLibraryCardsForLanguage,
+} from '$lib/server/cards.js';
+
+type CardLibraryActionRequestBody = {
+  action?: 'assign-group' | 'delete';
+  cardIds?: string[];
+  groupId?: string;
+};
+
+export const POST: RequestHandler = async (event) => {
+  const session = await event.locals.auth();
+  const userId = session?.user?.id;
+  const languageId = event.params.lang;
+
+  if (!userId || !languageId) {
+    return json({ message: 'You must be signed in to update cards.' }, { status: 401 });
+  }
+
+  if (!env.DATABASE_URL) {
+    return json({ message: 'The card service is not configured right now.' }, { status: 500 });
+  }
+
+  let body: CardLibraryActionRequestBody;
+
+  try {
+    body = (await event.request.json()) as CardLibraryActionRequestBody;
+  } catch {
+    return json({ message: 'The card action payload must be valid JSON.' }, { status: 400 });
+  }
+
+  try {
+    const result = await withTransactionDb(env.DATABASE_URL, async (database) => {
+      if (body.action === 'delete') {
+        return {
+          deletedCardIds: await deleteCardLibraryCardsForLanguage(userId, languageId, body.cardIds, database as never),
+        };
+      }
+
+      if (body.action === 'assign-group') {
+        return {
+          assignedCardIds: await bulkAssignCardLibraryCardsToGroupForLanguage(
+            userId,
+            languageId,
+            body.cardIds,
+            body.groupId,
+            database as never,
+          ),
+        };
+      }
+
+      throw new CardLibraryRequestError(400, 'A valid card action is required.');
+    });
+
+    return json(result);
+  } catch (requestError) {
+    if (requestError instanceof CardLibraryRequestError) {
+      return json({ message: requestError.message }, { status: requestError.status });
+    }
+
+    console.error('Failed to apply Card Library action:', requestError);
+    return json({ message: 'The card action could not be completed right now.' }, { status: 500 });
+  }
+};


### PR DESCRIPTION
## Summary
- build the full Cards page surface with live search, group/type filters, empty states, and filtered-set drawer navigation
- add bulk selection plus bulk delete and assign-to-group actions for the Card Library
- extend the shared card-list primitives and add small helper coverage to support the new surface

## Testing
- pnpm turbo test lint build --filter=web
- pnpm test:db:branch:secure

Closes #141.