### PR TITLE
Stabilize settings language-format e2e assertion

### DIFF
--- a/apps/web/tests/e2e/shell-and-settings.spec.ts
+++ b/apps/web/tests/e2e/shell-and-settings.spec.ts
@@ -90,11 +90,10 @@ test('saves a language-specific Card Entry example sentence format', async ({ pa
 	}).click();
 	await chineseCard.getByRole('button', { name: 'Save Example Format', exact: true }).click();
 
-	await expect(
-		chineseCard.getByText(
-			'Chinese (Mandarin) Card Entry examples will now use sentence + transliteration + translation.'
-		)
-	).toBeVisible();
+	await expect(chineseCard).toContainText(
+		'Chinese (Mandarin) Card Entry examples will now use sentence + transliteration + translation.',
+		{ timeout: 10000 }
+	);
 
 	await page.reload();
 


### PR DESCRIPTION
## Summary
- stabilize the settings Playwright assertion that failed on the main-branch merge run
- assert on the whole language card text with a longer timeout instead of an exact nested text-node visibility match

## Testing
- pnpm turbo test lint build --filter=web
- pnpm test:e2e:secure
