### PR TITLE
Build Groups list with create and delete workflows

### DIFF
--- a/apps/web/src/lib/cards/groups.test.ts
+++ b/apps/web/src/lib/cards/groups.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { buildDeleteGroupMessage, sortCardLibraryGroupItems } from './groups.js';
+
+describe('sortCardLibraryGroupItems', () => {
+  it('sorts groups alphabetically by name', () => {
+    expect(
+      sortCardLibraryGroupItems([
+        { groupId: 'g2', groupName: 'Travel', description: null, activeCardCount: 1 },
+        { groupId: 'g1', groupName: 'Daily', description: null, activeCardCount: 0 },
+      ]),
+    ).toEqual([
+      { groupId: 'g1', groupName: 'Daily', description: null, activeCardCount: 0 },
+      { groupId: 'g2', groupName: 'Travel', description: null, activeCardCount: 1 },
+    ]);
+  });
+});
+
+describe('buildDeleteGroupMessage', () => {
+  it('uses concise copy for empty groups and dissociation copy for non-empty groups', () => {
+    expect(
+      buildDeleteGroupMessage({ groupId: 'g1', groupName: 'Greetings', description: null, activeCardCount: 0 }),
+    ).toBe('Are you sure? This cannot be undone.');
+    expect(
+      buildDeleteGroupMessage({ groupId: 'g2', groupName: 'Daily', description: null, activeCardCount: 2 }),
+    ).toContain('This group has 2 cards.');
+  });
+});

--- a/apps/web/src/lib/cards/groups.ts
+++ b/apps/web/src/lib/cards/groups.ts
@@ -1,0 +1,13 @@
+import type { CardLibraryGroupListItemData } from '$lib/server/cards.js';
+
+export function sortCardLibraryGroupItems(groups: CardLibraryGroupListItemData[]) {
+  return [...groups].sort((left, right) => left.groupName.localeCompare(right.groupName));
+}
+
+export function buildDeleteGroupMessage(group: CardLibraryGroupListItemData) {
+  if (group.activeCardCount === 0) {
+    return 'Are you sure? This cannot be undone.';
+  }
+
+  return `This group has ${group.activeCardCount} card${group.activeCardCount === 1 ? '' : 's'}. Deleting the group will remove the group tag from those cards, but the cards themselves will not be deleted.`;
+}

--- a/apps/web/src/lib/components/card-list/CardListRow.svelte
+++ b/apps/web/src/lib/components/card-list/CardListRow.svelte
@@ -46,7 +46,7 @@
   }
 
   function handleKeydown(event: KeyboardEvent) {
-    if (!clickable || shouldIgnoreActivate(event.target) || event.key !== 'Enter') {
+    if (!clickable || shouldIgnoreActivate(event.target) || (event.key !== 'Enter' && event.key !== ' ')) {
       return;
     }
 
@@ -68,11 +68,12 @@
   }
 </script>
 
-<article
+<div
   class:selected
   class:card-list-row--clickable={clickable}
   class:card-list-row--mobile-checkbox-hidden={!mobileShowCheckbox}
   class="card-list-row"
+  role={clickable ? 'button' : undefined}
   tabindex={clickable ? 0 : undefined}
   on:click={handleActivate}
   on:keydown={handleKeydown}
@@ -105,7 +106,7 @@
       </div>
     {/if}
   </div>
-</article>
+</div>
 
 <style>
   .card-list-row {

--- a/apps/web/src/lib/server/cards.test.ts
+++ b/apps/web/src/lib/server/cards.test.ts
@@ -3,6 +3,7 @@ import {
   CardLibraryRequestError,
   formatCardLibraryRelativeTime,
   loadCardLibraryData,
+  loadCardLibraryGroupsData,
   loadGroupDetailData,
   loadActiveCardDetailData,
 } from './cards.js';
@@ -160,6 +161,42 @@ describe('Card Library server helpers', () => {
 
     expect(result.card.examples).toEqual(['我们聊天吧。']);
     expect(result.availableGroups).toEqual([{ groupId: 'group-chat', groupName: 'Chat' }]);
+  });
+
+  it('loads the groups list sorted alphabetically with active card counts', async () => {
+    baseDeps.listGroupsWithActiveCardCounts.mockResolvedValueOnce([
+      {
+        userId: 'user-1',
+        languageId: 'zh',
+        groupId: 'group-z',
+        groupName: 'Zeta',
+        description: null,
+        embedding: null,
+        embeddingModel: null,
+        embeddingGeneratedAt: null,
+        createdAt: null,
+        metadata: null,
+        activeCardCount: 0,
+      },
+      {
+        userId: 'user-1',
+        languageId: 'zh',
+        groupId: 'group-a',
+        groupName: 'Alpha',
+        description: null,
+        embedding: null,
+        embeddingModel: null,
+        embeddingGeneratedAt: null,
+        createdAt: null,
+        metadata: null,
+        activeCardCount: 2,
+      },
+    ]);
+
+    const result = await loadCardLibraryGroupsData('user-1', 'zh', database, baseDeps);
+
+    expect(result.items.map((group) => group.groupName)).toEqual(['Alpha', 'Zeta']);
+    expect(result.totalCount).toBe(2);
   });
 
   it('rejects invalid filter input before hitting the data layer', async () => {

--- a/apps/web/src/lib/server/cards.ts
+++ b/apps/web/src/lib/server/cards.ts
@@ -2,6 +2,7 @@ import {
   addCardToGroup,
   bulkAssignActiveCardsToGroup,
   createGroup,
+  deleteGroup,
   getActiveCardWithGroups,
   getActiveUserLanguages,
   getDb,
@@ -21,8 +22,10 @@ import {
 } from '@studypuck/database';
 import {
   cardEntryDraftCardUpdateSchema,
+  editableCardOptionalTextSchema,
   editableGroupNameSchema,
 } from '$lib/schemas/card-entry.js';
+import { z } from 'zod';
 import {
   activeCardIdSchema,
   activeCardTypeSchema,
@@ -118,6 +121,23 @@ export type GroupDetailData = {
   };
   cards: CardLibraryData;
 };
+
+export type CardLibraryGroupListItemData = {
+  groupId: string;
+  groupName: string;
+  description: string | null;
+  activeCardCount: number;
+};
+
+export type CardLibraryGroupsData = {
+  items: CardLibraryGroupListItemData[];
+  totalCount: number;
+};
+
+const cardLibraryGroupCreateSchema = z.object({
+  groupName: editableGroupNameSchema,
+  description: editableCardOptionalTextSchema.optional().default(null),
+});
 
 function normalizeStringList(value: unknown): string[] {
   if (!Array.isArray(value)) {
@@ -263,6 +283,15 @@ function mapGroupFilterOption(group: GroupWithActiveCardCount): CardLibraryGroup
   return {
     groupId: group.groupId,
     groupName: group.groupName,
+    activeCardCount: group.activeCardCount,
+  };
+}
+
+function mapGroupListItem(group: GroupWithActiveCardCount): CardLibraryGroupListItemData {
+  return {
+    groupId: group.groupId,
+    groupName: group.groupName,
+    description: group.description ?? null,
     activeCardCount: group.activeCardCount,
   };
 }
@@ -426,6 +455,22 @@ export async function loadCardLibraryData(
     filteredCardIds: items.map((item) => item.cardId),
     filters,
     availableGroups: sortGroupsByName(availableGroups.map((group) => mapGroupFilterOption(group))),
+  };
+}
+
+export async function loadCardLibraryGroupsData(
+  userId: string,
+  languageId: string,
+  database: DatabaseClient,
+  deps: LoaderDeps = defaultLoaderDeps,
+): Promise<CardLibraryGroupsData> {
+  await assertUserHasLanguage(userId, languageId, database, deps);
+
+  const groups = await deps.listGroupsWithActiveCardCounts(userId, languageId, database as never);
+
+  return {
+    items: sortGroupsByName(groups.map((group) => mapGroupListItem(group))),
+    totalCount: groups.length,
   };
 }
 
@@ -594,4 +639,75 @@ export async function deleteCardLibraryCardsForLanguage(
     parseCardIds(cardIds),
     database as never,
   );
+}
+
+export async function createCardLibraryGroupForLanguage(
+  userId: string,
+  languageId: string,
+  input: unknown,
+  database: DatabaseClient,
+) {
+  await assertUserHasLanguage(userId, languageId, database);
+
+  const parsedInput = cardLibraryGroupCreateSchema.safeParse(input);
+
+  if (!parsedInput.success) {
+    throw new CardLibraryRequestError(
+      400,
+      parsedInput.error.issues[0]?.message ?? 'Group data is invalid.',
+    );
+  }
+
+  const existingGroups = await getGroups(userId, languageId, database as never);
+  const normalizedName = parsedInput.data.groupName.trim().toLocaleLowerCase();
+  const duplicateGroup = existingGroups.find(
+    (group) => group.groupName.trim().toLocaleLowerCase() === normalizedName,
+  );
+
+  if (duplicateGroup) {
+    throw new CardLibraryRequestError(409, 'A group with this name already exists.');
+  }
+
+  const createdGroup = await createGroup(
+    {
+      userId,
+      languageId,
+      groupId: createGroupId(),
+      groupName: parsedInput.data.groupName,
+      description: parsedInput.data.description,
+    },
+    database as never,
+  );
+
+  return mapGroupListItem({
+    ...createdGroup,
+    activeCardCount: 0,
+  });
+}
+
+export async function deleteCardLibraryGroupForLanguage(
+  userId: string,
+  languageId: string,
+  groupId: unknown,
+  database: DatabaseClient,
+) {
+  await assertUserHasLanguage(userId, languageId, database);
+
+  const parsedGroupId = parseGroupId(groupId);
+  const group = await getGroupWithActiveCardCount(userId, languageId, parsedGroupId, database as never);
+
+  if (!group) {
+    throw new CardLibraryRequestError(404, 'Group not found.');
+  }
+
+  const deleted = await deleteGroup(userId, languageId, parsedGroupId, database as never);
+
+  if (!deleted) {
+    throw new CardLibraryRequestError(404, 'Group not found.');
+  }
+
+  return {
+    groupId: group.groupId,
+    activeCardCount: group.activeCardCount,
+  };
 }

--- a/apps/web/src/routes/[lang]/cards/groups/+page.server.ts
+++ b/apps/web/src/routes/[lang]/cards/groups/+page.server.ts
@@ -1,0 +1,28 @@
+import { error, redirect } from '@sveltejs/kit';
+import { getDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import { CardLibraryRequestError, loadCardLibraryGroupsData } from '$lib/server/cards.js';
+import type { PageServerLoad } from './$types.js';
+
+export const load: PageServerLoad = async (event) => {
+  const { session } = await event.parent();
+  const languageCode = event.params.lang;
+
+  if (!session?.user?.id || !languageCode) {
+    throw redirect(303, '/');
+  }
+
+  const database = getDb(env.DATABASE_URL);
+
+  try {
+    return {
+      groups: await loadCardLibraryGroupsData(session.user.id, languageCode, database),
+    };
+  } catch (requestError) {
+    if (requestError instanceof CardLibraryRequestError) {
+      throw error(requestError.status, requestError.message);
+    }
+
+    throw requestError;
+  }
+};

--- a/apps/web/src/routes/[lang]/cards/groups/+page.svelte
+++ b/apps/web/src/routes/[lang]/cards/groups/+page.svelte
@@ -1,0 +1,723 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import { onMount, tick } from 'svelte';
+  import { buildDeleteGroupMessage, sortCardLibraryGroupItems } from '$lib/cards/groups.js';
+  import type { CardLibraryGroupListItemData, CardLibraryGroupsData } from '$lib/server/cards.js';
+  import type { PageData } from './$types.js';
+
+  export let data: PageData;
+
+  type Feedback = {
+    title: string;
+    message: string;
+  };
+
+  let groups: CardLibraryGroupsData = data.groups;
+  let previousGroups = data.groups;
+  let createDrawerOpen = false;
+  let drawerElement: HTMLElement | null = null;
+  let groupNameInput: HTMLInputElement | null = null;
+  let groupName = '';
+  let groupDescription = '';
+  let createErrorMessage = '';
+  let createPending = false;
+  let deletePendingGroupId: string | null = null;
+  let deleteTarget: CardLibraryGroupListItemData | null = null;
+  let feedback: Feedback | null = null;
+  let isMobileViewport = false;
+  let viewportMediaQuery: MediaQueryList | null = null;
+  let touchStartX = 0;
+  let swipedGroupId: string | null = null;
+
+  onMount(() => {
+    viewportMediaQuery = window.matchMedia('(max-width: 900px)');
+    const syncViewportMode = () => {
+      isMobileViewport = viewportMediaQuery?.matches ?? false;
+
+      if (!isMobileViewport) {
+        swipedGroupId = null;
+      }
+    };
+
+    syncViewportMode();
+    viewportMediaQuery.addEventListener('change', syncViewportMode);
+
+    return () => {
+      viewportMediaQuery?.removeEventListener('change', syncViewportMode);
+    };
+  });
+
+  $: currentLang = $page.params.lang ?? '';
+
+  $: if (data.groups !== previousGroups) {
+    groups = data.groups;
+    previousGroups = data.groups;
+  }
+
+  function openCreateDrawer() {
+    createDrawerOpen = true;
+    createErrorMessage = '';
+    groupName = '';
+    groupDescription = '';
+    tick().then(() => {
+      groupNameInput?.focus();
+    });
+  }
+
+  function closeCreateDrawer() {
+    if (createPending) {
+      return;
+    }
+
+    createDrawerOpen = false;
+    createErrorMessage = '';
+    groupName = '';
+    groupDescription = '';
+  }
+
+  function handleWindowKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      if (deleteTarget) {
+        deleteTarget = null;
+        return;
+      }
+
+      if (createDrawerOpen) {
+        event.preventDefault();
+        closeCreateDrawer();
+      }
+    }
+  }
+
+  function handleDrawerKeydown(event: KeyboardEvent) {
+    if (event.key !== 'Tab' || !drawerElement) {
+      return;
+    }
+
+    const focusableElements = Array.from(
+      drawerElement.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], textarea:not([disabled]), input:not([disabled])',
+      ),
+    );
+
+    if (focusableElements.length === 0) {
+      return;
+    }
+
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    if (event.shiftKey && document.activeElement === firstElement) {
+      event.preventDefault();
+      lastElement?.focus();
+      return;
+    }
+
+    if (!event.shiftKey && document.activeElement === lastElement) {
+      event.preventDefault();
+      firstElement?.focus();
+    }
+  }
+
+  async function handleCreateGroup(event: SubmitEvent) {
+    event.preventDefault();
+
+    if (createPending || !currentLang) {
+      return;
+    }
+
+    createPending = true;
+    createErrorMessage = '';
+    feedback = null;
+
+    try {
+      const response = await fetch(`/${currentLang}/cards/groups/actions`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          action: 'create',
+          groupName,
+          description: groupDescription,
+        }),
+      });
+
+      const responseBody = (await response.json().catch(() => null)) as
+        | {
+            group?: CardLibraryGroupListItemData;
+            message?: string;
+          }
+        | null;
+
+      if (!response.ok || !responseBody?.group) {
+        throw new Error(responseBody?.message ?? 'The group could not be created right now.');
+      }
+
+      const nextItems = sortCardLibraryGroupItems([...groups.items, responseBody.group]);
+      groups = {
+        items: nextItems,
+        totalCount: nextItems.length,
+      };
+      closeCreateDrawer();
+    } catch (error) {
+      createErrorMessage = error instanceof Error ? error.message : 'The group could not be created right now.';
+    } finally {
+      createPending = false;
+    }
+  }
+
+  function requestDelete(group: CardLibraryGroupListItemData) {
+    deleteTarget = group;
+    feedback = null;
+  }
+
+  async function confirmDelete() {
+    if (!deleteTarget || !currentLang || deletePendingGroupId) {
+      return;
+    }
+
+    deletePendingGroupId = deleteTarget.groupId;
+    feedback = null;
+
+    try {
+      const response = await fetch(`/${currentLang}/cards/groups/actions`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          action: 'delete',
+          groupId: deleteTarget.groupId,
+        }),
+      });
+
+      const responseBody = (await response.json().catch(() => null)) as
+        | {
+            deleted?: {
+              groupId: string;
+            };
+            message?: string;
+          }
+        | null;
+
+      if (!response.ok || !responseBody?.deleted) {
+        throw new Error(responseBody?.message ?? 'The group could not be deleted right now.');
+      }
+
+      const nextItems = groups.items.filter((group) => group.groupId !== responseBody.deleted?.groupId);
+      groups = {
+        items: nextItems,
+        totalCount: nextItems.length,
+      };
+      deleteTarget = null;
+      swipedGroupId = null;
+    } catch (error) {
+      feedback = {
+        title: 'Delete failed',
+        message: error instanceof Error ? error.message : 'The group could not be deleted right now.',
+      };
+    } finally {
+      deletePendingGroupId = null;
+    }
+  }
+
+  function handleRowClick(groupId: string) {
+    if (isMobileViewport && swipedGroupId === groupId) {
+      swipedGroupId = null;
+      return;
+    }
+
+    void goto(`/${currentLang}/cards/groups/${groupId}`);
+  }
+
+  function handleTouchStart(event: TouchEvent) {
+    touchStartX = event.touches[0]?.clientX ?? 0;
+  }
+
+  function handleTouchEnd(event: TouchEvent, groupId: string) {
+    if (!isMobileViewport) {
+      return;
+    }
+
+    const endX = event.changedTouches[0]?.clientX ?? touchStartX;
+    const deltaX = endX - touchStartX;
+
+    if (deltaX <= -40) {
+      swipedGroupId = groupId;
+      return;
+    }
+
+    if (deltaX >= 40 || Math.abs(deltaX) < 10) {
+      swipedGroupId = null;
+    }
+  }
+</script>
+
+<svelte:window on:keydown={handleWindowKeydown} />
+
+<svelte:head>
+  <title>Groups - StudyPuck</title>
+</svelte:head>
+
+<section class="groups-page stack" style="--stack-space: var(--space-5)">
+  <header class="groups-page__header cluster">
+    <div class="stack" style="--stack-space: var(--space-2)">
+      <p class="groups-page__eyebrow">Cards</p>
+      <h1>Groups</h1>
+    </div>
+
+    <button type="button" class="groups-page__new-button" on:click={openCreateDrawer}>
+      {isMobileViewport ? '+ New' : '+ New Group'}
+    </button>
+  </header>
+
+  {#if feedback}
+    <section class="groups-page__feedback" role="status" aria-live="polite">
+      <div class="stack" style="--stack-space: var(--space-1)">
+        <p class="groups-page__feedback-title">{feedback.title}</p>
+        <p>{feedback.message}</p>
+      </div>
+    </section>
+  {/if}
+
+  {#if groups.items.length === 0}
+    <section class="groups-page__state">
+      <div class="groups-page__state-icon" aria-hidden="true">[ ]</div>
+      <h2>No groups yet</h2>
+      <p>Groups let you organize your cards by topic, category, or any system that works for you.</p>
+      <button type="button" class="groups-page__state-cta" on:click={openCreateDrawer}>
+        + Create your first group
+      </button>
+    </section>
+  {:else}
+    <section class="groups-page__list stack" style="--stack-space: var(--space-2)">
+      <div class="groups-page__columns" aria-hidden="true">
+        <span>Name</span>
+        <span>Description</span>
+        <span>Cards</span>
+      </div>
+
+      {#each groups.items as group (group.groupId)}
+        <div class:groups-page__row-shell--swiped={swipedGroupId === group.groupId} class="groups-page__row-shell">
+          <button
+            type="button"
+            class="groups-page__row"
+            on:click={() => handleRowClick(group.groupId)}
+            on:touchstart={handleTouchStart}
+            on:touchend={(event) => handleTouchEnd(event, group.groupId)}
+          >
+            <div class="groups-page__name stack" style="--stack-space: var(--space-1)">
+              <h2>{group.groupName}</h2>
+              <p class="groups-page__mobile-count">{group.activeCardCount}</p>
+            </div>
+            <p class="groups-page__description">{group.description ?? 'No description yet.'}</p>
+            <p class="groups-page__count">{group.activeCardCount}</p>
+          </button>
+
+          <button
+            type="button"
+            class="groups-page__delete"
+            aria-label={`Delete ${group.groupName}`}
+            on:click={() => requestDelete(group)}
+          >
+            {isMobileViewport ? 'Delete' : 'Delete'}
+          </button>
+        </div>
+      {/each}
+    </section>
+  {/if}
+</section>
+
+{#if createDrawerOpen}
+  <button
+    type="button"
+    class="groups-page__backdrop"
+    aria-label="Close new group drawer"
+    on:click={closeCreateDrawer}
+  ></button>
+
+  <div
+    bind:this={drawerElement}
+    class="groups-page__drawer stack"
+    style="--stack-space: var(--space-4)"
+    role="dialog"
+    tabindex="-1"
+    aria-modal="true"
+    aria-labelledby="new-group-title"
+    on:keydown={handleDrawerKeydown}
+  >
+    <header class="groups-page__drawer-header cluster">
+      <h2 id="new-group-title">New Group</h2>
+      <button type="button" class="groups-page__drawer-close" aria-label="Close drawer" on:click={closeCreateDrawer}>
+        x
+      </button>
+    </header>
+
+    <form class="stack" style="--stack-space: var(--space-4)" on:submit={handleCreateGroup}>
+      <label class="groups-page__field stack" style="--stack-space: var(--space-2)">
+        <span class="groups-page__label">Group name *</span>
+        <input
+          bind:this={groupNameInput}
+          bind:value={groupName}
+          class="groups-page__control"
+          type="text"
+          placeholder='e.g. "Daily Conversations"'
+          disabled={createPending}
+        />
+      </label>
+
+      <label class="groups-page__field stack" style="--stack-space: var(--space-2)">
+        <span class="groups-page__label">Description (optional)</span>
+        <textarea
+          bind:value={groupDescription}
+          class="groups-page__control groups-page__control--textarea"
+          rows="4"
+          placeholder="Optional description..."
+          disabled={createPending}
+        ></textarea>
+      </label>
+
+      {#if createErrorMessage}
+        <p class="groups-page__error" role="alert">{createErrorMessage}</p>
+      {/if}
+
+      <button
+        type="submit"
+        class="groups-page__submit"
+        disabled={createPending || groupName.trim().length === 0}
+      >
+        {createPending ? 'Creating...' : 'Create Group'}
+      </button>
+    </form>
+  </div>
+{/if}
+
+{#if deleteTarget}
+  <div class="groups-page__dialog-backdrop">
+    <section class="groups-page__dialog stack" style="--stack-space: var(--space-3)" role="alertdialog" aria-modal="true">
+      <h2>Delete "{deleteTarget.groupName}"?</h2>
+      <p>{buildDeleteGroupMessage(deleteTarget)}</p>
+      <div class="groups-page__dialog-actions cluster">
+        <button
+          type="button"
+          class="groups-page__dialog-button"
+          disabled={deletePendingGroupId !== null}
+          on:click={() => {
+            deleteTarget = null;
+          }}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="groups-page__dialog-button groups-page__dialog-button--danger"
+          disabled={deletePendingGroupId !== null}
+          on:click={confirmDelete}
+        >
+          {deletePendingGroupId === deleteTarget.groupId ? 'Deleting...' : 'Delete Group'}
+        </button>
+      </div>
+    </section>
+  </div>
+{/if}
+
+<style>
+  .groups-page {
+    padding: calc(var(--shell-header-height) + var(--space-5)) var(--space-4) calc(var(--space-7) + 4.5rem);
+  }
+
+  .groups-page__header,
+  .groups-page__drawer-header,
+  .groups-page__dialog-actions {
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  .groups-page__eyebrow,
+  .groups-page__description,
+  .groups-page__count,
+  .groups-page__mobile-count,
+  .groups-page__feedback-title {
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+  }
+
+  .groups-page__eyebrow {
+    margin: 0;
+    font-size: var(--font-size-caption);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .groups-page h1,
+  .groups-page h2,
+  .groups-page p {
+    margin: 0;
+  }
+
+  .groups-page__new-button,
+  .groups-page__state-cta,
+  .groups-page__submit,
+  .groups-page__dialog-button {
+    min-block-size: 2.75rem;
+    padding-inline: var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text-primary);
+    font-family: var(--font-ui);
+  }
+
+  .groups-page__new-button,
+  .groups-page__submit {
+    border-color: var(--color-primary);
+    background: var(--color-primary);
+    color: var(--color-text-inverse);
+  }
+
+  .groups-page__columns {
+    display: grid;
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 2.2fr) auto;
+    gap: var(--space-3);
+    padding: 0 var(--space-4) var(--space-2);
+    color: var(--color-text-muted);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-caption);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .groups-page__row-shell {
+    position: relative;
+    overflow: hidden;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+    transition:
+      border-color var(--duration-fast) var(--ease-standard),
+      background var(--duration-fast) var(--ease-standard);
+  }
+
+  .groups-page__row-shell:hover,
+  .groups-page__row-shell:focus-within {
+    border-color: var(--color-border);
+    background: color-mix(in srgb, var(--color-surface-raised) 45%, var(--color-surface));
+  }
+
+  .groups-page__row {
+    display: grid;
+    grid-template-columns: minmax(0, 1.2fr) minmax(0, 2.2fr) auto;
+    gap: var(--space-3);
+    align-items: center;
+    inline-size: 100%;
+    padding: var(--space-4);
+    border: 0;
+    background: transparent;
+    color: inherit;
+    text-align: start;
+  }
+
+  .groups-page__name h2 {
+    font-size: var(--font-size-h4);
+  }
+
+  .groups-page__description {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+    line-clamp: 1;
+  }
+
+  .groups-page__count {
+    justify-self: end;
+  }
+
+  .groups-page__mobile-count {
+    display: none;
+  }
+
+  .groups-page__delete {
+    position: absolute;
+    inset-block: 0;
+    inset-inline-end: 0;
+    inline-size: 5rem;
+    border: 0;
+    background: color-mix(in srgb, var(--color-danger-text) 12%, var(--color-surface));
+    color: var(--color-danger-text);
+    font-family: var(--font-ui);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--duration-fast) var(--ease-standard);
+  }
+
+  .groups-page__row-shell:hover .groups-page__delete,
+  .groups-page__row-shell:focus-within .groups-page__delete {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .groups-page__state,
+  .groups-page__feedback,
+  .groups-page__dialog {
+    padding: var(--space-5);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+  }
+
+  .groups-page__state,
+  .groups-page__dialog {
+    text-align: center;
+  }
+
+  .groups-page__feedback-title {
+    color: var(--color-error-text);
+    font-size: var(--font-size-small);
+    font-weight: 600;
+  }
+
+  .groups-page__backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 52;
+    border: 0;
+    background: color-mix(in srgb, var(--neutral-900) 14%, transparent);
+  }
+
+  .groups-page__drawer {
+    position: fixed;
+    inset-block: 0;
+    inset-inline-end: 0;
+    z-index: 53;
+    inline-size: min(30rem, 100vw);
+    padding: var(--space-4);
+    border-inline-start: 1px solid var(--color-border);
+    background: var(--color-surface-raised);
+    box-shadow: var(--shadow-lg);
+  }
+
+  .groups-page__drawer-header {
+    position: sticky;
+    inset-block-start: 0;
+    padding-block-end: var(--space-2);
+    border-block-end: 1px solid var(--color-border);
+    background: var(--color-surface-raised);
+  }
+
+  .groups-page__drawer-close {
+    border: 0;
+    background: transparent;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-h4);
+  }
+
+  .groups-page__label {
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-caption);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .groups-page__control {
+    inline-size: 100%;
+    min-block-size: 2.75rem;
+    padding: var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text-primary);
+    font-family: var(--font-ui);
+  }
+
+  .groups-page__control--textarea {
+    resize: vertical;
+  }
+
+  .groups-page__error {
+    color: var(--color-danger-text);
+    font-family: var(--font-ui);
+  }
+
+  .groups-page__dialog-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 54;
+    display: grid;
+    place-items: center;
+    padding: var(--space-4);
+    background: color-mix(in srgb, var(--neutral-900) 28%, transparent);
+  }
+
+  .groups-page__dialog {
+    inline-size: min(100%, 24rem);
+  }
+
+  .groups-page__dialog-button--danger {
+    border-color: var(--color-danger-text);
+    background: color-mix(in srgb, var(--color-danger-text) 10%, var(--color-surface));
+    color: var(--color-danger-text);
+  }
+
+  .groups-page__new-button:focus-visible,
+  .groups-page__state-cta:focus-visible,
+  .groups-page__submit:focus-visible,
+  .groups-page__dialog-button:focus-visible,
+  .groups-page__row:focus-visible,
+  .groups-page__delete:focus-visible,
+  .groups-page__drawer-close:focus-visible,
+  .groups-page__control:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  @media (max-width: 900px) {
+    .groups-page {
+      padding-inline: var(--space-3);
+    }
+
+    .groups-page__columns {
+      display: none;
+    }
+
+    .groups-page__row-shell--swiped .groups-page__row {
+      transform: translateX(-5rem);
+    }
+
+    .groups-page__row {
+      grid-template-columns: 1fr;
+      align-items: start;
+      transition: transform var(--duration-fast) var(--ease-standard);
+    }
+
+    .groups-page__name {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: var(--space-3);
+    }
+
+    .groups-page__count {
+      display: none;
+    }
+
+    .groups-page__mobile-count {
+      display: inline;
+    }
+
+    .groups-page__delete {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .groups-page__drawer {
+      inline-size: 100vw;
+      border-inline-start: 0;
+      padding-block-end: calc(var(--space-5) + env(safe-area-inset-bottom));
+    }
+  }
+</style>

--- a/apps/web/src/routes/[lang]/cards/groups/actions/+server.ts
+++ b/apps/web/src/routes/[lang]/cards/groups/actions/+server.ts
@@ -1,0 +1,76 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { withTransactionDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import {
+  CardLibraryRequestError,
+  createCardLibraryGroupForLanguage,
+  deleteCardLibraryGroupForLanguage,
+} from '$lib/server/cards.js';
+
+type GroupActionRequestBody =
+  | {
+      action?: 'create';
+      groupName?: string;
+      description?: string;
+    }
+  | {
+      action?: 'delete';
+      groupId?: string;
+    };
+
+export const POST: RequestHandler = async (event) => {
+  const session = await event.locals.auth();
+  const userId = session?.user?.id;
+  const languageId = event.params.lang;
+
+  if (!userId || !languageId) {
+    return json({ message: 'You must be signed in to update groups.' }, { status: 401 });
+  }
+
+  if (!env.DATABASE_URL) {
+    return json({ message: 'The group service is not configured right now.' }, { status: 500 });
+  }
+
+  let body: GroupActionRequestBody;
+
+  try {
+    body = (await event.request.json()) as GroupActionRequestBody;
+  } catch {
+    return json({ message: 'The group action payload must be valid JSON.' }, { status: 400 });
+  }
+
+  try {
+    const result = await withTransactionDb(env.DATABASE_URL, async (database) => {
+      if (body.action === 'create') {
+        return {
+          group: await createCardLibraryGroupForLanguage(
+            userId,
+            languageId,
+            {
+              groupName: body.groupName,
+              description: body.description,
+            },
+            database as never,
+          ),
+        };
+      }
+
+      if (body.action === 'delete') {
+        return {
+          deleted: await deleteCardLibraryGroupForLanguage(userId, languageId, body.groupId, database as never),
+        };
+      }
+
+      throw new CardLibraryRequestError(400, 'A valid group action is required.');
+    });
+
+    return json(result);
+  } catch (requestError) {
+    if (requestError instanceof CardLibraryRequestError) {
+      return json({ message: requestError.message }, { status: requestError.status });
+    }
+
+    console.error('Failed to apply Card Library group action:', requestError);
+    return json({ message: 'The group action could not be completed right now.' }, { status: 500 });
+  }
+};

--- a/packages/database/src/cards.ts
+++ b/packages/database/src/cards.ts
@@ -360,8 +360,41 @@ export async function updateGroup(
       eq(groups.groupId, groupId)
     ))
     .returning();
-  
+
   return result[0] || null;
+}
+
+/**
+ * Delete a group and dissociate any cards currently assigned to it.
+ */
+export async function deleteGroup(
+  userId: string,
+  languageId: string,
+  groupId: string,
+  database?: AnyDb,
+): Promise<boolean> {
+  const conn = getConn(database);
+
+  await conn
+    .delete(cardGroups)
+    .where(and(
+      eq(cardGroups.userId, userId),
+      eq(cardGroups.languageId, languageId),
+      eq(cardGroups.groupId, groupId),
+    ));
+
+  const result = await conn
+    .delete(groups)
+    .where(and(
+      eq(groups.userId, userId),
+      eq(groups.languageId, languageId),
+      eq(groups.groupId, groupId),
+    ))
+    .returning({
+      groupId: groups.groupId,
+    });
+
+  return result.length > 0;
 }
 
 /**

--- a/packages/database/src/tests/cards.test.ts
+++ b/packages/database/src/tests/cards.test.ts
@@ -5,6 +5,7 @@ import { setupTestDatabase, cleanupTestDatabase, resetTestTables, type TestDb } 
 import { cardGroups, cards, groups, studyLanguages, users } from '../schema.js';
 import {
   bulkAssignActiveCardsToGroup,
+  deleteGroup,
   getActiveCardWithGroups,
   getGroupWithActiveCardCount,
   listActiveCards,
@@ -301,5 +302,18 @@ describe('Card Library database operations', () => {
     expect(storedContentCard.status).toBe('deleted');
     expect(storedContentCard.deletedAt).not.toBeNull();
     expect(foodCards.map((card) => card.cardId)).toEqual(['card-examples']);
+  });
+
+  it('deletes groups by dissociating memberships without deleting cards', async () => {
+    await seedLibrary();
+
+    const deleted = await deleteGroup(TEST_USER.userId, TEST_LANG.languageId, 'group-greetings', db);
+
+    const remainingGroups = await listGroupsWithActiveCardCounts(TEST_USER.userId, TEST_LANG.languageId, db);
+    const remainingCards = await listActiveCards(TEST_USER.userId, TEST_LANG.languageId, {}, db);
+
+    expect(deleted).toBe(true);
+    expect(remainingGroups.map((group) => group.groupId)).toEqual(['group-chat', 'group-food']);
+    expect(remainingCards.find((card) => card.cardId === 'card-content')?.groups).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- build the `/{lang}/cards/groups` surface with alphabetical rows, empty state, mobile layout, and Group Detail navigation
- add the new-group drawer plus create and delete action routes, including duplicate-name validation and safe group dissociation on delete
- add web and database coverage for group helpers, list loading, and delete behavior

## Testing
- pnpm turbo test lint build --filter=web
- pnpm test:db:branch:secure

Closes #142
