### PR TITLE
Add Card Library chat context plumbing

### DIFF
--- a/apps/web/src/lib/chat.ts
+++ b/apps/web/src/lib/chat.ts
@@ -1,4 +1,11 @@
 import { z } from 'zod';
+import {
+  activeCardIdSchema,
+  activeCardTypeSchema,
+  activeGroupIdSchema,
+  cardLibraryFiltersSchema,
+  cardLibrarySearchSchema,
+} from '$lib/schemas/cards.js';
 
 export const CHAT_SUGGESTION_TYPES = ['append_example_sentence'] as const;
 
@@ -9,7 +16,44 @@ export const conversationHistoryTurnSchema = z.object({
   content: z.string().trim().min(1).max(2_000),
 });
 
+const selectedChatCardIdsSchema = z.array(activeCardIdSchema).max(100).default([]);
+
+export const cardLibraryListSurfaceContextSchema = z.object({
+  surface: z.literal('card_library_list'),
+  filters: cardLibraryFiltersSchema,
+  selectedCardIds: selectedChatCardIdsSchema,
+});
+
+export const groupsListSurfaceContextSchema = z.object({
+  surface: z.literal('groups_list'),
+});
+
+export const groupDetailSurfaceContextSchema = z.object({
+  surface: z.literal('group_detail'),
+  groupId: activeGroupIdSchema,
+  filters: z.object({
+    searchText: cardLibrarySearchSchema.default(''),
+    cardType: activeCardTypeSchema.nullable(),
+  }),
+  selectedCardIds: selectedChatCardIdsSchema,
+});
+
+export const addCardsToGroupDrawerSurfaceContextSchema = z.object({
+  surface: z.literal('add_cards_to_group_drawer'),
+  groupId: activeGroupIdSchema,
+  searchText: cardLibrarySearchSchema.default(''),
+  selectedCardIds: selectedChatCardIdsSchema,
+});
+
+export const chatSurfaceContextSchema = z.discriminatedUnion('surface', [
+  cardLibraryListSurfaceContextSchema,
+  groupsListSurfaceContextSchema,
+  groupDetailSurfaceContextSchema,
+  addCardsToGroupDrawerSurfaceContextSchema,
+]);
+
 export type ConversationHistoryTurn = z.infer<typeof conversationHistoryTurnSchema>;
+export type ChatSurfaceContext = z.infer<typeof chatSurfaceContextSchema>;
 
 export const chatRequestSchema = z.object({
   input: z.string().trim().min(1, 'A chat message is required.').max(2_000),
@@ -18,6 +62,7 @@ export const chatRequestSchema = z.object({
   noteId: z.string().trim().min(1).max(128).optional(),
   cardId: z.string().trim().min(1).max(128).optional(),
   focusedField: z.string().trim().min(1).max(64).optional(),
+  surfaceContext: chatSurfaceContextSchema.optional(),
   conversationHistory: z.array(conversationHistoryTurnSchema).max(PROMPT_HISTORY_CAP).optional(),
 });
 

--- a/apps/web/src/lib/command-bar/shared.ts
+++ b/apps/web/src/lib/command-bar/shared.ts
@@ -5,7 +5,9 @@ export type RouteContextType =
   | 'card-entry'
   | 'card-review'
   | 'translation-drills'
-  | 'cards'
+  | 'card_library_list'
+  | 'groups_list'
+  | 'group_detail'
   | 'settings'
   | 'stats';
 
@@ -104,6 +106,8 @@ export function defaultRouteContext(): RouteContext {
 export function resolveRouteContext(pathname: string): RouteContext {
   const segments = pathname.split('/').filter(Boolean);
   const section = segments[1];
+  const cardsSubsection = segments[2];
+  const groupId = segments[3];
 
   if (!section) {
     return {
@@ -127,7 +131,15 @@ export function resolveRouteContext(pathname: string): RouteContext {
         pathname,
       };
     case 'cards':
-      return { commandContext: 'global', routeContextType: 'cards', label: 'Cards', pathname };
+      if (cardsSubsection === 'groups' && groupId) {
+        return { commandContext: 'global', routeContextType: 'group_detail', label: 'Group Detail', pathname };
+      }
+
+      if (cardsSubsection === 'groups') {
+        return { commandContext: 'global', routeContextType: 'groups_list', label: 'Groups', pathname };
+      }
+
+      return { commandContext: 'global', routeContextType: 'card_library_list', label: 'Cards', pathname };
     case 'settings':
       return { commandContext: 'global', routeContextType: 'settings', label: 'Settings', pathname };
     case 'stats':

--- a/apps/web/src/lib/components/CommandBar.dom.test.ts
+++ b/apps/web/src/lib/components/CommandBar.dom.test.ts
@@ -56,6 +56,7 @@ describe('CommandBar component behavior', () => {
     commandBar.setPathname('/zh/card-review');
     commandBar.setWorkspaceContext(null, null);
     commandBar.setTargetHint(null, null);
+    commandBar.setSurfaceContext(null);
     requestStructuredChatResponse.mockReset();
   });
 

--- a/apps/web/src/lib/components/CommandBar.svelte
+++ b/apps/web/src/lib/components/CommandBar.svelte
@@ -207,6 +207,7 @@
         noteId: effectiveNoteId,
         cardId: submissionState.activeCardId ?? undefined,
         focusedField: submissionState.activeFocusedField ?? undefined,
+        surfaceContext: submissionState.surfaceContextHint ?? undefined,
         conversationHistory: promptHistory.length > 0 ? promptHistory : undefined,
       });
 

--- a/apps/web/src/lib/server/ai-prompts/chat.test.ts
+++ b/apps/web/src/lib/server/ai-prompts/chat.test.ts
@@ -47,4 +47,50 @@ describe('buildStructuredChatPrompt', () => {
     expect(prompt.userPrompt).toContain('ask a clarifying question instead of guessing');
     expect(prompt.userPrompt).toContain('Use the exact cardId from the workspace data');
   });
+
+  it('includes card-library list state and snapshot data for card-library chat contexts', () => {
+    const canonicalContext: CanonicalChatContext = {
+      contextType: 'card_library_list',
+      languageId: 'zh',
+      allowedSuggestionTypes: [],
+      listState: {
+        searchText: 'train',
+        groupFilters: [{ groupId: 'group-1', groupName: 'Travel' }],
+        cardType: 'word',
+        ordering: 'updated_desc',
+      },
+      resultCount: 2,
+      selectedCardIds: ['card-2'],
+      selectedCards: [
+        {
+          cardId: 'card-2',
+          content: '飞机',
+          meaning: 'airplane',
+          cardType: 'word',
+          groupNames: ['Travel'],
+        },
+      ],
+      visibleCards: [
+        {
+          cardId: 'card-1',
+          content: '火车',
+          meaning: 'train',
+          cardType: 'word',
+          groupNames: ['Travel'],
+        },
+      ],
+    };
+
+    const prompt = buildStructuredChatPrompt({
+      canonicalContext,
+      userInput: 'What should I study first from this list?',
+      allowedSuggestionTypes: [],
+    });
+
+    expect(prompt.userPrompt).toContain('"contextType": "card_library_list"');
+    expect(prompt.userPrompt).toContain('"searchText": "train"');
+    expect(prompt.userPrompt).toContain('"groupName": "Travel"');
+    expect(prompt.userPrompt).toContain('"selectedCardIds": [');
+    expect(prompt.userPrompt).toContain('"content": "火车"');
+  });
 });

--- a/apps/web/src/lib/server/ai-prompts/chat.ts
+++ b/apps/web/src/lib/server/ai-prompts/chat.ts
@@ -44,22 +44,10 @@ function buildCardEntryNoteWorkspaceContextBlock(context: CardEntryNoteWorkspace
   ].join('\n');
 }
 
-function buildNonActionableContextBlock(
-  context: Extract<CanonicalChatContext, { contextType: 'non_actionable' }>,
+function buildGenericContextBlock(
+  context: Exclude<CanonicalChatContext, { contextType: 'card_entry_note_workspace' }>,
 ): string {
-  return [
-    'Machine context:',
-    JSON.stringify(
-      {
-        contextType: context.contextType,
-        routeContextType: context.routeContextType,
-        languageId: context.languageId,
-        allowedSuggestionTypes: context.allowedSuggestionTypes,
-      },
-      null,
-      2,
-    ),
-  ].join('\n');
+  return ['Machine context:', JSON.stringify(context, null, 2)].join('\n');
 }
 
 function buildConversationHistoryBlock(history: ConversationHistoryTurn[]): string {
@@ -83,7 +71,7 @@ export function buildStructuredChatPrompt(input: {
   const contextBlock =
     input.canonicalContext.contextType === 'card_entry_note_workspace'
       ? buildCardEntryNoteWorkspaceContextBlock(input.canonicalContext)
-      : buildNonActionableContextBlock(input.canonicalContext);
+      : buildGenericContextBlock(input.canonicalContext);
 
   const historyBlock = buildConversationHistoryBlock(input.conversationHistory ?? []);
 

--- a/apps/web/src/lib/server/chat-context.test.ts
+++ b/apps/web/src/lib/server/chat-context.test.ts
@@ -1,8 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { resolveRouteContext } from '$lib/command-bar/shared.js';
-import { resolveCanonicalChatContext, getAllowedSuggestionTypes } from './chat-context.js';
-
-// ── Tests: non-actionable context ─────────────────────────────────────────────
+import { getAllowedSuggestionTypes, resolveCanonicalChatContext } from './chat-context.js';
 
 describe('resolveCanonicalChatContext', () => {
   it('returns a non-actionable context when no database is provided', async () => {
@@ -21,37 +19,6 @@ describe('resolveCanonicalChatContext', () => {
     expect(context.allowedSuggestionTypes).toEqual([]);
   });
 
-  it('returns a non-actionable context when card-entry has no database', async () => {
-    const context = await resolveCanonicalChatContext(
-      'user-1',
-      {
-        routeContext: resolveRouteContext('/es/card-entry'),
-        languageId: 'es',
-        noteId: 'note-1',
-      },
-      null,
-    );
-
-    expect(context.contextType).toBe('non_actionable');
-    expect(getAllowedSuggestionTypes(context)).toEqual([]);
-  });
-
-  it('returns a non-actionable context for cards, stats, and workspace routes', async () => {
-    for (const pathname of ['/es/cards', '/es/stats', '/es']) {
-      const context = await resolveCanonicalChatContext(
-        'user-1',
-        {
-          routeContext: resolveRouteContext(pathname),
-          languageId: 'es',
-        },
-        null,
-      );
-
-      expect(context.contextType).toBe('non_actionable');
-      expect(context.allowedSuggestionTypes).toEqual([]);
-    }
-  });
-
   it('includes the languageId and routeContextType in non-actionable context', async () => {
     const context = await resolveCanonicalChatContext(
       'user-1',
@@ -68,17 +35,8 @@ describe('resolveCanonicalChatContext', () => {
       expect(context.routeContextType).toBe('translation-drills');
     }
   });
-});
 
-// ── Tests: Card Entry note workspace context (database path) ─────────────────
-
-describe('resolveCanonicalChatContext — Card Entry note workspace', () => {
   it('attempts a DB call when note workspace hints + database are provided', async () => {
-    // Pass an empty object as a fake database — the resolver will call
-    // getNoteWithDraftCards which uses the db as a Drizzle query builder.
-    // The empty object will cause a runtime error inside the DB query,
-    // confirming that the Card Entry note-workspace code path was entered rather than
-    // the non-actionable fallback.
     const fakeDb = {} as Parameters<typeof resolveCanonicalChatContext>[2];
 
     await expect(
@@ -91,19 +49,311 @@ describe('resolveCanonicalChatContext — Card Entry note workspace', () => {
         },
         fakeDb,
       ),
-    ).rejects.toThrow(); // Confirms the DB-loading path was taken, not the fallback
+    ).rejects.toThrow();
   });
-});
 
-describe('getAllowedSuggestionTypes', () => {
-  it('returns empty array for non-actionable context', async () => {
+  it('resolves card-library list context with canonical list-state data', async () => {
     const context = await resolveCanonicalChatContext(
       'user-1',
       {
         routeContext: resolveRouteContext('/es/cards'),
         languageId: 'es',
+        surfaceContext: {
+          surface: 'card_library_list',
+          filters: {
+            searchText: 'tra',
+            groupIds: ['group-1'],
+            cardType: 'word',
+          },
+          selectedCardIds: ['card-2'],
+        },
       },
-      null,
+      {} as Parameters<typeof resolveCanonicalChatContext>[2],
+      {
+        loadCardLibraryData: vi.fn().mockResolvedValue({
+          items: [
+            {
+              cardId: 'card-1',
+              content: 'tren',
+              meaning: 'train',
+              cardType: 'word',
+              updatedAtIso: null,
+              updatedAtLabel: '1d',
+              groups: [{ groupId: 'group-1', groupName: 'Travel' }],
+            },
+            {
+              cardId: 'card-2',
+              content: 'avion',
+              meaning: 'airplane',
+              cardType: 'word',
+              updatedAtIso: null,
+              updatedAtLabel: '2d',
+              groups: [{ groupId: 'group-1', groupName: 'Travel' }],
+            },
+          ],
+          totalCount: 2,
+          filteredCardIds: ['card-1', 'card-2'],
+          filters: {
+            searchText: 'tra',
+            groupIds: ['group-1'],
+            cardType: 'word',
+          },
+          availableGroups: [
+            { groupId: 'group-1', groupName: 'Travel', activeCardCount: 2 },
+            { groupId: 'group-2', groupName: 'Food', activeCardCount: 1 },
+          ],
+        }),
+        loadCardLibraryGroupsData: vi.fn(),
+        loadGroupDetailData: vi.fn(),
+      },
+    );
+
+    expect(context).toMatchObject({
+      contextType: 'card_library_list',
+      languageId: 'es',
+      listState: {
+        searchText: 'tra',
+        groupFilters: [{ groupId: 'group-1', groupName: 'Travel' }],
+        cardType: 'word',
+        ordering: 'updated_desc',
+      },
+      resultCount: 2,
+      selectedCardIds: ['card-2'],
+      selectedCards: [{ cardId: 'card-2', content: 'avion' }],
+    });
+    if (context.contextType === 'card_library_list') {
+      expect(context.visibleCards[0]).toMatchObject({ cardId: 'card-1', content: 'tren' });
+    }
+  });
+
+  it('resolves groups-list context with visible group snapshots', async () => {
+    const context = await resolveCanonicalChatContext(
+      'user-1',
+      {
+        routeContext: resolveRouteContext('/es/cards/groups'),
+        languageId: 'es',
+        surfaceContext: {
+          surface: 'groups_list',
+        },
+      },
+      {} as Parameters<typeof resolveCanonicalChatContext>[2],
+      {
+        loadCardLibraryData: vi.fn(),
+        loadCardLibraryGroupsData: vi.fn().mockResolvedValue({
+          items: [
+            {
+              groupId: 'group-1',
+              groupName: 'Travel',
+              description: 'Trips and transit',
+              activeCardCount: 4,
+            },
+          ],
+          totalCount: 1,
+        }),
+        loadGroupDetailData: vi.fn(),
+      },
+    );
+
+    expect(context).toMatchObject({
+      contextType: 'groups_list',
+      languageId: 'es',
+      listState: {
+        scope: 'all_groups_for_language',
+        ordering: 'group_name_asc',
+      },
+      resultCount: 1,
+      visibleGroups: [{ groupId: 'group-1', groupName: 'Travel' }],
+    });
+  });
+
+  it('resolves group-detail context with scoped filters and selection snapshots', async () => {
+    const context = await resolveCanonicalChatContext(
+      'user-1',
+      {
+        routeContext: resolveRouteContext('/es/cards/groups/group-1'),
+        languageId: 'es',
+        surfaceContext: {
+          surface: 'group_detail',
+          groupId: 'group-1',
+          filters: {
+            searchText: 'hol',
+            cardType: 'word',
+          },
+          selectedCardIds: ['card-1'],
+        },
+      },
+      {} as Parameters<typeof resolveCanonicalChatContext>[2],
+      {
+        loadCardLibraryData: vi.fn(),
+        loadCardLibraryGroupsData: vi.fn(),
+        loadGroupDetailData: vi.fn().mockResolvedValue({
+          group: {
+            groupId: 'group-1',
+            groupName: 'Greetings',
+            description: 'Hello and goodbye',
+            activeCardCount: 1,
+          },
+          cards: {
+            items: [
+              {
+                cardId: 'card-1',
+                content: 'hola',
+                meaning: 'hello',
+                cardType: 'word',
+                updatedAtIso: null,
+                updatedAtLabel: '1d',
+                groups: [{ groupId: 'group-1', groupName: 'Greetings' }],
+              },
+            ],
+            totalCount: 1,
+            filteredCardIds: ['card-1'],
+            filters: {
+              searchText: 'hol',
+              groupIds: [],
+              cardType: 'word',
+            },
+            availableGroups: [],
+          },
+          addableCards: {
+            items: [],
+            totalCount: 0,
+          },
+        }),
+      },
+    );
+
+    expect(context).toMatchObject({
+      contextType: 'group_detail',
+      languageId: 'es',
+      group: {
+        groupId: 'group-1',
+        groupName: 'Greetings',
+      },
+      listState: {
+        searchText: 'hol',
+        cardType: 'word',
+        scopeGroupId: 'group-1',
+      },
+      selectedCardIds: ['card-1'],
+      selectedCards: [{ cardId: 'card-1', content: 'hola' }],
+    });
+  });
+
+  it('resolves add-cards drawer context with candidate filtering and selected snapshots', async () => {
+    const context = await resolveCanonicalChatContext(
+      'user-1',
+      {
+        routeContext: resolveRouteContext('/es/cards/groups/group-1'),
+        languageId: 'es',
+        surfaceContext: {
+          surface: 'add_cards_to_group_drawer',
+          groupId: 'group-1',
+          searchText: 'ad',
+          selectedCardIds: ['card-2'],
+        },
+      },
+      {} as Parameters<typeof resolveCanonicalChatContext>[2],
+      {
+        loadCardLibraryData: vi.fn(),
+        loadCardLibraryGroupsData: vi.fn(),
+        loadGroupDetailData: vi.fn().mockResolvedValue({
+          group: {
+            groupId: 'group-1',
+            groupName: 'Greetings',
+            description: 'Hello and goodbye',
+            activeCardCount: 1,
+          },
+          cards: {
+            items: [],
+            totalCount: 0,
+            filteredCardIds: [],
+            filters: {
+              searchText: '',
+              groupIds: [],
+              cardType: null,
+            },
+            availableGroups: [],
+          },
+          addableCards: {
+            items: [
+              {
+                cardId: 'card-2',
+                content: 'adios',
+                meaning: 'goodbye',
+                cardType: 'word',
+                updatedAtIso: null,
+                updatedAtLabel: '1d',
+                groups: [],
+              },
+              {
+                cardId: 'card-3',
+                content: 'gracias',
+                meaning: 'thanks',
+                cardType: 'word',
+                updatedAtIso: null,
+                updatedAtLabel: '1d',
+                groups: [],
+              },
+            ],
+            totalCount: 2,
+          },
+        }),
+      },
+    );
+
+    expect(context).toMatchObject({
+      contextType: 'add_cards_to_group_drawer',
+      languageId: 'es',
+      group: {
+        groupId: 'group-1',
+        groupName: 'Greetings',
+      },
+      listState: {
+        searchText: 'ad',
+        excludedGroupId: 'group-1',
+        scope: 'active_language_cards_not_in_target_group',
+      },
+      candidateCount: 1,
+      selectedCardIds: ['card-2'],
+      selectedCards: [{ cardId: 'card-2', content: 'adios' }],
+      visibleCards: [{ cardId: 'card-2', content: 'adios' }],
+    });
+  });
+});
+
+describe('getAllowedSuggestionTypes', () => {
+  it('returns empty array for card-library contexts', async () => {
+    const context = await resolveCanonicalChatContext(
+      'user-1',
+      {
+        routeContext: resolveRouteContext('/es/cards'),
+        languageId: 'es',
+        surfaceContext: {
+          surface: 'card_library_list',
+          filters: {
+            searchText: '',
+            groupIds: [],
+            cardType: null,
+          },
+          selectedCardIds: [],
+        },
+      },
+      {} as Parameters<typeof resolveCanonicalChatContext>[2],
+      {
+        loadCardLibraryData: vi.fn().mockResolvedValue({
+          items: [],
+          totalCount: 0,
+          filteredCardIds: [],
+          filters: {
+            searchText: '',
+            groupIds: [],
+            cardType: null,
+          },
+          availableGroups: [],
+        }),
+        loadCardLibraryGroupsData: vi.fn(),
+        loadGroupDetailData: vi.fn(),
+      },
     );
 
     expect(getAllowedSuggestionTypes(context)).toEqual([]);

--- a/apps/web/src/lib/server/chat-context.ts
+++ b/apps/web/src/lib/server/chat-context.ts
@@ -4,11 +4,23 @@ import {
   readCardEntryExampleSentenceFormat,
   type CardEntryExampleSentenceFormat,
 } from '$lib/card-entry/example-sentence-format.js';
-import type { ChatSuggestionType } from '$lib/chat.js';
+import { filterAddableGroupCards } from '$lib/cards/group-detail.js';
+import type { ChatSuggestionType, ChatSurfaceContext } from '$lib/chat.js';
 import type { RouteContext } from '$lib/command-bar/shared.js';
 import { CardEntryRequestError } from '$lib/server/card-entry.js';
+import {
+  loadCardLibraryData,
+  loadCardLibraryGroupsData,
+  loadGroupDetailData,
+  type CardLibraryCardListItemData,
+  type CardLibraryGroupListItemData,
+  type CardLibraryGroupData,
+} from '$lib/server/cards.js';
 
 type DatabaseClient = NonNullable<Parameters<typeof getNoteWithDraftCards>[3]>;
+
+const CARD_SNAPSHOT_LIMIT = 12;
+const GROUP_SNAPSHOT_LIMIT = 12;
 
 // ── Canonical context types ──────────────────────────────────────────────────
 
@@ -34,6 +46,83 @@ export type CardEntryNoteWorkspaceContext = {
   draftCards: NoteWorkspaceDraftCardSummary[];
 };
 
+export type ChatCardSnapshot = {
+  cardId: string;
+  content: string;
+  meaning: string | null;
+  cardType: string | null;
+  groupNames: string[];
+};
+
+export type ChatGroupSnapshot = {
+  groupId: string;
+  groupName: string;
+  description: string | null;
+  activeCardCount: number;
+};
+
+export type CardLibraryListContext = {
+  contextType: 'card_library_list';
+  languageId: string;
+  allowedSuggestionTypes: readonly [];
+  listState: {
+    searchText: string;
+    groupFilters: CardLibraryGroupData[];
+    cardType: string | null;
+    ordering: 'updated_desc';
+  };
+  resultCount: number;
+  selectedCardIds: string[];
+  selectedCards: ChatCardSnapshot[];
+  visibleCards: ChatCardSnapshot[];
+};
+
+export type GroupsListContext = {
+  contextType: 'groups_list';
+  languageId: string;
+  allowedSuggestionTypes: readonly [];
+  listState: {
+    scope: 'all_groups_for_language';
+    ordering: 'group_name_asc';
+  };
+  resultCount: number;
+  visibleGroups: ChatGroupSnapshot[];
+};
+
+export type GroupDetailContext = {
+  contextType: 'group_detail';
+  languageId: string;
+  allowedSuggestionTypes: readonly [];
+  group: ChatGroupSnapshot;
+  listState: {
+    searchText: string;
+    cardType: string | null;
+    scopeGroupId: string;
+    ordering: 'updated_desc';
+  };
+  resultCount: number;
+  selectedCardIds: string[];
+  selectedCards: ChatCardSnapshot[];
+  visibleCards: ChatCardSnapshot[];
+};
+
+export type AddCardsToGroupDrawerContext = {
+  contextType: 'add_cards_to_group_drawer';
+  languageId: string;
+  allowedSuggestionTypes: readonly [];
+  group: ChatGroupSnapshot;
+  listState: {
+    searchText: string;
+    excludedGroupId: string;
+    scope: 'active_language_cards_not_in_target_group';
+    ordering: 'updated_desc';
+  };
+  candidateCount: number;
+  selectedCardIds: string[];
+  selectedCards: ChatCardSnapshot[];
+  visibleCards: ChatCardSnapshot[];
+};
+
 export type NonActionableContext = {
   contextType: 'non_actionable';
   routeContextType: RouteContext['routeContextType'];
@@ -41,7 +130,13 @@ export type NonActionableContext = {
   allowedSuggestionTypes: readonly [];
 };
 
-export type CanonicalChatContext = CardEntryNoteWorkspaceContext | NonActionableContext;
+export type CanonicalChatContext =
+  | CardEntryNoteWorkspaceContext
+  | CardLibraryListContext
+  | GroupsListContext
+  | GroupDetailContext
+  | AddCardsToGroupDrawerContext
+  | NonActionableContext;
 
 // ── Context hint (derived from the client request) ───────────────────────────
 
@@ -51,6 +146,19 @@ export type ChatContextHint = {
   noteId?: string;
   cardId?: string;
   focusedField?: string;
+  surfaceContext?: ChatSurfaceContext;
+};
+
+type ResolverDeps = {
+  loadCardLibraryData: typeof loadCardLibraryData;
+  loadCardLibraryGroupsData: typeof loadCardLibraryGroupsData;
+  loadGroupDetailData: typeof loadGroupDetailData;
+};
+
+const defaultResolverDeps: ResolverDeps = {
+  loadCardLibraryData,
+  loadCardLibraryGroupsData,
+  loadGroupDetailData,
 };
 
 // jsonb columns in the database schema are typed as `unknown` by Drizzle because
@@ -62,6 +170,73 @@ function toStringArray(value: unknown): string[] {
   }
 
   return value.filter((item): item is string => typeof item === 'string');
+}
+
+function buildUrlFromFilters(
+  pathname: string,
+  filters:
+    | Extract<ChatSurfaceContext, { surface: 'card_library_list' }>['filters']
+    | Extract<ChatSurfaceContext, { surface: 'group_detail' }>['filters'],
+) {
+  const url = new URL(pathname, 'https://studypuck.test');
+
+  if (filters.searchText.trim().length > 0) {
+    url.searchParams.set('q', filters.searchText.trim());
+  }
+
+  if ('groupIds' in filters) {
+    url.searchParams.delete('group');
+
+    for (const groupId of filters.groupIds) {
+      url.searchParams.append('group', groupId);
+    }
+  }
+
+  if (filters.cardType) {
+    url.searchParams.set('type', filters.cardType);
+  }
+
+  return url;
+}
+
+function dedupeIds(ids: string[]) {
+  return [...new Set(ids)];
+}
+
+function buildCardSnapshot(item: CardLibraryCardListItemData): ChatCardSnapshot {
+  return {
+    cardId: item.cardId,
+    content: item.content,
+    meaning: item.meaning,
+    cardType: item.cardType,
+    groupNames: item.groups.map((group) => group.groupName),
+  };
+}
+
+function buildGroupSnapshot(item: CardLibraryGroupListItemData): ChatGroupSnapshot {
+  return {
+    groupId: item.groupId,
+    groupName: item.groupName,
+    description: item.description,
+    activeCardCount: item.activeCardCount,
+  };
+}
+
+function selectCardSnapshots(items: CardLibraryCardListItemData[], selectedCardIds: string[]) {
+  const itemsById = new Map(items.map((item) => [item.cardId, item]));
+
+  return dedupeIds(selectedCardIds)
+    .map((cardId) => itemsById.get(cardId))
+    .filter((item): item is CardLibraryCardListItemData => item !== undefined)
+    .map((item) => buildCardSnapshot(item));
+}
+
+function sliceCardSnapshots(items: CardLibraryCardListItemData[]) {
+  return items.slice(0, CARD_SNAPSHOT_LIMIT).map((item) => buildCardSnapshot(item));
+}
+
+function sliceGroupSnapshots(items: CardLibraryGroupListItemData[]) {
+  return items.slice(0, GROUP_SNAPSHOT_LIMIT).map((item) => buildGroupSnapshot(item));
 }
 
 async function resolveCardEntryNoteWorkspaceContext(
@@ -108,6 +283,134 @@ async function resolveCardEntryNoteWorkspaceContext(
   };
 }
 
+async function resolveCardLibraryListContext(
+  userId: string,
+  languageId: string,
+  surfaceContext: Extract<ChatSurfaceContext, { surface: 'card_library_list' }>,
+  routeContext: RouteContext,
+  database: DatabaseClient,
+  deps: ResolverDeps,
+): Promise<CardLibraryListContext> {
+  const library = await deps.loadCardLibraryData(
+    userId,
+    languageId,
+    buildUrlFromFilters(routeContext.pathname, surfaceContext.filters),
+    database,
+  );
+  const groupFilters = library.availableGroups
+    .filter((group) => library.filters.groupIds.includes(group.groupId))
+    .map((group) => ({
+      groupId: group.groupId,
+      groupName: group.groupName,
+    }));
+
+  return {
+    contextType: 'card_library_list',
+    languageId,
+    allowedSuggestionTypes: [],
+    listState: {
+      searchText: library.filters.searchText,
+      groupFilters,
+      cardType: library.filters.cardType,
+      ordering: 'updated_desc',
+    },
+    resultCount: library.totalCount,
+    selectedCardIds: dedupeIds(surfaceContext.selectedCardIds),
+    selectedCards: selectCardSnapshots(library.items, surfaceContext.selectedCardIds),
+    visibleCards: sliceCardSnapshots(library.items),
+  };
+}
+
+async function resolveGroupsListContext(
+  userId: string,
+  languageId: string,
+  database: DatabaseClient,
+  deps: ResolverDeps,
+): Promise<GroupsListContext> {
+  const groups = await deps.loadCardLibraryGroupsData(userId, languageId, database);
+
+  return {
+    contextType: 'groups_list',
+    languageId,
+    allowedSuggestionTypes: [],
+    listState: {
+      scope: 'all_groups_for_language',
+      ordering: 'group_name_asc',
+    },
+    resultCount: groups.totalCount,
+    visibleGroups: sliceGroupSnapshots(groups.items),
+  };
+}
+
+async function resolveGroupDetailContext(
+  userId: string,
+  languageId: string,
+  surfaceContext: Extract<ChatSurfaceContext, { surface: 'group_detail' }>,
+  routeContext: RouteContext,
+  database: DatabaseClient,
+  deps: ResolverDeps,
+): Promise<GroupDetailContext> {
+  const groupDetail = await deps.loadGroupDetailData(
+    userId,
+    languageId,
+    surfaceContext.groupId,
+    buildUrlFromFilters(routeContext.pathname, surfaceContext.filters),
+    database,
+  );
+
+  return {
+    contextType: 'group_detail',
+    languageId,
+    allowedSuggestionTypes: [],
+    group: buildGroupSnapshot(groupDetail.group),
+    listState: {
+      searchText: groupDetail.cards.filters.searchText,
+      cardType: groupDetail.cards.filters.cardType,
+      scopeGroupId: groupDetail.group.groupId,
+      ordering: 'updated_desc',
+    },
+    resultCount: groupDetail.cards.totalCount,
+    selectedCardIds: dedupeIds(surfaceContext.selectedCardIds),
+    selectedCards: selectCardSnapshots(groupDetail.cards.items, surfaceContext.selectedCardIds),
+    visibleCards: sliceCardSnapshots(groupDetail.cards.items),
+  };
+}
+
+async function resolveAddCardsToGroupDrawerContext(
+  userId: string,
+  languageId: string,
+  surfaceContext: Extract<ChatSurfaceContext, { surface: 'add_cards_to_group_drawer' }>,
+  routeContext: RouteContext,
+  database: DatabaseClient,
+  deps: ResolverDeps,
+): Promise<AddCardsToGroupDrawerContext> {
+  const groupDetail = await deps.loadGroupDetailData(
+    userId,
+    languageId,
+    surfaceContext.groupId,
+    new URL(routeContext.pathname, 'https://studypuck.test'),
+    database,
+  );
+  const filteredCandidates = filterAddableGroupCards(groupDetail.addableCards.items, surfaceContext.searchText);
+
+  return {
+    contextType: 'add_cards_to_group_drawer',
+    languageId,
+    allowedSuggestionTypes: [],
+    group: buildGroupSnapshot(groupDetail.group),
+    listState: {
+      searchText: surfaceContext.searchText.trim(),
+      excludedGroupId: groupDetail.group.groupId,
+      scope: 'active_language_cards_not_in_target_group',
+      ordering: 'updated_desc',
+    },
+    candidateCount: filteredCandidates.length,
+    selectedCardIds: dedupeIds(surfaceContext.selectedCardIds),
+    selectedCards: selectCardSnapshots(groupDetail.addableCards.items, surfaceContext.selectedCardIds),
+    visibleCards: sliceCardSnapshots(filteredCandidates),
+  };
+}
+
 // ── Resolver: non-actionable (cards, stats, settings, workspace) ─────────────
 
 function resolveNonActionableContext(
@@ -131,15 +434,19 @@ function resolveNonActionableContext(
  * database, verifies ownership, and constructs a context that includes the
  * workspace plus an optional likely-target-card hint.
  *
- * For all other contexts the backend constructs a lightweight non-actionable
- * context with no DB lookups.
+ * For supported Card Library surfaces, the backend validates the surface hint
+ * and assembles an authoritative list/group snapshot that matches the active
+ * list state producing the visible items.
+ *
+ * All other contexts fall back to a lightweight non-actionable context.
  */
 export async function resolveCanonicalChatContext(
   userId: string,
   hint: ChatContextHint,
   database: DatabaseClient | null,
+  deps: ResolverDeps = defaultResolverDeps,
 ): Promise<CanonicalChatContext> {
-  const { languageId, noteId, cardId, focusedField } = hint;
+  const { languageId, noteId, cardId, focusedField, surfaceContext } = hint;
 
   if (
     hint.routeContext.routeContextType === 'card-entry' &&
@@ -154,7 +461,57 @@ export async function resolveCanonicalChatContext(
     );
   }
 
-  return resolveNonActionableContext(hint);
+  if (!languageId || database === null || !surfaceContext) {
+    return resolveNonActionableContext(hint);
+  }
+
+  switch (surfaceContext.surface) {
+    case 'card_library_list':
+      if (hint.routeContext.routeContextType !== 'card_library_list') {
+        return resolveNonActionableContext(hint);
+      }
+
+      return resolveCardLibraryListContext(
+        userId,
+        languageId,
+        surfaceContext,
+        hint.routeContext,
+        database,
+        deps,
+      );
+    case 'groups_list':
+      if (hint.routeContext.routeContextType !== 'groups_list') {
+        return resolveNonActionableContext(hint);
+      }
+
+      return resolveGroupsListContext(userId, languageId, database, deps);
+    case 'group_detail':
+      if (hint.routeContext.routeContextType !== 'group_detail') {
+        return resolveNonActionableContext(hint);
+      }
+
+      return resolveGroupDetailContext(
+        userId,
+        languageId,
+        surfaceContext,
+        hint.routeContext,
+        database,
+        deps,
+      );
+    case 'add_cards_to_group_drawer':
+      if (hint.routeContext.routeContextType !== 'group_detail') {
+        return resolveNonActionableContext(hint);
+      }
+
+      return resolveAddCardsToGroupDrawerContext(
+        userId,
+        languageId,
+        surfaceContext,
+        hint.routeContext,
+        database,
+        deps,
+      );
+  }
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/apps/web/src/lib/server/chat.ts
+++ b/apps/web/src/lib/server/chat.ts
@@ -5,6 +5,7 @@ import {
   getCommandsForContext,
   type RouteContext,
 } from '$lib/command-bar/shared.js';
+import type { ChatSurfaceContext } from '$lib/chat.js';
 import { buildStructuredChatPrompt } from '$lib/server/ai-prompts/chat.js';
 import { resolveCanonicalChatContext, getAllowedSuggestionTypes, type CanonicalChatContext } from '$lib/server/chat-context.js';
 import { createAiService } from '$lib/server/ai-service.js';
@@ -34,6 +35,7 @@ type HandleStudyPuckChatRequestInput = {
   noteId?: string;
   cardId?: string;
   focusedField?: string;
+  surfaceContext?: ChatSurfaceContext;
   conversationHistory?: ConversationHistoryTurn[];
   database?: DatabaseClient;
   privateEnv: Record<string, string | undefined>;
@@ -177,6 +179,7 @@ export async function handleStudyPuckChatRequest(
       noteId: input.noteId,
       cardId: input.cardId,
       focusedField: input.focusedField,
+      surfaceContext: input.surfaceContext,
     },
     input.database ?? null,
   );

--- a/apps/web/src/lib/stores/commandBar.test.ts
+++ b/apps/web/src/lib/stores/commandBar.test.ts
@@ -18,6 +18,21 @@ describe('commandBar route context', () => {
     });
   });
 
+  it('distinguishes Card Library list, Groups list, and Group Detail routes', () => {
+    expect(resolveRouteContext('/zh/cards')).toMatchObject({
+      routeContextType: 'card_library_list',
+      label: 'Cards',
+    });
+    expect(resolveRouteContext('/zh/cards/groups')).toMatchObject({
+      routeContextType: 'groups_list',
+      label: 'Groups',
+    });
+    expect(resolveRouteContext('/zh/cards/groups/group-1')).toMatchObject({
+      routeContextType: 'group_detail',
+      label: 'Group Detail',
+    });
+  });
+
   it('keeps dashboard and settings in the global command context', () => {
     expect(resolveRouteContext('/zh')).toMatchObject({
       commandContext: 'global',
@@ -110,6 +125,52 @@ describe('commandBar entity context and conversation reset', () => {
     expect(stateAfter.activeNoteId).toBe(stateBefore.activeNoteId);
     expect(stateAfter.activeCardId).toBe(stateBefore.activeCardId);
     expect(stateAfter.activeFocusedField).toBe(stateBefore.activeFocusedField);
+  });
+
+  it('resets messages when the card-library surface scope changes', () => {
+    commandBar.setWorkspaceContext('es', null);
+    commandBar.setSurfaceContext({
+      surface: 'card_library_list',
+      filters: { searchText: '', groupIds: [], cardType: null },
+      selectedCardIds: [],
+    });
+    commandBar.pushAssistantMessage('Existing conversation');
+    commandBar.setSurfaceContext({
+      surface: 'group_detail',
+      groupId: 'group-1',
+      filters: { searchText: '', cardType: null },
+      selectedCardIds: [],
+    });
+
+    const state = getState();
+    expect(state.messages).toEqual([]);
+    expect(state.surfaceContextHint).toMatchObject({
+      surface: 'group_detail',
+      groupId: 'group-1',
+    });
+  });
+
+  it('keeps messages when only card-library filter inputs change within one surface', () => {
+    commandBar.setWorkspaceContext('es', null);
+    commandBar.setSurfaceContext({
+      surface: 'card_library_list',
+      filters: { searchText: '', groupIds: [], cardType: null },
+      selectedCardIds: [],
+    });
+    commandBar.pushAssistantMessage('Existing conversation');
+    commandBar.setSurfaceContext({
+      surface: 'card_library_list',
+      filters: { searchText: 'hola', groupIds: [], cardType: null },
+      selectedCardIds: ['card-1'],
+    });
+
+    const state = getState();
+    expect(state.messages).toHaveLength(1);
+    expect(state.surfaceContextHint).toMatchObject({
+      surface: 'card_library_list',
+      filters: { searchText: 'hola' },
+      selectedCardIds: ['card-1'],
+    });
   });
 
   it('getPromptHistory returns only user and assistant turns bounded to PROMPT_HISTORY_CAP', () => {

--- a/apps/web/src/lib/stores/commandBar.ts
+++ b/apps/web/src/lib/stores/commandBar.ts
@@ -9,7 +9,13 @@ import {
   type CommandDefinition,
   type RouteContext,
 } from '$lib/command-bar/shared.js';
-import { PROMPT_HISTORY_CAP, type ChatResponse, type ChatSuggestion, type ConversationHistoryTurn } from '$lib/chat.js';
+import {
+  PROMPT_HISTORY_CAP,
+  type ChatResponse,
+  type ChatSuggestion,
+  type ChatSurfaceContext,
+  type ConversationHistoryTurn,
+} from '$lib/chat.js';
 export type MessageRole = 'assistant' | 'system' | 'user';
 
 export type ConversationMessage = {
@@ -33,6 +39,7 @@ export type CommandBarState = {
   /** Last interacted draft-card hint within the current workspace. */
   activeCardId: string | null;
   activeFocusedField: string | null;
+  surfaceContextHint: ChatSurfaceContext | null;
   messages: ConversationMessage[];
   desktopConversationCollapsed: boolean;
   desktopContextWidth: number;
@@ -80,6 +87,7 @@ function initialState(): CommandBarState {
     activeNoteId: null,
     activeCardId: null,
     activeFocusedField: null,
+    surfaceContextHint: null,
     messages: [],
     desktopConversationCollapsed: false,
     desktopContextWidth: DEFAULT_CONTEXT_WIDTH.global,
@@ -94,6 +102,25 @@ function clamp(value: number, min: number, max: number) {
 
 function isAutocompleteInput(input: string) {
   return input.startsWith('/');
+}
+
+function getSurfaceContextScopeKey(surfaceContext: ChatSurfaceContext | null) {
+  if (!surfaceContext) {
+    return null;
+  }
+
+  switch (surfaceContext.surface) {
+    case 'card_library_list':
+    case 'groups_list':
+      return surfaceContext.surface;
+    case 'group_detail':
+    case 'add_cards_to_group_drawer':
+      return `${surfaceContext.surface}:${surfaceContext.groupId}`;
+  }
+}
+
+function areSurfaceContextsEqual(left: ChatSurfaceContext | null, right: ChatSurfaceContext | null) {
+  return JSON.stringify(left) === JSON.stringify(right);
 }
 
 function buildAssistantResponse(input: string, routeContext: RouteContext) {
@@ -181,7 +208,7 @@ function createCommandBarStore() {
 
         const contextChanged =
           state.routeContext.commandContext !== routeContext.commandContext ||
-          state.routeContext.label !== routeContext.label;
+          state.routeContext.routeContextType !== routeContext.routeContextType;
 
         if (!contextChanged) {
           return { ...state, routeContext };
@@ -192,6 +219,11 @@ function createCommandBarStore() {
         return {
           ...state,
           routeContext,
+          activeLanguageId: null,
+          activeNoteId: null,
+          activeCardId: null,
+          activeFocusedField: null,
+          surfaceContextHint: null,
           input: '',
           isWaiting: false,
           lastSubmittedInput: null,
@@ -200,6 +232,40 @@ function createCommandBarStore() {
           messages: [],
           desktopConversationCollapsed: false,
           desktopContextWidth: DEFAULT_CONTEXT_WIDTH[routeContext.commandContext],
+          mobileSheetOpen: false,
+          unreadCount: 0,
+        };
+      });
+    },
+
+    setSurfaceContext(surfaceContext: ChatSurfaceContext | null) {
+      store.update((state) => {
+        if (areSurfaceContextsEqual(state.surfaceContextHint, surfaceContext)) {
+          return state;
+        }
+
+        const scopeChanged =
+          getSurfaceContextScopeKey(state.surfaceContextHint) !== getSurfaceContextScopeKey(surfaceContext);
+
+        if (!scopeChanged) {
+          return {
+            ...state,
+            surfaceContextHint: surfaceContext,
+          };
+        }
+
+        clearPendingTimer();
+
+        return {
+          ...state,
+          surfaceContextHint: surfaceContext,
+          input: '',
+          isWaiting: false,
+          lastSubmittedInput: null,
+          autocompleteOpen: false,
+          highlightedIndex: 0,
+          messages: [],
+          desktopConversationCollapsed: false,
           mobileSheetOpen: false,
           unreadCount: 0,
         };

--- a/apps/web/src/routes/[lang]/cards/+page.svelte
+++ b/apps/web/src/routes/[lang]/cards/+page.svelte
@@ -18,6 +18,7 @@
     sortCardLibraryItems,
     type CardLibraryCardType,
   } from '$lib/cards/library.js';
+  import { commandBar } from '$lib/stores/commandBar.js';
   import type {
     CardLibraryCardDetailData,
     CardLibraryCardListItemData,
@@ -79,6 +80,12 @@
   });
 
   $: currentLang = $page.params.lang ?? '';
+  $: commandBar.setWorkspaceContext(currentLang || null, null);
+  $: commandBar.setSurfaceContext({
+    surface: 'card_library_list',
+    filters: library.filters,
+    selectedCardIds,
+  });
 
   $: if (data.library !== previousLibraryData) {
     library = data.library;

--- a/apps/web/src/routes/[lang]/cards/groups/+page.svelte
+++ b/apps/web/src/routes/[lang]/cards/groups/+page.svelte
@@ -3,6 +3,7 @@
   import { page } from '$app/stores';
   import { onMount, tick } from 'svelte';
   import { buildDeleteGroupMessage, sortCardLibraryGroupItems } from '$lib/cards/groups.js';
+  import { commandBar } from '$lib/stores/commandBar.js';
   import type { CardLibraryGroupListItemData, CardLibraryGroupsData } from '$lib/server/cards.js';
   import type { PageData } from './$types.js';
 
@@ -50,6 +51,10 @@
   });
 
   $: currentLang = $page.params.lang ?? '';
+  $: commandBar.setWorkspaceContext(currentLang || null, null);
+  $: commandBar.setSurfaceContext({
+    surface: 'groups_list',
+  });
 
   $: if (data.groups !== previousGroups) {
     groups = data.groups;

--- a/apps/web/src/routes/[lang]/cards/groups/[groupId]/+page.svelte
+++ b/apps/web/src/routes/[lang]/cards/groups/[groupId]/+page.svelte
@@ -23,6 +23,7 @@
     sortCardLibraryGroups,
     sortCardLibraryItems,
   } from '$lib/cards/library.js';
+  import { commandBar } from '$lib/stores/commandBar.js';
   import type {
     CardLibraryCardDetailData,
     CardLibraryCardListItemData,
@@ -106,11 +107,30 @@
   });
 
   $: currentLang = $page.params.lang ?? '';
+  $: commandBar.setWorkspaceContext(currentLang || null, null);
   $: currentGroupId = group.groupId;
   $: currentGroupSummary = {
     groupId: group.groupId,
     groupName: group.groupName,
   };
+  $: commandBar.setSurfaceContext(
+    addCardsDrawerOpen
+      ? {
+          surface: 'add_cards_to_group_drawer',
+          groupId: currentGroupId,
+          searchText: addCardsSearchQuery,
+          selectedCardIds: addCardsSelectedIds,
+        }
+      : {
+          surface: 'group_detail',
+          groupId: currentGroupId,
+          filters: {
+            searchText: cards.filters.searchText,
+            cardType: cards.filters.cardType,
+          },
+          selectedCardIds,
+        },
+  );
 
   $: if (data.groupDetail !== previousGroupDetail) {
     groupDetail = data.groupDetail;

--- a/apps/web/src/routes/api/chat/+server.ts
+++ b/apps/web/src/routes/api/chat/+server.ts
@@ -32,6 +32,7 @@ export const POST: RequestHandler = async (event) => {
       noteId: parsedBody.data.noteId,
       cardId: parsedBody.data.cardId,
       focusedField: parsedBody.data.focusedField,
+      surfaceContext: parsedBody.data.surfaceContext,
       conversationHistory: parsedBody.data.conversationHistory,
       database: database as never,
       privateEnv: env,


### PR DESCRIPTION
## Summary
- add structured chat surface hints for Card Library list, Groups list, Group Detail, and the Add Cards drawer
- resolve canonical backend chat contexts with authoritative list-state and compact card/group snapshots
- cover the new routing, prompt assembly, and command-bar context behavior with tests

Closes #167