### PR TITLE
Build Group Detail with inline metadata editing and scoped card management

### DIFF
--- a/apps/web/src/lib/cards/group-detail.test.ts
+++ b/apps/web/src/lib/cards/group-detail.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildGroupDetailMobileMeta,
+  filterAddableGroupCards,
+  matchesGroupDetailFilters,
+  withCurrentGroupMembership,
+} from './group-detail.js';
+
+describe('buildGroupDetailMobileMeta', () => {
+  it('combines meaning and updated label for mobile rows', () => {
+    expect(
+      buildGroupDetailMobileMeta({
+        cardId: 'card-1',
+        content: '你好',
+        meaning: 'hello',
+        cardType: 'word',
+        updatedAtIso: '2026-04-01T00:00:00.000Z',
+        updatedAtLabel: '2d',
+        groups: [],
+      }),
+    ).toBe('hello · 2d');
+  });
+});
+
+describe('filterAddableGroupCards', () => {
+  const items = [
+    {
+      cardId: 'card-1',
+      content: '你好',
+      meaning: 'hello',
+      cardType: 'word',
+      updatedAtIso: '2026-04-01T00:00:00.000Z',
+      updatedAtLabel: '2d',
+      groups: [],
+    },
+    {
+      cardId: 'card-2',
+      content: '谢谢',
+      meaning: 'thank you',
+      cardType: 'word',
+      updatedAtIso: '2026-04-02T00:00:00.000Z',
+      updatedAtLabel: '1d',
+      groups: [],
+    },
+  ];
+
+  it('filters by content or meaning', () => {
+    expect(filterAddableGroupCards(items, 'thank').map((item) => item.cardId)).toEqual(['card-2']);
+    expect(filterAddableGroupCards(items, '你好').map((item) => item.cardId)).toEqual(['card-1']);
+  });
+});
+
+describe('matchesGroupDetailFilters', () => {
+  const item = {
+    cardId: 'card-1',
+    content: '你好',
+    meaning: 'hello',
+    cardType: 'word',
+    updatedAtIso: '2026-04-01T00:00:00.000Z',
+    updatedAtLabel: '2d',
+    groups: [],
+  };
+
+  it('checks type and search state', () => {
+    expect(matchesGroupDetailFilters(item, '', null)).toBe(true);
+    expect(matchesGroupDetailFilters(item, 'hell', 'word')).toBe(true);
+    expect(matchesGroupDetailFilters(item, 'bye', 'word')).toBe(false);
+    expect(matchesGroupDetailFilters(item, '', 'pattern')).toBe(false);
+  });
+});
+
+describe('withCurrentGroupMembership', () => {
+  it('adds the current group exactly once and sorts the result', () => {
+    expect(
+      withCurrentGroupMembership(
+        [{ groupId: 'group-b', groupName: 'Beta' }],
+        { groupId: 'group-a', groupName: 'Alpha' },
+      ),
+    ).toEqual([
+      { groupId: 'group-a', groupName: 'Alpha' },
+      { groupId: 'group-b', groupName: 'Beta' },
+    ]);
+  });
+});

--- a/apps/web/src/lib/cards/group-detail.ts
+++ b/apps/web/src/lib/cards/group-detail.ts
@@ -1,0 +1,60 @@
+import type {
+  CardLibraryCardListItemData,
+  CardLibraryData,
+  CardLibraryGroupData,
+} from '$lib/server/cards.js';
+
+export type GroupDetailCardType = NonNullable<CardLibraryData['filters']['cardType']>;
+
+export function buildGroupDetailMobileMeta(item: CardLibraryCardListItemData) {
+  const segments = [];
+
+  if (item.meaning) {
+    segments.push(item.meaning);
+  }
+
+  segments.push(item.updatedAtLabel);
+  return segments.join(' · ');
+}
+
+export function filterAddableGroupCards(items: CardLibraryCardListItemData[], query: string) {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+
+  if (!normalizedQuery) {
+    return items;
+  }
+
+  return items.filter((item) => {
+    const haystacks = [item.content, item.meaning ?? ''];
+    return haystacks.some((value) => value.toLocaleLowerCase().includes(normalizedQuery));
+  });
+}
+
+export function matchesGroupDetailFilters(
+  item: CardLibraryCardListItemData,
+  searchQuery: string,
+  selectedType: GroupDetailCardType | null,
+) {
+  if (selectedType && item.cardType !== selectedType) {
+    return false;
+  }
+
+  const normalizedQuery = searchQuery.trim().toLocaleLowerCase();
+
+  if (!normalizedQuery) {
+    return true;
+  }
+
+  return [item.content, item.meaning ?? ''].some((value) => value.toLocaleLowerCase().includes(normalizedQuery));
+}
+
+export function withCurrentGroupMembership(
+  groups: CardLibraryGroupData[],
+  currentGroup: CardLibraryGroupData,
+) {
+  if (groups.some((group) => group.groupId === currentGroup.groupId)) {
+    return groups;
+  }
+
+  return [...groups, currentGroup].sort((left, right) => left.groupName.localeCompare(right.groupName));
+}

--- a/apps/web/src/lib/components/card-list/CardListBulkActionBar.svelte
+++ b/apps/web/src/lib/components/card-list/CardListBulkActionBar.svelte
@@ -4,6 +4,7 @@
   const dispatch = createEventDispatcher<{
     primary: void;
     secondary: void;
+    tertiary: void;
     clear: void;
   }>();
 
@@ -14,9 +15,11 @@
   export let primaryActionPendingLabel = 'Working...';
   export let secondaryActionLabel = 'Secondary';
   export let secondaryActionPendingLabel = 'Working...';
+  export let tertiaryActionLabel = '';
+  export let tertiaryActionPendingLabel = 'Working...';
   export let clearLabel = 'Deselect all';
   export let disabled = false;
-  export let pendingAction: 'primary' | 'secondary' | null = null;
+  export let pendingAction: 'primary' | 'secondary' | 'tertiary' | null = null;
 </script>
 
 <section class="card-list-bulk-bar cluster" aria-live="polite">
@@ -34,6 +37,11 @@
     >
       {pendingAction === 'secondary' ? secondaryActionPendingLabel : secondaryActionLabel}
     </button>
+    {#if tertiaryActionLabel}
+      <button type="button" class="card-list-bulk-bar__button" disabled={disabled} on:click={() => dispatch('tertiary')}>
+        {pendingAction === 'tertiary' ? tertiaryActionPendingLabel : tertiaryActionLabel}
+      </button>
+    {/if}
     <button type="button" class="card-list-bulk-bar__link" on:click={() => dispatch('clear')}>{clearLabel}</button>
   </div>
 </section>

--- a/apps/web/src/lib/components/card-list/CardListFilterBar.svelte
+++ b/apps/web/src/lib/components/card-list/CardListFilterBar.svelte
@@ -20,6 +20,7 @@
   export let selectedType: string | null = null;
   export let clearGroupLabel = 'Clear group filters';
   export let clearTypeLabel = 'All types';
+  export let showGroupFilter = true;
 
   function toggleGroup(groupId: string) {
     if (selectedGroupIds.includes(groupId)) {
@@ -51,32 +52,34 @@
     />
   </label>
 
-  <details class="card-list-filter-bar__groups">
-    <summary
-      class:card-list-filter-bar__summary--active={selectedGroupIds.length > 0}
-      class="card-list-filter-bar__groups-summary"
-    >
-      {groupFilterLabel}
-      <span aria-hidden="true">▾</span>
-    </summary>
+  {#if showGroupFilter}
+    <details class="card-list-filter-bar__groups">
+      <summary
+        class:card-list-filter-bar__summary--active={selectedGroupIds.length > 0}
+        class="card-list-filter-bar__groups-summary"
+      >
+        {groupFilterLabel}
+        <span aria-hidden="true">▾</span>
+      </summary>
 
-    <div class="card-list-filter-bar__groups-menu stack" style="--stack-space: var(--space-2)">
-      <button type="button" class="card-list-filter-bar__clear" on:click={clearGroupFilters}>
-        {clearGroupLabel}
-      </button>
+      <div class="card-list-filter-bar__groups-menu stack" style="--stack-space: var(--space-2)">
+        <button type="button" class="card-list-filter-bar__clear" on:click={clearGroupFilters}>
+          {clearGroupLabel}
+        </button>
 
-      {#each availableGroups as group}
-        <label class="card-list-filter-bar__group-option">
-          <input
-            type="checkbox"
-            checked={selectedGroupIds.includes(group.groupId)}
-            on:change={() => toggleGroup(group.groupId)}
-          />
-          <span>{group.groupName}</span>
-        </label>
-      {/each}
-    </div>
-  </details>
+        {#each availableGroups as group}
+          <label class="card-list-filter-bar__group-option">
+            <input
+              type="checkbox"
+              checked={selectedGroupIds.includes(group.groupId)}
+              on:change={() => toggleGroup(group.groupId)}
+            />
+            <span>{group.groupName}</span>
+          </label>
+        {/each}
+      </div>
+    </details>
+  {/if}
 
   {#if availableTypes.length > 0}
     <details class="card-list-filter-bar__groups">

--- a/apps/web/src/lib/components/card-list/CardListRow.svelte
+++ b/apps/web/src/lib/components/card-list/CardListRow.svelte
@@ -12,6 +12,7 @@
   export let rowTemplate = '1rem minmax(0, 2.25fr) minmax(9rem, 1fr) auto auto';
   export let clickable = false;
   export let mobileShowCheckbox = true;
+  export let showGroups = true;
   export let hasActions = true;
   export let longPressDuration = 500;
 
@@ -92,9 +93,11 @@
       <slot name="content" />
     </div>
 
-    <div class="card-list-row__groups">
-      <slot name="groups" />
-    </div>
+    {#if showGroups}
+      <div class="card-list-row__groups">
+        <slot name="groups" />
+      </div>
+    {/if}
 
     <div class="card-list-row__updated">
       <slot name="updated" />

--- a/apps/web/src/lib/server/cards.test.ts
+++ b/apps/web/src/lib/server/cards.test.ts
@@ -154,6 +154,7 @@ describe('Card Library server helpers', () => {
       },
       database,
     );
+    expect(result.addableCards.items.map((item) => item.cardId)).toEqual([]);
   });
 
   it('loads active card detail with available groups', async () => {
@@ -197,6 +198,33 @@ describe('Card Library server helpers', () => {
 
     expect(result.items.map((group) => group.groupName)).toEqual(['Alpha', 'Zeta']);
     expect(result.totalCount).toBe(2);
+  });
+
+  it('excludes current group members from addable cards in group detail', async () => {
+    baseDeps.listActiveCards.mockResolvedValueOnce([
+      {
+        cardId: 'card-2',
+        content: '聊天',
+        meaning: 'to chat',
+        cardType: 'pattern',
+        updatedAt: new Date('2026-04-02T00:00:00.000Z'),
+        groups: [{ groupId: 'group-chat', groupName: 'Chat' }],
+      },
+      {
+        cardId: 'card-3',
+        content: '你好',
+        meaning: 'hello',
+        cardType: 'word',
+        updatedAt: new Date('2026-04-03T00:00:00.000Z'),
+        groups: [],
+      },
+    ]);
+
+    const url = new URL('https://studypuck.test/zh/cards/groups/group-chat');
+    const result = await loadGroupDetailData('user-1', 'zh', 'group-chat', url, database, baseDeps);
+
+    expect(result.addableCards.items.map((item) => item.cardId)).toEqual(['card-3']);
+    expect(result.addableCards.totalCount).toBe(1);
   });
 
   it('rejects invalid filter input before hitting the data layer', async () => {

--- a/apps/web/src/lib/server/cards.ts
+++ b/apps/web/src/lib/server/cards.ts
@@ -14,6 +14,7 @@ import {
   removeCardFromGroup,
   softDeleteActiveCards,
   updateActiveCard,
+  updateGroup,
   type ActiveCardDetail,
   type ActiveCardGroupSummary,
   type ActiveCardListItem,
@@ -120,6 +121,10 @@ export type GroupDetailData = {
     activeCardCount: number;
   };
   cards: CardLibraryData;
+  addableCards: {
+    items: CardLibraryCardListItemData[];
+    totalCount: number;
+  };
 };
 
 export type CardLibraryGroupListItemData = {
@@ -139,6 +144,11 @@ const cardLibraryGroupCreateSchema = z.object({
   description: editableCardOptionalTextSchema.optional().default(null),
 });
 
+const groupDetailGroupUpdateSchema = z.object({
+  groupName: editableGroupNameSchema,
+  description: editableCardOptionalTextSchema.optional().default(null),
+});
+
 function normalizeStringList(value: unknown): string[] {
   if (!Array.isArray(value)) {
     return [];
@@ -149,6 +159,10 @@ function normalizeStringList(value: unknown): string[] {
 
 function createGroupId(): string {
   return `group-${globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`}`;
+}
+
+function normalizeGroupName(value: string) {
+  return value.trim().toLocaleLowerCase();
 }
 
 async function assertUserHasLanguage(
@@ -326,6 +340,30 @@ function mapActiveCardDetail(card: ActiveCardDetail): CardLibraryCardDetailData 
   };
 }
 
+async function ensureUniqueGroupName(
+  userId: string,
+  languageId: string,
+  groupName: string,
+  database: DatabaseClient,
+  options?: {
+    excludeGroupId?: string;
+  },
+) {
+  const normalizedName = normalizeGroupName(groupName);
+  const existingGroups = await getGroups(userId, languageId, database as never);
+  const duplicateGroup = existingGroups.find((group) => {
+    if (options?.excludeGroupId && group.groupId === options.excludeGroupId) {
+      return false;
+    }
+
+    return normalizeGroupName(group.groupName) === normalizedName;
+  });
+
+  if (duplicateGroup) {
+    throw new CardLibraryRequestError(409, 'A group with this name already exists.');
+  }
+}
+
 async function resolveGroupSelections(
   userId: string,
   languageId: string,
@@ -486,7 +524,7 @@ export async function loadGroupDetailData(
 
   const parsedGroupId = parseGroupId(groupId);
   const filters = parseFilters(url);
-  const [group, items, availableGroups] = await Promise.all([
+  const [group, items, allActiveCards, availableGroups] = await Promise.all([
     deps.getGroupWithActiveCardCount(userId, languageId, parsedGroupId, database as never),
     deps.listActiveCardsInGroup(
       userId,
@@ -498,6 +536,7 @@ export async function loadGroupDetailData(
       },
       database as never,
     ),
+    deps.listActiveCards(userId, languageId, {}, database as never),
     deps.listGroupsWithActiveCardCounts(userId, languageId, database as never),
   ]);
 
@@ -518,6 +557,12 @@ export async function loadGroupDetailData(
       filteredCardIds: items.map((item) => item.cardId),
       filters,
       availableGroups: sortGroupsByName(availableGroups.map((availableGroup) => mapGroupFilterOption(availableGroup))),
+    },
+    addableCards: {
+      items: allActiveCards
+        .filter((item) => !item.groups.some((itemGroup) => itemGroup.groupId === parsedGroupId))
+        .map((item) => mapCardListItem(item)),
+      totalCount: allActiveCards.filter((item) => !item.groups.some((itemGroup) => itemGroup.groupId === parsedGroupId)).length,
     },
   };
 }
@@ -658,15 +703,7 @@ export async function createCardLibraryGroupForLanguage(
     );
   }
 
-  const existingGroups = await getGroups(userId, languageId, database as never);
-  const normalizedName = parsedInput.data.groupName.trim().toLocaleLowerCase();
-  const duplicateGroup = existingGroups.find(
-    (group) => group.groupName.trim().toLocaleLowerCase() === normalizedName,
-  );
-
-  if (duplicateGroup) {
-    throw new CardLibraryRequestError(409, 'A group with this name already exists.');
-  }
+  await ensureUniqueGroupName(userId, languageId, parsedInput.data.groupName, database);
 
   const createdGroup = await createGroup(
     {
@@ -710,4 +747,115 @@ export async function deleteCardLibraryGroupForLanguage(
     groupId: group.groupId,
     activeCardCount: group.activeCardCount,
   };
+}
+
+export async function updateGroupDetailForLanguage(
+  userId: string,
+  languageId: string,
+  groupId: unknown,
+  input: unknown,
+  database: DatabaseClient,
+) {
+  await assertUserHasLanguage(userId, languageId, database);
+
+  const parsedGroupId = parseGroupId(groupId);
+  const parsedInput = groupDetailGroupUpdateSchema.safeParse(input);
+
+  if (!parsedInput.success) {
+    throw new CardLibraryRequestError(
+      400,
+      parsedInput.error.issues[0]?.message ?? 'Group data is invalid.',
+    );
+  }
+
+  const existingGroup = await getGroupWithActiveCardCount(userId, languageId, parsedGroupId, database as never);
+
+  if (!existingGroup) {
+    throw new CardLibraryRequestError(404, 'Group not found.');
+  }
+
+  await ensureUniqueGroupName(
+    userId,
+    languageId,
+    parsedInput.data.groupName,
+    database,
+    { excludeGroupId: parsedGroupId },
+  );
+
+  const updatedGroup = await updateGroup(
+    userId,
+    languageId,
+    parsedGroupId,
+    {
+      groupName: parsedInput.data.groupName,
+      description: parsedInput.data.description,
+    },
+    database as never,
+  );
+
+  if (!updatedGroup) {
+    throw new CardLibraryRequestError(404, 'Group not found.');
+  }
+
+  return {
+    groupId: updatedGroup.groupId,
+    groupName: updatedGroup.groupName,
+    description: updatedGroup.description ?? null,
+    activeCardCount: existingGroup.activeCardCount,
+  };
+}
+
+export async function addCardsToGroupDetailForLanguage(
+  userId: string,
+  languageId: string,
+  groupId: unknown,
+  cardIds: unknown,
+  database: DatabaseClient,
+) {
+  await assertUserHasLanguage(userId, languageId, database);
+
+  const parsedGroupId = parseGroupId(groupId);
+  const parsedCardIds = parseCardIds(cardIds);
+  const group = await getGroupWithActiveCardCount(userId, languageId, parsedGroupId, database as never);
+
+  if (!group) {
+    throw new CardLibraryRequestError(404, 'Group not found.');
+  }
+
+  return bulkAssignActiveCardsToGroup(
+    userId,
+    languageId,
+    parsedCardIds,
+    parsedGroupId,
+    database as never,
+  );
+}
+
+export async function removeCardsFromGroupDetailForLanguage(
+  userId: string,
+  languageId: string,
+  groupId: unknown,
+  cardIds: unknown,
+  database: DatabaseClient,
+) {
+  await assertUserHasLanguage(userId, languageId, database);
+
+  const parsedGroupId = parseGroupId(groupId);
+  const parsedCardIds = parseCardIds(cardIds);
+  const group = await getGroupWithActiveCardCount(userId, languageId, parsedGroupId, database as never);
+
+  if (!group) {
+    throw new CardLibraryRequestError(404, 'Group not found.');
+  }
+
+  const removableCards = await listActiveCardsInGroup(userId, languageId, parsedGroupId, {}, database as never);
+  const removableCardIds = removableCards
+    .map((card) => card.cardId)
+    .filter((cardId) => parsedCardIds.includes(cardId));
+
+  for (const cardId of removableCardIds) {
+    await removeCardFromGroup(userId, languageId, cardId, parsedGroupId, database as never);
+  }
+
+  return removableCardIds;
 }

--- a/apps/web/src/routes/[lang]/cards/groups/[groupId]/+page.svelte
+++ b/apps/web/src/routes/[lang]/cards/groups/[groupId]/+page.svelte
@@ -1,29 +1,122 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
+  import { onDestroy, onMount, tick } from 'svelte';
   import ActiveCardDrawer from '$lib/components/cards/ActiveCardDrawer.svelte';
-  import CardListStatusBadge from '$lib/components/card-list/CardListStatusBadge.svelte';
+  import CardListBulkActionBar from '$lib/components/card-list/CardListBulkActionBar.svelte';
+  import CardListColumns from '$lib/components/card-list/CardListColumns.svelte';
+  import CardListFilterBar from '$lib/components/card-list/CardListFilterBar.svelte';
+  import CardListRow from '$lib/components/card-list/CardListRow.svelte';
   import CardListTagChip from '$lib/components/card-list/CardListTagChip.svelte';
+  import {
+    buildGroupDetailMobileMeta,
+    filterAddableGroupCards,
+    matchesGroupDetailFilters,
+    withCurrentGroupMembership,
+    type GroupDetailCardType,
+  } from '$lib/cards/group-detail.js';
+  import { buildDeleteGroupMessage } from '$lib/cards/groups.js';
+  import {
+    cardLibraryTypeOptions,
+    formatCardLibraryTypeFilterLabel,
+    mapCardDetailToListItem,
+    sortCardLibraryGroups,
+    sortCardLibraryItems,
+  } from '$lib/cards/library.js';
   import type {
     CardLibraryCardDetailData,
     CardLibraryCardListItemData,
     CardLibraryData,
     CardLibraryGroupData,
+    GroupDetailData,
   } from '$lib/server/cards.js';
   import type { PageData } from './$types.js';
 
   export let data: PageData;
 
-  let cards: CardLibraryData = data.groupDetail.cards;
+  type BulkAction = 'assign-group' | 'delete' | 'remove-from-group';
+  type ActionFeedback = {
+    title: string;
+    message: string;
+  };
+
+  let groupDetail: GroupDetailData = data.groupDetail;
   let selectedCard: CardLibraryCardDetailData | null = data.selectedCard;
   let selectedCardAvailableGroups: CardLibraryGroupData[] = data.selectedCardAvailableGroups;
-  let previousCards = data.groupDetail.cards;
+  let previousGroupDetail = data.groupDetail;
   let previousSelectedCard = data.selectedCard;
   let previousSelectedCardAvailableGroups = data.selectedCardAvailableGroups;
 
-  $: if (data.groupDetail.cards !== previousCards) {
+  let cards: CardLibraryData = data.groupDetail.cards;
+  let addableCards = data.groupDetail.addableCards;
+  let group = data.groupDetail.group;
+  let searchQuery = data.groupDetail.cards.filters.searchText;
+  let selectedType: GroupDetailCardType | null = data.groupDetail.cards.filters.cardType;
+  let lastAppliedFilterState = '';
+  let lastRequestedFilterState = '';
+  let filterSyncTimer: ReturnType<typeof setTimeout> | null = null;
+  let selectedCardIds: string[] = [];
+  let actionFeedback: ActionFeedback | null = null;
+  let pendingBulkAction: BulkAction | null = null;
+  let bulkAssignOpen = false;
+  let selectedBulkGroupId: string | null = null;
+  let isMobileViewport = false;
+  let viewportMediaQuery: MediaQueryList | null = null;
+
+  let addCardsDrawerOpen = false;
+  let addCardsDrawerElement: HTMLElement | null = null;
+  let addCardsSearchQuery = '';
+  let addCardsSelectedIds: string[] = [];
+  let addCardsPending = false;
+
+  let isEditingName = false;
+  let isEditingDescription = false;
+  let groupNameDraft = data.groupDetail.group.groupName;
+  let groupDescriptionDraft = data.groupDetail.group.description ?? '';
+  let groupNameError = '';
+  let groupDescriptionError = '';
+  let groupNameInput: HTMLInputElement | null = null;
+  let groupDescriptionInput: HTMLTextAreaElement | null = null;
+  let groupSavePending = false;
+
+  let deleteDialogOpen = false;
+  let deleteGroupPending = false;
+
+  function serializeFilterState(nextSearchQuery: string, nextType: GroupDetailCardType | null) {
+    return JSON.stringify({
+      searchQuery: nextSearchQuery.trim(),
+      type: nextType,
+    });
+  }
+
+  function syncViewportMode() {
+    isMobileViewport = viewportMediaQuery?.matches ?? false;
+  }
+
+  onMount(() => {
+    viewportMediaQuery = window.matchMedia('(max-width: 900px)');
+    syncViewportMode();
+    viewportMediaQuery.addEventListener('change', syncViewportMode);
+  });
+
+  onDestroy(() => {
+    filterSyncTimer && clearTimeout(filterSyncTimer);
+    viewportMediaQuery?.removeEventListener('change', syncViewportMode);
+  });
+
+  $: currentLang = $page.params.lang ?? '';
+  $: currentGroupId = group.groupId;
+  $: currentGroupSummary = {
+    groupId: group.groupId,
+    groupName: group.groupName,
+  };
+
+  $: if (data.groupDetail !== previousGroupDetail) {
+    groupDetail = data.groupDetail;
+    group = data.groupDetail.group;
     cards = data.groupDetail.cards;
-    previousCards = data.groupDetail.cards;
+    addableCards = data.groupDetail.addableCards;
+    previousGroupDetail = data.groupDetail;
   }
 
   $: if (data.selectedCard !== previousSelectedCard) {
@@ -36,10 +129,63 @@
     previousSelectedCardAvailableGroups = data.selectedCardAvailableGroups;
   }
 
-  $: selectedIndex = selectedCard ? cards.filteredCardIds.indexOf(selectedCard.cardId) : -1;
+  $: appliedFilterState = serializeFilterState(cards.filters.searchText, cards.filters.cardType);
 
-  function buildDrawerUrl(cardId: string | null) {
+  $: if (appliedFilterState !== lastAppliedFilterState) {
+    searchQuery = cards.filters.searchText;
+    selectedType = cards.filters.cardType;
+    lastAppliedFilterState = appliedFilterState;
+    lastRequestedFilterState = appliedFilterState;
+    selectedCardIds = selectedCardIds.filter((cardId) => cards.filteredCardIds.includes(cardId));
+  }
+
+  $: currentFilterState = serializeFilterState(searchQuery, selectedType);
+
+  $: if (currentFilterState !== lastAppliedFilterState && currentFilterState !== lastRequestedFilterState) {
+    scheduleFilterNavigation(currentFilterState);
+  }
+
+  $: selectedIndex = selectedCard ? cards.filteredCardIds.indexOf(selectedCard.cardId) : -1;
+  $: isSelectMode = selectedCardIds.length > 0;
+  $: typeFilterLabel = formatCardLibraryTypeFilterLabel(selectedType);
+  $: hasActiveFilters = searchQuery.trim().length > 0 || selectedType !== null;
+  $: filteredAddableCards = filterAddableGroupCards(addableCards.items, addCardsSearchQuery);
+  $: sortedAssignableGroups = sortCardLibraryGroups(cards.availableGroups.filter((item) => item.groupId !== currentGroupId));
+
+  function scheduleFilterNavigation(nextFilterState: string) {
+    if (filterSyncTimer) {
+      clearTimeout(filterSyncTimer);
+    }
+
+    filterSyncTimer = setTimeout(() => {
+      lastRequestedFilterState = nextFilterState;
+      selectedCardIds = [];
+      bulkAssignOpen = false;
+      selectedBulkGroupId = null;
+      actionFeedback = null;
+      addCardsDrawerOpen = false;
+      void goto(buildFilterUrl(), {
+        keepFocus: true,
+        noScroll: true,
+        replaceState: true,
+      });
+    }, 150);
+  }
+
+  function buildFilterUrl(cardId: string | null = null) {
     const nextUrl = new URL($page.url);
+
+    if (searchQuery.trim().length > 0) {
+      nextUrl.searchParams.set('q', searchQuery.trim());
+    } else {
+      nextUrl.searchParams.delete('q');
+    }
+
+    if (selectedType) {
+      nextUrl.searchParams.set('type', selectedType);
+    } else {
+      nextUrl.searchParams.delete('type');
+    }
 
     if (cardId) {
       nextUrl.searchParams.set('card', cardId);
@@ -51,133 +197,863 @@
   }
 
   async function openCard(cardId: string) {
-    await goto(buildDrawerUrl(cardId), {
+    await goto(buildFilterUrl(cardId), {
       keepFocus: true,
       noScroll: true,
     });
   }
 
   async function navigateDrawer(cardId: string | null) {
-    await goto(buildDrawerUrl(cardId), {
+    await goto(buildFilterUrl(cardId), {
       keepFocus: true,
       noScroll: true,
       replaceState: true,
     });
   }
 
-  function sortCards(items: CardLibraryCardListItemData[]) {
-    return [...items].sort((left, right) => {
-      const leftTime = left.updatedAtIso ? Date.parse(left.updatedAtIso) : 0;
-      const rightTime = right.updatedAtIso ? Date.parse(right.updatedAtIso) : 0;
-      return rightTime - leftTime;
-    });
+  function clearFilters() {
+    searchQuery = '';
+    selectedType = null;
   }
 
-  function mapDetailToListItem(card: CardLibraryCardDetailData): CardLibraryCardListItemData {
-    return {
-      cardId: card.cardId,
-      content: card.content,
-      meaning: card.meaning,
-      cardType: card.cardType,
-      updatedAtIso: card.updatedAtIso ?? new Date().toISOString(),
-      updatedAtLabel: 'Just now',
-      groups: card.groups,
-    };
+  function dismissActionFeedback() {
+    actionFeedback = null;
   }
 
-  function handleCardUpdated(event: CustomEvent<{ card: CardLibraryCardDetailData; availableGroups: CardLibraryGroupData[] }>) {
-    selectedCard = event.detail.card;
-    selectedCardAvailableGroups = event.detail.availableGroups;
+  function toggleSelection(cardId: string) {
+    if (selectedCardIds.includes(cardId)) {
+      selectedCardIds = selectedCardIds.filter((selectedCardId) => selectedCardId !== cardId);
+      return;
+    }
 
-    const nextItem = mapDetailToListItem(event.detail.card);
-    const otherItems = cards.items.filter((item) => item.cardId !== nextItem.cardId);
-    const nextItems = sortCards([nextItem, ...otherItems]);
-
-    cards = {
-      ...cards,
-      items: nextItems,
-      filteredCardIds: nextItems.map((item) => item.cardId),
-    };
+    selectedCardIds = [...selectedCardIds, cardId];
   }
 
-  function handleCardDeleted(event: CustomEvent<{ cardId: string }>) {
-    const nextItems = cards.items.filter((item) => item.cardId !== event.detail.cardId);
+  function clearSelection() {
+    selectedCardIds = [];
+    bulkAssignOpen = false;
+    selectedBulkGroupId = null;
+  }
 
+  function handleRowActivate(cardId: string) {
+    if (isMobileViewport && isSelectMode) {
+      toggleSelection(cardId);
+      return;
+    }
+
+    void openCard(cardId);
+  }
+
+  function handleRowLongPress(cardId: string) {
+    if (!isMobileViewport) {
+      return;
+    }
+
+    if (!selectedCardIds.includes(cardId)) {
+      selectedCardIds = [...selectedCardIds, cardId];
+    }
+  }
+
+  function replaceCards(nextItems: CardLibraryCardListItemData[]) {
     cards = {
       ...cards,
       items: nextItems,
       totalCount: nextItems.length,
       filteredCardIds: nextItems.map((item) => item.cardId),
     };
+  }
 
-    selectedCard = null;
-    void navigateDrawer(null);
+  function removeCardIdsFromCurrentList(cardIds: string[]) {
+    replaceCards(cards.items.filter((item) => !cardIds.includes(item.cardId)));
+    selectedCardIds = selectedCardIds.filter((cardId) => !cardIds.includes(cardId));
+
+    if (selectedCard && cardIds.includes(selectedCard.cardId)) {
+      selectedCard = null;
+      void navigateDrawer(null);
+    }
+  }
+
+  function addItemsToAddableList(items: CardLibraryCardListItemData[]) {
+    const existingIds = new Set(addableCards.items.map((item) => item.cardId));
+    const nextItems = [
+      ...addableCards.items,
+      ...items.filter((item) => !existingIds.has(item.cardId)),
+    ];
+
+    addableCards = {
+      items: sortCardLibraryItems(nextItems),
+      totalCount: nextItems.length,
+    };
+  }
+
+  function removeAddableCardIds(cardIds: string[]) {
+    const nextItems = addableCards.items.filter((item) => !cardIds.includes(item.cardId));
+    addableCards = {
+      items: nextItems,
+      totalCount: nextItems.length,
+    };
+  }
+
+  async function applyBulkAction(action: BulkAction, options?: { groupId?: string }) {
+    if (selectedCardIds.length === 0 || !currentLang) {
+      return;
+    }
+
+    pendingBulkAction = action;
+    actionFeedback = null;
+
+    try {
+      const endpoint = action === 'remove-from-group'
+        ? `/${currentLang}/cards/groups/${currentGroupId}/actions`
+        : `/${currentLang}/cards/actions`;
+      const body = action === 'remove-from-group'
+        ? {
+            action: 'remove-cards',
+            cardIds: selectedCardIds,
+          }
+        : {
+            action,
+            cardIds: selectedCardIds,
+            groupId: options?.groupId ?? null,
+          };
+
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+
+      const responseBody = (await response.json().catch(() => null)) as
+        | {
+            message?: string;
+            deletedCardIds?: string[];
+            removedCardIds?: string[];
+          }
+        | null;
+
+      if (!response.ok) {
+        throw new Error(responseBody?.message ?? 'The card action could not be completed right now.');
+      }
+
+      if (action === 'delete') {
+        const deletedCardIds = responseBody?.deletedCardIds ?? [];
+        const deletedCount = cards.items.filter((item) => deletedCardIds.includes(item.cardId)).length;
+        removeCardIdsFromCurrentList(deletedCardIds);
+        group = {
+          ...group,
+          activeCardCount: Math.max(group.activeCardCount - deletedCount, 0),
+        };
+      }
+
+      if (action === 'remove-from-group') {
+        const removedCardIds = responseBody?.removedCardIds ?? [];
+        const removedItems = cards.items
+          .filter((item) => removedCardIds.includes(item.cardId))
+          .map((item) => ({
+            ...item,
+            groups: item.groups.filter((itemGroup) => itemGroup.groupId !== currentGroupId),
+          }));
+
+        removeCardIdsFromCurrentList(removedCardIds);
+        addItemsToAddableList(removedItems);
+        group = {
+          ...group,
+          activeCardCount: Math.max(group.activeCardCount - removedCardIds.length, 0),
+        };
+      }
+
+      selectedCardIds = [];
+      bulkAssignOpen = false;
+      selectedBulkGroupId = null;
+    } catch (error) {
+      actionFeedback = {
+        title: 'Action failed',
+        message: error instanceof Error ? error.message : 'The card action could not be completed right now.',
+      };
+    } finally {
+      pendingBulkAction = null;
+    }
+  }
+
+  function handleCardUpdated(event: CustomEvent<{ card: CardLibraryCardDetailData; availableGroups: CardLibraryGroupData[] }>) {
+    selectedCard = event.detail.card;
+    selectedCardAvailableGroups = event.detail.availableGroups;
+
+    const stillInGroup = event.detail.card.groups.some((itemGroup) => itemGroup.groupId === currentGroupId);
+
+    if (!stillInGroup) {
+      removeCardIdsFromCurrentList([event.detail.card.cardId]);
+      addItemsToAddableList([
+        {
+          ...mapCardDetailToListItem(event.detail.card),
+          groups: event.detail.card.groups.filter((itemGroup) => itemGroup.groupId !== currentGroupId),
+        },
+      ]);
+      group = {
+        ...group,
+        activeCardCount: Math.max(group.activeCardCount - 1, 0),
+      };
+      return;
+    }
+
+    const nextItem = mapCardDetailToListItem(event.detail.card);
+    const otherItems = cards.items.filter((item) => item.cardId !== nextItem.cardId);
+    const nextItems = sortCardLibraryItems([nextItem, ...otherItems]);
+
+    replaceCards(nextItems);
+    removeAddableCardIds([nextItem.cardId]);
+  }
+
+  function handleCardDeleted(event: CustomEvent<{ cardId: string }>) {
+    const deletedCount = cards.items.some((item) => item.cardId === event.detail.cardId) ? 1 : 0;
+    removeCardIdsFromCurrentList([event.detail.cardId]);
+    group = {
+      ...group,
+      activeCardCount: Math.max(group.activeCardCount - deletedCount, 0),
+    };
+  }
+
+  function openAddCardsDrawer() {
+    addCardsDrawerOpen = true;
+    addCardsSearchQuery = '';
+    addCardsSelectedIds = [];
+    tick().then(() => addCardsDrawerElement?.focus());
+  }
+
+  function closeAddCardsDrawer() {
+    if (addCardsPending) {
+      return;
+    }
+
+    addCardsDrawerOpen = false;
+    addCardsSearchQuery = '';
+    addCardsSelectedIds = [];
+  }
+
+  function toggleAddCardSelection(cardId: string) {
+    if (addCardsSelectedIds.includes(cardId)) {
+      addCardsSelectedIds = addCardsSelectedIds.filter((selectedCardId) => selectedCardId !== cardId);
+      return;
+    }
+
+    addCardsSelectedIds = [...addCardsSelectedIds, cardId];
+  }
+
+  async function addSelectedCardsToGroup() {
+    if (addCardsSelectedIds.length === 0 || !currentLang) {
+      return;
+    }
+
+    addCardsPending = true;
+    actionFeedback = null;
+
+    try {
+      const response = await fetch(`/${currentLang}/cards/groups/${currentGroupId}/actions`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          action: 'add-cards',
+          cardIds: addCardsSelectedIds,
+        }),
+      });
+
+      const responseBody = (await response.json().catch(() => null)) as
+        | {
+            addedCardIds?: string[];
+            message?: string;
+          }
+        | null;
+
+      if (!response.ok) {
+        throw new Error(responseBody?.message ?? 'The cards could not be added right now.');
+      }
+
+      const addedCardIds = responseBody?.addedCardIds ?? [];
+      const addedItems = addableCards.items
+        .filter((item) => addedCardIds.includes(item.cardId))
+        .map((item) => ({
+          ...item,
+          groups: withCurrentGroupMembership(item.groups, currentGroupSummary),
+        }));
+
+      const visibleAddedItems = addedItems.filter((item) => matchesGroupDetailFilters(item, searchQuery, selectedType));
+
+      if (visibleAddedItems.length > 0) {
+        replaceCards(sortCardLibraryItems([...visibleAddedItems, ...cards.items]));
+      }
+
+      removeAddableCardIds(addedCardIds);
+      group = {
+        ...group,
+        activeCardCount: group.activeCardCount + addedCardIds.length,
+      };
+      closeAddCardsDrawer();
+    } catch (error) {
+      actionFeedback = {
+        title: 'Add cards failed',
+        message: error instanceof Error ? error.message : 'The cards could not be added right now.',
+      };
+    } finally {
+      addCardsPending = false;
+    }
+  }
+
+  function beginEditingName() {
+    groupNameDraft = group.groupName;
+    groupNameError = '';
+    isEditingName = true;
+    tick().then(() => {
+      groupNameInput?.focus();
+      groupNameInput?.select();
+    });
+  }
+
+  function beginEditingDescription() {
+    groupDescriptionDraft = group.description ?? '';
+    groupDescriptionError = '';
+    isEditingDescription = true;
+    tick().then(() => {
+      groupDescriptionInput?.focus();
+      groupDescriptionInput?.select();
+    });
+  }
+
+  async function saveGroupMetadata(source: 'name' | 'description') {
+    if (groupSavePending || !currentLang) {
+      return;
+    }
+
+    groupSavePending = true;
+    actionFeedback = null;
+
+    try {
+      const response = await fetch(`/${currentLang}/cards/groups/${currentGroupId}/actions`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          action: 'update-group',
+          groupName: source === 'name' ? groupNameDraft : group.groupName,
+          description: source === 'description' ? groupDescriptionDraft : (group.description ?? ''),
+        }),
+      });
+
+      const responseBody = (await response.json().catch(() => null)) as
+        | {
+            group?: GroupDetailData['group'];
+            message?: string;
+          }
+        | null;
+
+      if (!response.ok || !responseBody?.group) {
+        throw new Error(responseBody?.message ?? 'The group could not be updated right now.');
+      }
+
+      const previousGroupId = group.groupId;
+      group = responseBody.group;
+      groupNameDraft = responseBody.group.groupName;
+      groupDescriptionDraft = responseBody.group.description ?? '';
+      groupNameError = '';
+      groupDescriptionError = '';
+      isEditingName = false;
+      isEditingDescription = false;
+      cards = {
+        ...cards,
+        availableGroups: sortCardLibraryGroups(
+          cards.availableGroups.map((item) => item.groupId === previousGroupId
+            ? { ...item, groupName: responseBody.group?.groupName ?? item.groupName }
+            : item),
+        ),
+      };
+      selectedCardAvailableGroups = sortCardLibraryGroups(
+        selectedCardAvailableGroups.map((item) => item.groupId === previousGroupId
+          ? { ...item, groupName: responseBody.group?.groupName ?? item.groupName }
+          : item),
+      );
+
+      if (selectedCard) {
+        selectedCard = {
+          ...selectedCard,
+          groups: selectedCard.groups.map((item) => item.groupId === previousGroupId
+            ? { ...item, groupName: responseBody.group?.groupName ?? item.groupName }
+            : item),
+        };
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'The group could not be updated right now.';
+
+      if (source === 'name') {
+        groupNameDraft = group.groupName;
+        groupNameError = message;
+        isEditingName = false;
+      } else {
+        groupDescriptionDraft = group.description ?? '';
+        groupDescriptionError = message;
+        isEditingDescription = false;
+      }
+    } finally {
+      groupSavePending = false;
+    }
+  }
+
+  async function confirmDeleteGroup() {
+    if (deleteGroupPending || !currentLang) {
+      return;
+    }
+
+    deleteGroupPending = true;
+    actionFeedback = null;
+
+    try {
+      const response = await fetch(`/${currentLang}/cards/groups/${currentGroupId}/actions`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          action: 'delete-group',
+        }),
+      });
+
+      const responseBody = (await response.json().catch(() => null)) as { message?: string } | null;
+
+      if (!response.ok) {
+        throw new Error(responseBody?.message ?? 'The group could not be deleted right now.');
+      }
+
+      await goto(`/${currentLang}/cards/groups`);
+    } catch (error) {
+      actionFeedback = {
+        title: 'Delete failed',
+        message: error instanceof Error ? error.message : 'The group could not be deleted right now.',
+      };
+    } finally {
+      deleteGroupPending = false;
+      deleteDialogOpen = false;
+    }
+  }
+
+  function handleWindowKeydown(event: KeyboardEvent) {
+    if (event.key !== 'Escape') {
+      return;
+    }
+
+    if (deleteDialogOpen) {
+      deleteDialogOpen = false;
+      return;
+    }
+
+    if (addCardsDrawerOpen) {
+      event.preventDefault();
+      closeAddCardsDrawer();
+      return;
+    }
+  }
+
+  function handleAddCardsDrawerKeydown(event: KeyboardEvent) {
+    if (event.key !== 'Tab' || !addCardsDrawerElement) {
+      return;
+    }
+
+    const focusableElements = Array.from(
+      addCardsDrawerElement.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], textarea:not([disabled]), input:not([disabled])',
+      ),
+    );
+
+    if (focusableElements.length === 0) {
+      return;
+    }
+
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    if (event.shiftKey && document.activeElement === firstElement) {
+      event.preventDefault();
+      lastElement?.focus();
+      return;
+    }
+
+    if (!event.shiftKey && document.activeElement === lastElement) {
+      event.preventDefault();
+      firstElement?.focus();
+    }
   }
 </script>
 
+<svelte:window on:keydown={handleWindowKeydown} />
+
 <svelte:head>
-  <title>{data.groupDetail.group.groupName} – StudyPuck</title>
+  <title>{group.groupName} - StudyPuck</title>
 </svelte:head>
 
 <section class="group-detail-page stack" style="--stack-space: var(--space-5)">
-  <header class="stack" style="--stack-space: var(--space-2)">
-    <p class="group-detail-page__eyebrow">Cards</p>
-    <h1>{data.groupDetail.group.groupName}</h1>
-    {#if data.groupDetail.group.description}
-      <p>{data.groupDetail.group.description}</p>
-    {/if}
-    <p class="group-detail-page__count">
-      {data.groupDetail.group.activeCardCount} active {data.groupDetail.group.activeCardCount === 1 ? 'card' : 'cards'}
-    </p>
+  <header class="group-detail-page__header stack" style="--stack-space: var(--space-3)">
+    <a class="group-detail-page__back-link" href={`/${currentLang}/cards/groups`}>← Back to Groups</a>
+
+    <div class="group-detail-page__header-main">
+      <div class="stack" style="--stack-space: var(--space-2)">
+        {#if isEditingName}
+          <div class="stack" style="--stack-space: var(--space-1)">
+            <input
+              bind:this={groupNameInput}
+              bind:value={groupNameDraft}
+              class="group-detail-page__name-input"
+              aria-label="Group name"
+              disabled={groupSavePending}
+              on:blur={() => void saveGroupMetadata('name')}
+              on:keydown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  void saveGroupMetadata('name');
+                }
+              }}
+            />
+            {#if groupNameError}
+              <p class="group-detail-page__error" role="alert">{groupNameError}</p>
+            {/if}
+          </div>
+        {:else}
+          <button type="button" class="group-detail-page__name-button" on:click={beginEditingName}>
+            <h1>{group.groupName}</h1>
+          </button>
+        {/if}
+
+        {#if isEditingDescription}
+          <div class="stack" style="--stack-space: var(--space-1)">
+            <textarea
+              bind:this={groupDescriptionInput}
+              bind:value={groupDescriptionDraft}
+              class="group-detail-page__description-input"
+              aria-label="Group description"
+              rows="3"
+              disabled={groupSavePending}
+              on:blur={() => void saveGroupMetadata('description')}
+            ></textarea>
+            {#if groupDescriptionError}
+              <p class="group-detail-page__error" role="alert">{groupDescriptionError}</p>
+            {/if}
+          </div>
+        {:else}
+          <button type="button" class="group-detail-page__description-button" on:click={beginEditingDescription}>
+            <p class:group-detail-page__description--placeholder={!group.description} class="group-detail-page__description">
+              {group.description ?? 'Add a description...'}
+            </p>
+          </button>
+        {/if}
+
+        <p class="group-detail-page__count">
+          {group.activeCardCount} {group.activeCardCount === 1 ? 'card' : 'cards'}
+        </p>
+      </div>
+
+      <div class="group-detail-page__header-actions cluster">
+        <button type="button" class="group-detail-page__header-button group-detail-page__header-button--danger" on:click={() => {
+          deleteDialogOpen = true;
+        }}>
+          Delete Group
+        </button>
+      </div>
+    </div>
   </header>
 
-  {#if cards.items.length === 0}
-    <section class="group-detail-page__state stack" style="--stack-space: var(--space-2)">
+  <div class="group-detail-page__toolbar">
+    <CardListFilterBar
+      bind:searchQuery
+      bind:selectedType
+      availableGroups={[]}
+      availableTypes={cardLibraryTypeOptions}
+      searchLabel="Search cards"
+      searchPlaceholder="Search cards..."
+      typeFilterLabel={typeFilterLabel}
+      clearTypeLabel="All types"
+      showGroupFilter={false}
+    />
+
+    <button type="button" class="group-detail-page__toolbar-button" on:click={openAddCardsDrawer}>
+      + Add Cards
+    </button>
+  </div>
+
+  {#if isSelectMode}
+    <div class="group-detail-page__bulk-actions">
+      <CardListBulkActionBar
+        selectedCount={selectedCardIds.length}
+        itemLabelSingular="card"
+        itemLabelPlural="cards"
+        primaryActionLabel="Assign to group"
+        primaryActionPendingLabel="Assigning..."
+        secondaryActionLabel="Delete"
+        secondaryActionPendingLabel="Deleting..."
+        tertiaryActionLabel="Remove from group"
+        tertiaryActionPendingLabel="Removing..."
+        disabled={pendingBulkAction !== null}
+        pendingAction={pendingBulkAction === 'assign-group'
+          ? 'primary'
+          : pendingBulkAction === 'delete'
+            ? 'secondary'
+            : pendingBulkAction === 'remove-from-group'
+              ? 'tertiary'
+              : null}
+        on:primary={() => {
+          if (sortedAssignableGroups.length === 0) {
+            actionFeedback = {
+              title: 'No other groups available',
+              message: 'Create another group first before assigning cards elsewhere.',
+            };
+            return;
+          }
+
+          bulkAssignOpen = true;
+          selectedBulkGroupId = sortedAssignableGroups[0]?.groupId ?? null;
+        }}
+        on:secondary={() => void applyBulkAction('delete')}
+        on:tertiary={() => void applyBulkAction('remove-from-group')}
+        on:clear={clearSelection}
+      />
+    </div>
+  {/if}
+
+  {#if actionFeedback}
+    <section class="group-detail-page__feedback" role="status" aria-live="polite">
+      <div class="stack" style="--stack-space: var(--space-1)">
+        <p class="group-detail-page__feedback-title">{actionFeedback.title}</p>
+        <p>{actionFeedback.message}</p>
+      </div>
+
+      <button type="button" class="group-detail-page__feedback-dismiss" on:click={dismissActionFeedback}>Dismiss</button>
+    </section>
+  {/if}
+
+  {#if cards.items.length === 0 && !hasActiveFilters}
+    <section class="group-detail-page__state">
       <div class="group-detail-page__state-icon" aria-hidden="true">📂</div>
       <h2>No cards in this group yet</h2>
-      <p>Add cards to this group from the library once they are active.</p>
+      <p>Add cards from the library to start building this group.</p>
+      <button type="button" class="group-detail-page__state-cta" on:click={openAddCardsDrawer}>+ Add Cards</button>
+    </section>
+  {:else if cards.items.length === 0}
+    <section class="group-detail-page__state">
+      <div class="group-detail-page__state-icon" aria-hidden="true">🔎</div>
+      <h2>No cards match your filters</h2>
+      <p>Try adjusting your search or clearing the active filters.</p>
+      <button type="button" class="group-detail-page__state-cta" on:click={clearFilters}>Clear filters</button>
     </section>
   {:else}
     <section class="group-detail-page__list stack" style="--stack-space: var(--space-3)">
-      <div class="group-detail-page__columns" aria-hidden="true">
-        <span>Card</span>
-        <span>Groups</span>
-        <span>Updated</span>
-      </div>
+      <CardListColumns labels={['Prompt / Content', 'Updated']} rowTemplate="1rem minmax(0, 2.4fr) auto" />
 
       {#each cards.items as item (item.cardId)}
-        <button type="button" class="group-detail-page__row" on:click={() => void openCard(item.cardId)}>
-          <div class="group-detail-page__content stack" style="--stack-space: var(--space-1)">
-            <div class="cluster group-detail-page__heading">
-              <CardListStatusBadge label="Active" tone="active" />
-              <h2>{item.content}</h2>
-            </div>
+        <CardListRow
+          selected={selectedCardIds.includes(item.cardId)}
+          checkboxLabel="Select card"
+          rowTemplate="1rem minmax(0, 2.4fr) auto"
+          clickable
+          showGroups={false}
+          hasActions={false}
+          mobileShowCheckbox={!isMobileViewport || isSelectMode}
+          on:toggleSelection={() => toggleSelection(item.cardId)}
+          on:activate={() => handleRowActivate(item.cardId)}
+          on:longpress={() => handleRowLongPress(item.cardId)}
+        >
+          <div slot="content" class="group-detail-row__content stack" style="--stack-space: var(--space-1)">
+            <h2>{item.content}</h2>
 
             {#if item.meaning}
-              <p class="group-detail-page__meaning">{item.meaning}</p>
+              <p class="group-detail-row__meaning">{item.meaning}</p>
             {/if}
+
+            <p class="group-detail-row__mobile-meta">{buildGroupDetailMobileMeta(item)}</p>
           </div>
 
-          <div class="group-detail-page__groups">
-            {#if item.groups.length === 0}
-              <span class="group-detail-page__empty-groups">No groups yet</span>
-            {:else}
-              {#each item.groups as group}
-                <CardListTagChip label={group.groupName} />
-              {/each}
-            {/if}
-          </div>
-
-          <span class="group-detail-page__updated">{item.updatedAtLabel}</span>
-        </button>
+          <span slot="updated" class="group-detail-row__updated">{item.updatedAtLabel}</span>
+        </CardListRow>
       {/each}
     </section>
   {/if}
 </section>
 
+{#if bulkAssignOpen}
+  <div class="group-detail-page__dialog-backdrop">
+    <section class="group-detail-page__dialog stack" style="--stack-space: var(--space-3)">
+      <h2>Assign {selectedCardIds.length} {selectedCardIds.length === 1 ? 'card' : 'cards'} to a group</h2>
+
+      <div class="stack" style="--stack-space: var(--space-2)">
+        {#each sortedAssignableGroups as assignableGroup}
+          <label class="group-detail-page__dialog-option">
+            <input type="radio" bind:group={selectedBulkGroupId} value={assignableGroup.groupId} />
+            <span>{assignableGroup.groupName}</span>
+          </label>
+        {/each}
+      </div>
+
+      <div class="group-detail-page__dialog-actions cluster">
+        <button
+          type="button"
+          class="group-detail-page__dialog-button"
+          on:click={() => {
+            bulkAssignOpen = false;
+            selectedBulkGroupId = null;
+          }}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="group-detail-page__dialog-button group-detail-page__dialog-button--primary"
+          disabled={!selectedBulkGroupId || pendingBulkAction !== null}
+          on:click={() => void applyBulkAction('assign-group', { groupId: selectedBulkGroupId ?? undefined })}
+        >
+          {pendingBulkAction === 'assign-group' ? 'Assigning...' : 'Assign cards'}
+        </button>
+      </div>
+    </section>
+  </div>
+{/if}
+
+{#if addCardsDrawerOpen}
+  <button
+    type="button"
+    class="group-detail-page__drawer-backdrop"
+    aria-label="Close add cards drawer"
+    on:click={closeAddCardsDrawer}
+  ></button>
+
+  <div
+    bind:this={addCardsDrawerElement}
+    class="group-detail-page__drawer stack"
+    style="--stack-space: var(--space-4)"
+    role="dialog"
+    tabindex="-1"
+    aria-modal="true"
+    aria-labelledby="group-detail-add-cards-title"
+    on:keydown={handleAddCardsDrawerKeydown}
+  >
+    <header class="group-detail-page__drawer-header cluster">
+      <h2 id="group-detail-add-cards-title">Add cards to {group.groupName}</h2>
+      <button type="button" class="group-detail-page__drawer-close" aria-label="Close drawer" on:click={closeAddCardsDrawer}>
+        ×
+      </button>
+    </header>
+
+    {#if addableCards.totalCount === 0 && group.activeCardCount === 0}
+      <section class="group-detail-page__drawer-state stack" style="--stack-space: var(--space-3)">
+        <h3>No cards to add.</h3>
+        <p>Create cards in Card Entry first.</p>
+        <a class="group-detail-page__state-cta" href={`/${currentLang}/card-entry`}>Go to Card Entry</a>
+      </section>
+    {:else if addableCards.totalCount === 0}
+      <section class="group-detail-page__drawer-state stack" style="--stack-space: var(--space-3)">
+        <h3>All your cards are already in this group.</h3>
+        <button type="button" class="group-detail-page__state-cta" on:click={closeAddCardsDrawer}>Close</button>
+      </section>
+    {:else}
+      <label class="group-detail-page__drawer-search stack" style="--stack-space: var(--space-2)">
+        <span class="group-detail-page__label">Search cards</span>
+        <input
+          bind:value={addCardsSearchQuery}
+          class="group-detail-page__drawer-search-input"
+          type="search"
+          placeholder="Search cards..."
+          autocomplete="off"
+        />
+      </label>
+
+      {#if filteredAddableCards.length === 0}
+        <section class="group-detail-page__drawer-state stack" style="--stack-space: var(--space-3)">
+          <h3>No cards match your search.</h3>
+          <p>Try a different prompt or meaning search.</p>
+        </section>
+      {:else}
+        <section class="group-detail-page__drawer-list stack" style="--stack-space: var(--space-2)">
+          {#each filteredAddableCards as item (item.cardId)}
+            <label class="group-detail-page__drawer-row">
+              <input
+                type="checkbox"
+                checked={addCardsSelectedIds.includes(item.cardId)}
+                on:change={() => toggleAddCardSelection(item.cardId)}
+              />
+
+              <div class="group-detail-page__drawer-row-body stack" style="--stack-space: var(--space-1)">
+                <div class="group-detail-page__drawer-row-heading cluster">
+                  <strong>{item.content}</strong>
+                  <span class="group-detail-page__drawer-row-updated">{item.updatedAtLabel}</span>
+                </div>
+
+                {#if item.meaning}
+                  <p>{item.meaning}</p>
+                {/if}
+
+                <div class="group-detail-page__drawer-row-groups">
+                  {#if item.groups.length === 0}
+                    <span class="group-detail-page__drawer-row-empty">No groups yet</span>
+                  {:else}
+                    {#each item.groups.slice(0, 2) as itemGroup}
+                      <CardListTagChip label={itemGroup.groupName} />
+                    {/each}
+                    {#if item.groups.length > 2}
+                      <span class="group-detail-page__drawer-row-empty">+{item.groups.length - 2} more</span>
+                    {/if}
+                  {/if}
+                </div>
+              </div>
+            </label>
+          {/each}
+        </section>
+      {/if}
+
+      <footer class="group-detail-page__drawer-footer">
+        <button
+          type="button"
+          class="group-detail-page__drawer-submit"
+          disabled={addCardsSelectedIds.length === 0 || addCardsPending}
+          on:click={addSelectedCardsToGroup}
+        >
+          {#if addCardsPending}
+            Adding...
+          {:else if addCardsSelectedIds.length === 0}
+            Add cards
+          {:else}
+            Add {addCardsSelectedIds.length} {addCardsSelectedIds.length === 1 ? 'card' : 'cards'}
+          {/if}
+        </button>
+      </footer>
+    {/if}
+  </div>
+{/if}
+
+{#if deleteDialogOpen}
+  <div class="group-detail-page__dialog-backdrop">
+    <section class="group-detail-page__dialog stack" style="--stack-space: var(--space-3)" role="alertdialog" aria-modal="true">
+      <h2>Delete "{group.groupName}"?</h2>
+      <p>{buildDeleteGroupMessage(group)}</p>
+      <div class="group-detail-page__dialog-actions cluster">
+        <button type="button" class="group-detail-page__dialog-button" disabled={deleteGroupPending} on:click={() => {
+          deleteDialogOpen = false;
+        }}>
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="group-detail-page__dialog-button group-detail-page__dialog-button--danger"
+          disabled={deleteGroupPending}
+          on:click={confirmDeleteGroup}
+        >
+          {deleteGroupPending ? 'Deleting...' : 'Delete Group'}
+        </button>
+      </div>
+    </section>
+  </div>
+{/if}
+
 {#if selectedCard && selectedIndex >= 0}
   <ActiveCardDrawer
-    lang={$page.params.lang ?? ''}
+    lang={currentLang}
     card={selectedCard}
     availableGroups={selectedCardAvailableGroups}
     selectedIndex={selectedIndex}
@@ -194,96 +1070,290 @@
 
 <style>
   .group-detail-page {
-    padding: calc(var(--shell-header-height) + var(--space-5)) var(--space-4) var(--space-7);
+    padding: calc(var(--shell-header-height) + var(--space-5)) var(--space-4) calc(var(--space-7) + 4.5rem);
   }
 
-  .group-detail-page__eyebrow,
+  .group-detail-page__header-main,
+  .group-detail-page__header-actions,
+  .group-detail-page__dialog-actions,
+  .group-detail-page__drawer-header,
+  .group-detail-page__drawer-row-heading {
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  .group-detail-page__toolbar {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: var(--space-3);
+    align-items: end;
+  }
+
+  .group-detail-page__back-link,
   .group-detail-page__count,
-  .group-detail-page__meaning,
-  .group-detail-page__updated,
-  .group-detail-page__empty-groups {
+  .group-detail-page__feedback-title,
+  .group-detail-row__meaning,
+  .group-detail-row__updated,
+  .group-detail-page__description,
+  .group-detail-page__drawer-row-empty,
+  .group-detail-page__drawer-row-updated {
     color: var(--color-text-secondary);
     font-family: var(--font-ui);
   }
 
-  .group-detail-page__eyebrow {
-    margin: 0;
-    font-size: var(--font-size-caption);
-    letter-spacing: var(--tracking-caps);
-    text-transform: uppercase;
-  }
-
   .group-detail-page h1,
   .group-detail-page h2,
+  .group-detail-page h3,
   .group-detail-page p {
     margin: 0;
   }
 
-  .group-detail-page__state {
+  .group-detail-page__back-link {
+    text-decoration: none;
+  }
+
+  .group-detail-page__name-button,
+  .group-detail-page__description-button {
+    display: block;
+    inline-size: fit-content;
+    padding: 0;
+    border: 0;
+    background: none;
+    color: inherit;
+    text-align: start;
+    cursor: pointer;
+  }
+
+  .group-detail-page__description-button {
+    inline-size: 100%;
+  }
+
+  .group-detail-page__description--placeholder {
+    color: var(--color-text-muted);
+  }
+
+  .group-detail-page__name-input,
+  .group-detail-page__description-input,
+  .group-detail-page__drawer-search-input {
+    inline-size: 100%;
+    min-block-size: 2.75rem;
+    padding: 0.7rem 0.95rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text-primary);
+    font-family: inherit;
+  }
+
+  .group-detail-page__description-input {
+    resize: vertical;
+  }
+
+  .group-detail-page__error {
+    color: var(--color-danger-text);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+  }
+
+  .group-detail-page__header-button,
+  .group-detail-page__toolbar-button,
+  .group-detail-page__state-cta,
+  .group-detail-page__dialog-button,
+  .group-detail-page__drawer-submit {
+    display: inline-flex;
     align-items: center;
-    justify-items: center;
-    padding: var(--space-6);
-    border: 1px dashed var(--color-border);
+    justify-content: center;
+    min-block-size: 2.75rem;
+    padding-inline: var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text-primary);
+    font-family: var(--font-ui);
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  .group-detail-page__toolbar-button,
+  .group-detail-page__drawer-submit,
+  .group-detail-page__dialog-button--primary {
+    border-color: var(--color-primary);
+    background: var(--color-primary);
+    color: var(--color-text-inverse);
+  }
+
+  .group-detail-page__header-button--danger,
+  .group-detail-page__dialog-button--danger {
+    color: var(--color-danger-text);
+    border-color: color-mix(in srgb, var(--color-danger-border) 60%, var(--color-border));
+    background: color-mix(in srgb, var(--color-danger-text) 10%, var(--color-surface));
+  }
+
+  .group-detail-page__bulk-actions {
+    position: sticky;
+    inset-block-start: calc(var(--shell-header-height) + var(--space-3));
+    z-index: 1;
+  }
+
+  .group-detail-page__feedback,
+  .group-detail-page__state,
+  .group-detail-page__dialog,
+  .group-detail-page__drawer-state {
+    border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
     background: var(--color-surface);
+  }
+
+  .group-detail-page__feedback {
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+    gap: var(--space-4);
+    padding: var(--space-3) var(--space-4);
+    border-color: color-mix(in srgb, var(--color-error-border) 65%, var(--color-border));
+    background: color-mix(in srgb, var(--color-error-bg) 18%, var(--color-surface));
+  }
+
+  .group-detail-page__feedback-title {
+    color: var(--color-error-text);
+    font-size: var(--font-size-small);
+    font-weight: 600;
+  }
+
+  .group-detail-page__feedback-dismiss {
+    padding: 0;
+    border: 0;
+    background: none;
+    color: var(--color-text-secondary);
+    text-decoration: underline;
+    cursor: pointer;
+    font-family: var(--font-ui);
+  }
+
+  .group-detail-page__state,
+  .group-detail-page__drawer-state {
+    padding: var(--space-5);
     text-align: center;
   }
 
   .group-detail-page__state-icon {
+    margin-block-end: var(--space-3);
     font-size: 2rem;
   }
 
-  .group-detail-page__columns {
+  .group-detail-row__content {
+    min-inline-size: 0;
+  }
+
+  .group-detail-row__mobile-meta {
+    display: none;
+  }
+
+  .group-detail-page__dialog-backdrop,
+  .group-detail-page__drawer-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 52;
+    background: color-mix(in srgb, var(--neutral-900) 22%, transparent);
+  }
+
+  .group-detail-page__dialog-backdrop {
     display: grid;
-    grid-template-columns: minmax(0, 2fr) minmax(10rem, 1fr) auto;
-    gap: var(--space-3);
-    padding: 0 var(--space-4) var(--space-2);
-    color: var(--color-text-muted);
+    place-items: center;
+    padding: var(--space-4);
+  }
+
+  .group-detail-page__dialog {
+    inline-size: min(100%, 28rem);
+    padding: var(--space-5);
+  }
+
+  .group-detail-page__drawer {
+    position: fixed;
+    inset-block: 0;
+    inset-inline-end: 0;
+    z-index: 53;
+    inline-size: min(34rem, 100vw);
+    padding: var(--space-4);
+    border-inline-start: 1px solid var(--color-border);
+    background: var(--color-surface-raised);
+    box-shadow: var(--shadow-lg);
+  }
+
+  .group-detail-page__drawer-header,
+  .group-detail-page__drawer-footer {
+    position: sticky;
+    background: var(--color-surface-raised);
+  }
+
+  .group-detail-page__drawer-header {
+    inset-block-start: 0;
+    padding-block-end: var(--space-2);
+    border-block-end: 1px solid var(--color-border);
+  }
+
+  .group-detail-page__drawer-footer {
+    inset-block-end: 0;
+    padding-block-start: var(--space-2);
+    border-block-start: 1px solid var(--color-border);
+  }
+
+  .group-detail-page__drawer-close {
+    border: 0;
+    background: none;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-h4);
+    cursor: pointer;
+  }
+
+  .group-detail-page__label {
+    color: var(--color-text-secondary);
     font-family: var(--font-ui);
     font-size: var(--font-size-caption);
     letter-spacing: var(--tracking-caps);
     text-transform: uppercase;
   }
 
-  .group-detail-page__row {
+  .group-detail-page__drawer-list {
+    overflow: auto;
+  }
+
+  .group-detail-page__drawer-row {
     display: grid;
-    grid-template-columns: minmax(0, 2fr) minmax(10rem, 1fr) auto;
+    grid-template-columns: auto minmax(0, 1fr);
     gap: var(--space-3);
-    align-items: start;
-    inline-size: 100%;
-    padding: var(--space-4);
+    padding: var(--space-3);
     border: 1px solid var(--color-border-subtle);
     border-radius: var(--radius-lg);
     background: var(--color-surface);
-    color: inherit;
-    text-align: start;
-    transition:
-      border-color var(--duration-fast) var(--ease-standard),
-      background var(--duration-fast) var(--ease-standard);
+    cursor: pointer;
   }
 
-  .group-detail-page__row:hover,
-  .group-detail-page__row:focus-visible {
-    border-color: var(--color-border);
-    background: color-mix(in srgb, var(--color-surface-raised) 45%, var(--color-surface));
+  .group-detail-page__drawer-row input {
+    margin-block-start: 0.2rem;
   }
 
-  .group-detail-page__heading {
-    align-items: center;
-    gap: var(--space-2);
-  }
-
-  .group-detail-page__heading h2 {
-    font-size: var(--font-size-h4);
-  }
-
-  .group-detail-page__groups {
+  .group-detail-page__drawer-row-groups {
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-2);
   }
 
-  .group-detail-page__row:focus-visible {
+  .group-detail-page__header-button:focus-visible,
+  .group-detail-page__toolbar-button:focus-visible,
+  .group-detail-page__state-cta:focus-visible,
+  .group-detail-page__dialog-button:focus-visible,
+  .group-detail-page__drawer-submit:focus-visible,
+  .group-detail-page__feedback-dismiss:focus-visible,
+  .group-detail-page__name-button:focus-visible,
+  .group-detail-page__description-button:focus-visible,
+  .group-detail-page__name-input:focus-visible,
+  .group-detail-page__description-input:focus-visible,
+  .group-detail-page__drawer-search-input:focus-visible,
+  .group-detail-page__drawer-close:focus-visible,
+  .group-detail-page__back-link:focus-visible {
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
   }
@@ -293,12 +1363,32 @@
       padding-inline: var(--space-3);
     }
 
-    .group-detail-page__columns {
+    .group-detail-page__header-main,
+    .group-detail-page__toolbar {
+      grid-template-columns: 1fr;
+    }
+
+    .group-detail-page__header-main,
+    .group-detail-page__header-actions {
+      flex-direction: column;
+    }
+
+    .group-detail-page__toolbar-button {
+      inline-size: 100%;
+    }
+
+    .group-detail-row__mobile-meta {
+      display: block;
+    }
+
+    .group-detail-row__updated {
       display: none;
     }
 
-    .group-detail-page__row {
-      grid-template-columns: 1fr;
+    .group-detail-page__drawer {
+      inline-size: 100vw;
+      border-inline-start: 0;
+      padding-block-end: calc(var(--space-5) + env(safe-area-inset-bottom));
     }
   }
 </style>

--- a/apps/web/src/routes/[lang]/cards/groups/[groupId]/actions/+server.ts
+++ b/apps/web/src/routes/[lang]/cards/groups/[groupId]/actions/+server.ts
@@ -1,0 +1,107 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { withTransactionDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import {
+  addCardsToGroupDetailForLanguage,
+  CardLibraryRequestError,
+  deleteCardLibraryGroupForLanguage,
+  removeCardsFromGroupDetailForLanguage,
+  updateGroupDetailForLanguage,
+} from '$lib/server/cards.js';
+
+type GroupDetailActionRequestBody =
+  | {
+      action?: 'update-group';
+      groupName?: string;
+      description?: string | null;
+    }
+  | {
+      action?: 'add-cards' | 'remove-cards';
+      cardIds?: string[];
+    }
+  | {
+      action?: 'delete-group';
+    };
+
+export const POST: RequestHandler = async (event) => {
+  const session = await event.locals.auth();
+  const userId = session?.user?.id;
+  const languageId = event.params.lang;
+  const groupId = event.params.groupId;
+
+  if (!userId || !languageId || !groupId) {
+    return json({ message: 'You must be signed in to update this group.' }, { status: 401 });
+  }
+
+  if (!env.DATABASE_URL) {
+    return json({ message: 'The group service is not configured right now.' }, { status: 500 });
+  }
+
+  let body: GroupDetailActionRequestBody;
+
+  try {
+    body = (await event.request.json()) as GroupDetailActionRequestBody;
+  } catch {
+    return json({ message: 'The group action payload must be valid JSON.' }, { status: 400 });
+  }
+
+  try {
+    const result = await withTransactionDb(env.DATABASE_URL, async (database) => {
+      if (body.action === 'update-group') {
+        return {
+          group: await updateGroupDetailForLanguage(
+            userId,
+            languageId,
+            groupId,
+            {
+              groupName: body.groupName,
+              description: body.description,
+            },
+            database as never,
+          ),
+        };
+      }
+
+      if (body.action === 'add-cards') {
+        return {
+          addedCardIds: await addCardsToGroupDetailForLanguage(
+            userId,
+            languageId,
+            groupId,
+            body.cardIds,
+            database as never,
+          ),
+        };
+      }
+
+      if (body.action === 'remove-cards') {
+        return {
+          removedCardIds: await removeCardsFromGroupDetailForLanguage(
+            userId,
+            languageId,
+            groupId,
+            body.cardIds,
+            database as never,
+          ),
+        };
+      }
+
+      if (body.action === 'delete-group') {
+        return {
+          deleted: await deleteCardLibraryGroupForLanguage(userId, languageId, groupId, database as never),
+        };
+      }
+
+      throw new CardLibraryRequestError(400, 'A valid group action is required.');
+    });
+
+    return json(result);
+  } catch (requestError) {
+    if (requestError instanceof CardLibraryRequestError) {
+      return json({ message: requestError.message }, { status: requestError.status });
+    }
+
+    console.error('Failed to apply Group Detail action:', requestError);
+    return json({ message: 'The group action could not be completed right now.' }, { status: 500 });
+  }
+};


### PR DESCRIPTION
## Summary
- build the full Group Detail surface with inline group metadata editing, scoped search/type filtering, and shared card drawer navigation
- add the group-detail actions route plus server helpers for metadata updates, add-cards flow, remove-from-group, and same-page delete handling
- extend the shared card-list primitives just enough for group-specific bulk actions and scoped row layouts, and add helper/server coverage for the new workflows

## Testing
- pnpm turbo test lint build --filter=web
- pnpm test:db:branch:secure

Closes #143
