### PR TITLE
Add Card Library group-management chat suggestions

### DIFF
--- a/apps/web/src/lib/chat.ts
+++ b/apps/web/src/lib/chat.ts
@@ -6,8 +6,15 @@ import {
   cardLibraryFiltersSchema,
   cardLibrarySearchSchema,
 } from '$lib/schemas/cards.js';
+import { editableCardOptionalTextSchema, editableGroupNameSchema } from '$lib/schemas/card-entry.js';
 
-export const CHAT_SUGGESTION_TYPES = ['append_example_sentence', 'append_mnemonic'] as const;
+export const CHAT_SUGGESTION_TYPES = [
+  'append_example_sentence',
+  'append_mnemonic',
+  'create_group',
+  'add_card_to_group',
+  'remove_card_from_group',
+] as const;
 
 export const PROMPT_HISTORY_CAP = 10;
 
@@ -90,9 +97,36 @@ export const appendMnemonicSuggestionSchema = z.object({
   }),
 });
 
+export const createGroupSuggestionSchema = z.object({
+  type: z.literal('create_group'),
+  payload: z.object({
+    name: editableGroupNameSchema,
+    description: editableCardOptionalTextSchema,
+  }),
+});
+
+export const addCardToGroupSuggestionSchema = z.object({
+  type: z.literal('add_card_to_group'),
+  payload: z.object({
+    cardId: activeCardIdSchema,
+    groupId: activeGroupIdSchema,
+  }),
+});
+
+export const removeCardFromGroupSuggestionSchema = z.object({
+  type: z.literal('remove_card_from_group'),
+  payload: z.object({
+    cardId: activeCardIdSchema,
+    groupId: activeGroupIdSchema,
+  }),
+});
+
 export const chatSuggestionSchema = z.discriminatedUnion('type', [
   appendExampleSentenceSuggestionSchema,
   appendMnemonicSuggestionSchema,
+  createGroupSuggestionSchema,
+  addCardToGroupSuggestionSchema,
+  removeCardFromGroupSuggestionSchema,
 ]);
 
 export type ChatRequest = z.infer<typeof chatRequestSchema>;

--- a/apps/web/src/lib/components/CommandBar.dom.test.ts
+++ b/apps/web/src/lib/components/CommandBar.dom.test.ts
@@ -43,6 +43,7 @@ vi.mock('$lib/chat/client.js', () => ({
 describe('CommandBar component behavior', () => {
   beforeEach(() => {
     vi.useRealTimers();
+    vi.unstubAllGlobals();
     document.body.innerHTML = '';
     pageStore.set({
       params: { lang: 'zh' },
@@ -202,5 +203,121 @@ describe('CommandBar component behavior', () => {
       'card-1',
       'Imagine talking while a memory hook keeps the phrase anchored.',
     );
+  });
+
+  it('posts create-group suggestions through the existing group action endpoint', async () => {
+    pageStore.set({
+      params: { lang: 'zh' },
+      route: { id: '/[lang]/cards/groups' },
+      status: 200,
+      error: null,
+      data: {},
+      form: undefined,
+      state: {},
+      url: new URL('https://studypuck.test/zh/cards/groups'),
+    });
+
+    requestStructuredChatResponse.mockResolvedValue({
+      message: 'I can create that group for you.',
+      suggestions: [
+        {
+          type: 'create_group',
+          payload: { name: 'Travel', description: 'Trips and transit' },
+        },
+      ],
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ group: { groupId: 'group-1', groupName: 'Travel', description: 'Trips and transit' } }),
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { default: CommandBar } = await import('./CommandBar.svelte');
+    const snippet = createRawSnippet(() => ({
+      render: () => '<section>context content</section>',
+    }));
+
+    render(CommandBar, {
+      props: {
+        children: snippet,
+      },
+    });
+
+    commandBar.setPathname('/zh/cards/groups');
+    commandBar.setWorkspaceContext('zh', null);
+    commandBar.setSurfaceContext({ surface: 'groups_list' });
+
+    const textbox = screen.getByLabelText('Command bar');
+    await fireEvent.input(textbox, { target: { value: 'Create a travel group' } });
+    await fireEvent.keyDown(textbox, { key: 'Enter' });
+
+    await screen.findAllByText('Travel');
+    await fireEvent.click(screen.getAllByRole('button', { name: /Travel/ })[0]);
+
+    expect(fetchMock).toHaveBeenCalledWith('/zh/cards/groups/actions', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        action: 'create',
+        groupName: 'Travel',
+        description: 'Trips and transit',
+      }),
+    });
+  });
+
+  it('forwards drawer add-to-group suggestions to the active card action store', async () => {
+    pageStore.set({
+      params: { lang: 'zh' },
+      route: { id: '/[lang]/cards' },
+      status: 200,
+      error: null,
+      data: {},
+      form: undefined,
+      state: {},
+      url: new URL('https://studypuck.test/zh/cards'),
+    });
+
+    requestStructuredChatResponse.mockResolvedValue({
+      message: 'I can add this card to Favorites.',
+      suggestions: [
+        {
+          type: 'add_card_to_group',
+          payload: { cardId: 'card-1', groupId: 'group-2' },
+        },
+      ],
+    });
+
+    const applySpy = vi.spyOn(activeCardSuggestionActions, 'applyAddCardToGroup');
+    const { default: CommandBar } = await import('./CommandBar.svelte');
+    const snippet = createRawSnippet(() => ({
+      render: () => '<section>context content</section>',
+    }));
+
+    render(CommandBar, {
+      props: {
+        children: snippet,
+      },
+    });
+
+    commandBar.setPathname('/zh/cards');
+    commandBar.setWorkspaceContext('zh', null);
+    commandBar.setSurfaceContext({
+      surface: 'card_detail_drawer',
+      sourceSurface: 'card_library_list',
+      cardId: 'card-1',
+    });
+
+    const textbox = screen.getByLabelText('Command bar');
+    await fireEvent.input(textbox, { target: { value: 'Add this card to Favorites too' } });
+    await fireEvent.keyDown(textbox, { key: 'Enter' });
+
+    expect(await screen.findAllByText('Card card-1 -> Group group-2')).toHaveLength(2);
+    await fireEvent.click(screen.getAllByRole('button', { name: /Card card-1 -> Group group-2/ })[0]);
+
+    expect(applySpy).toHaveBeenCalledWith('card-1', 'group-2');
   });
 });

--- a/apps/web/src/lib/components/CommandBar.svelte
+++ b/apps/web/src/lib/components/CommandBar.svelte
@@ -314,6 +314,12 @@
         return 'Add to examples';
       case 'append_mnemonic':
         return 'Add to mnemonics';
+      case 'create_group':
+        return 'Create group';
+      case 'add_card_to_group':
+        return 'Add card to group';
+      case 'remove_card_from_group':
+        return 'Remove from group';
       default:
         return 'Apply';
     }
@@ -324,8 +330,30 @@
       case 'append_example_sentence':
       case 'append_mnemonic':
         return suggestion.payload.text;
+      case 'create_group':
+        return suggestion.payload.name;
+      case 'add_card_to_group':
+        return `Card ${suggestion.payload.cardId} -> Group ${suggestion.payload.groupId}`;
+      case 'remove_card_from_group':
+        return `Card ${suggestion.payload.cardId} <- Group ${suggestion.payload.groupId}`;
       default:
         return '';
+    }
+  }
+
+  async function postSuggestionAction(path: string, body: unknown) {
+    const response = await fetch(path, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const responseBody = (await response.json().catch(() => null)) as { message?: string } | null;
+
+    if (!response.ok) {
+      throw new Error(responseBody?.message ?? 'The suggested action could not be completed right now.');
     }
   }
 
@@ -334,37 +362,97 @@
    * it into the active draft-card editor's normal save path.
    */
   async function handleSuggestionClick(suggestion: ChatSuggestion) {
-    if (suggestion.type === 'append_example_sentence' || suggestion.type === 'append_mnemonic') {
-      const activeNoteId = $commandBar.activeNoteId;
+    const currentLang = $page.params.lang;
 
-      if (activeNoteId) {
-        if (suggestion.type === 'append_mnemonic') {
-          cardEntrySuggestionActions.applyAppendMnemonic(
-            activeNoteId,
-            suggestion.payload.cardId,
-            suggestion.payload.text,
-          );
-        } else {
-          cardEntrySuggestionActions.applyAppendExampleSentence(
-            activeNoteId,
-            suggestion.payload.cardId,
-            suggestion.payload.text,
-          );
+    try {
+      if (suggestion.type === 'append_example_sentence' || suggestion.type === 'append_mnemonic') {
+        const activeNoteId = $commandBar.activeNoteId;
+
+        if (activeNoteId) {
+          if (suggestion.type === 'append_mnemonic') {
+            cardEntrySuggestionActions.applyAppendMnemonic(
+              activeNoteId,
+              suggestion.payload.cardId,
+              suggestion.payload.text,
+            );
+          } else {
+            cardEntrySuggestionActions.applyAppendExampleSentence(
+              activeNoteId,
+              suggestion.payload.cardId,
+              suggestion.payload.text,
+            );
+          }
+
+          return;
+        }
+
+        if ($commandBar.surfaceContextHint?.surface === 'card_detail_drawer') {
+          if (suggestion.type === 'append_mnemonic') {
+            activeCardSuggestionActions.applyAppendMnemonic(suggestion.payload.cardId, suggestion.payload.text);
+          } else {
+            activeCardSuggestionActions.applyAppendExampleSentence(
+              suggestion.payload.cardId,
+              suggestion.payload.text,
+            );
+          }
         }
 
         return;
       }
 
-      if ($commandBar.surfaceContextHint?.surface === 'card_detail_drawer') {
-        if (suggestion.type === 'append_mnemonic') {
-          activeCardSuggestionActions.applyAppendMnemonic(suggestion.payload.cardId, suggestion.payload.text);
-        } else {
-          activeCardSuggestionActions.applyAppendExampleSentence(
-            suggestion.payload.cardId,
-            suggestion.payload.text,
-          );
-        }
+      if (!currentLang) {
+        return;
       }
+
+      if (suggestion.type === 'create_group') {
+        await postSuggestionAction(`/${currentLang}/cards/groups/actions`, {
+          action: 'create',
+          groupName: suggestion.payload.name,
+          description: suggestion.payload.description,
+        });
+        await invalidateAll();
+        commandBar.pushAssistantMessage(`Created group "${suggestion.payload.name}".`);
+        return;
+      }
+
+      if (suggestion.type === 'add_card_to_group') {
+        if ($commandBar.surfaceContextHint?.surface === 'card_detail_drawer') {
+          activeCardSuggestionActions.applyAddCardToGroup(
+            suggestion.payload.cardId,
+            suggestion.payload.groupId,
+          );
+          return;
+        }
+
+        await postSuggestionAction(`/${currentLang}/cards/groups/${suggestion.payload.groupId}/actions`, {
+          action: 'add-cards',
+          cardIds: [suggestion.payload.cardId],
+        });
+        await invalidateAll();
+        commandBar.pushAssistantMessage('Added the card to the suggested group.');
+        return;
+      }
+
+      if (suggestion.type === 'remove_card_from_group') {
+        if ($commandBar.surfaceContextHint?.surface === 'card_detail_drawer') {
+          activeCardSuggestionActions.applyRemoveCardFromGroup(
+            suggestion.payload.cardId,
+            suggestion.payload.groupId,
+          );
+          return;
+        }
+
+        await postSuggestionAction(`/${currentLang}/cards/groups/${suggestion.payload.groupId}/actions`, {
+          action: 'remove-cards',
+          cardIds: [suggestion.payload.cardId],
+        });
+        await invalidateAll();
+        commandBar.pushAssistantMessage('Removed the card from the suggested group.');
+      }
+    } catch (error) {
+      commandBar.pushAssistantMessage(
+        error instanceof Error ? error.message : 'The suggested action could not be completed right now.',
+      );
     }
   }
 

--- a/apps/web/src/lib/components/cards/ActiveCardDrawer.svelte
+++ b/apps/web/src/lib/components/cards/ActiveCardDrawer.svelte
@@ -310,22 +310,8 @@
     await persistDraft();
   }
 
-  $: if (
-    $activeCardSuggestionActions &&
-    $activeCardSuggestionActions.actionId !== lastHandledSuggestionActionId &&
-    $activeCardSuggestionActions.cardId === card.cardId
-  ) {
-    lastHandledSuggestionActionId = $activeCardSuggestionActions.actionId;
-
-    if ($activeCardSuggestionActions.suggestionType === 'append_mnemonic') {
-      void applySuggestedListValue('mnemonics', $activeCardSuggestionActions.text);
-    } else {
-      void applySuggestedListValue('examples', $activeCardSuggestionActions.text);
-    }
-  }
-
-  async function toggleGroup(group: CardLibraryGroupData) {
-    if (disabled) {
+  async function addExistingGroup(group: CardLibraryGroupData) {
+    if (disabled || draft.groups.some((item) => item.groupId === group.groupId)) {
       return;
     }
 
@@ -336,6 +322,32 @@
 
     closeGroupMenu();
     await persistDraft();
+  }
+
+  $: if (
+    $activeCardSuggestionActions &&
+    $activeCardSuggestionActions.actionId !== lastHandledSuggestionActionId &&
+    $activeCardSuggestionActions.cardId === card.cardId
+  ) {
+    lastHandledSuggestionActionId = $activeCardSuggestionActions.actionId;
+
+    if ($activeCardSuggestionActions.suggestionType === 'append_mnemonic') {
+      void applySuggestedListValue('mnemonics', $activeCardSuggestionActions.text);
+    } else if ($activeCardSuggestionActions.suggestionType === 'append_example_sentence') {
+      void applySuggestedListValue('examples', $activeCardSuggestionActions.text);
+    } else if ($activeCardSuggestionActions.suggestionType === 'add_card_to_group') {
+      const matchingGroup = availableGroups.find((group) => group.groupId === $activeCardSuggestionActions.groupId);
+
+      if (matchingGroup) {
+        void addExistingGroup(matchingGroup);
+      }
+    } else if ($activeCardSuggestionActions.suggestionType === 'remove_card_from_group') {
+      void removeGroup($activeCardSuggestionActions.groupId);
+    }
+  }
+
+  async function toggleGroup(group: CardLibraryGroupData) {
+    await addExistingGroup(group);
   }
 
   async function createGroupFromQuery() {

--- a/apps/web/src/lib/components/cards/ActiveCardDrawer.test.ts
+++ b/apps/web/src/lib/components/cards/ActiveCardDrawer.test.ts
@@ -164,4 +164,86 @@ describe('ActiveCardDrawer', () => {
 
     expect(await screen.findByDisplayValue('Imagine two people talking while a memory hook keeps the phrase anchored.')).toBeTruthy();
   });
+
+  it('applies add-card-to-group suggestions through the active-card PATCH endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        card: createCard({ groups: [createGroup()] }),
+        availableGroups: [createGroup(), createGroup({ groupId: 'group-2', groupName: 'Favorites' })],
+      }),
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(ActiveCardDrawer, {
+      props: {
+        lang: 'zh',
+        card: createCard(),
+        availableGroups: [createGroup(), createGroup({ groupId: 'group-2', groupName: 'Favorites' })],
+        selectedIndex: 0,
+        totalCount: 1,
+      },
+    });
+
+    activeCardSuggestionActions.applyAddCardToGroup('card-1', 'group-1');
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/zh/cards/card-1', {
+        method: 'PATCH',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          content: '谈论',
+          meaning: 'to discuss',
+          examples: [],
+          mnemonics: [],
+          llmInstructions: '',
+          groups: [{ groupId: 'group-1', groupName: 'Conversation' }],
+        }),
+      });
+    });
+  });
+
+  it('applies remove-card-from-group suggestions through the active-card PATCH endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        card: createCard({ groups: [] }),
+        availableGroups: [createGroup()],
+      }),
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(ActiveCardDrawer, {
+      props: {
+        lang: 'zh',
+        card: createCard({ groups: [createGroup()] }),
+        availableGroups: [createGroup()],
+        selectedIndex: 0,
+        totalCount: 1,
+      },
+    });
+
+    activeCardSuggestionActions.applyRemoveCardFromGroup('card-1', 'group-1');
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/zh/cards/card-1', {
+        method: 'PATCH',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          content: '谈论',
+          meaning: 'to discuss',
+          examples: [],
+          mnemonics: [],
+          llmInstructions: '',
+          groups: [],
+        }),
+      });
+    });
+  });
 });

--- a/apps/web/src/lib/server/ai-prompts/chat.test.ts
+++ b/apps/web/src/lib/server/ai-prompts/chat.test.ts
@@ -41,8 +41,8 @@ describe('buildStructuredChatPrompt', () => {
     });
 
     expect(prompt.userPrompt).toContain('"contextType": "card_entry_note_workspace"');
-    expect(prompt.userPrompt).toContain('"cardId":"string"');
-    expect(prompt.userPrompt).toContain('replace the type value with "append_mnemonic"');
+    expect(prompt.userPrompt).toContain('{"type":"append_example_sentence","payload":{"cardId":"string","text":"string"}}');
+    expect(prompt.userPrompt).toContain('{"type":"append_mnemonic","payload":{"cardId":"string","text":"string"}}');
     expect(prompt.userPrompt).toContain('"cardId": "card-1"');
     expect(prompt.userPrompt).toContain('"cardId": "card-2"');
     expect(prompt.userPrompt).toContain('ask a clarifying question instead of guessing');
@@ -53,7 +53,7 @@ describe('buildStructuredChatPrompt', () => {
     const canonicalContext: CanonicalChatContext = {
       contextType: 'card_library_list',
       languageId: 'zh',
-      allowedSuggestionTypes: [],
+      allowedSuggestionTypes: ['create_group'],
       listState: {
         searchText: 'train',
         groupFilters: [{ groupId: 'group-1', groupName: 'Travel' }],
@@ -85,7 +85,7 @@ describe('buildStructuredChatPrompt', () => {
     const prompt = buildStructuredChatPrompt({
       canonicalContext,
       userInput: 'What should I study first from this list?',
-      allowedSuggestionTypes: [],
+      allowedSuggestionTypes: ['create_group'],
     });
 
     expect(prompt.userPrompt).toContain('"contextType": "card_library_list"');
@@ -93,5 +93,58 @@ describe('buildStructuredChatPrompt', () => {
     expect(prompt.userPrompt).toContain('"groupName": "Travel"');
     expect(prompt.userPrompt).toContain('"selectedCardIds": [');
     expect(prompt.userPrompt).toContain('"content": "火车"');
+  });
+
+  it('includes exact ID guidance for group-management suggestion types', () => {
+    const canonicalContext: CanonicalChatContext = {
+      contextType: 'group_detail',
+      languageId: 'zh',
+      allowedSuggestionTypes: ['create_group', 'add_card_to_group', 'remove_card_from_group'],
+      group: {
+        groupId: 'group-current',
+        groupName: 'Travel',
+        description: 'Trips and transit',
+        activeCardCount: 2,
+      },
+      availableGroupsForAddition: [{ groupId: 'group-other', groupName: 'Favorites' }],
+      listState: {
+        searchText: '',
+        cardType: null,
+        scopeGroupId: 'group-current',
+        ordering: 'updated_desc',
+      },
+      resultCount: 2,
+      selectedCardIds: ['card-1'],
+      selectedCards: [
+        {
+          cardId: 'card-1',
+          content: '火车',
+          meaning: 'train',
+          cardType: 'word',
+          groupNames: ['Travel'],
+        },
+      ],
+      visibleCards: [
+        {
+          cardId: 'card-1',
+          content: '火车',
+          meaning: 'train',
+          cardType: 'word',
+          groupNames: ['Travel'],
+        },
+      ],
+    };
+
+    const prompt = buildStructuredChatPrompt({
+      canonicalContext,
+      userInput: 'Put this card into Favorites too',
+      allowedSuggestionTypes: ['create_group', 'add_card_to_group', 'remove_card_from_group'],
+    });
+
+    expect(prompt.userPrompt).toContain('{"type":"create_group","payload":{"name":"string","description":"string | null"}}');
+    expect(prompt.userPrompt).toContain('{"type":"add_card_to_group","payload":{"cardId":"string","groupId":"string"}}');
+    expect(prompt.userPrompt).toContain('{"type":"remove_card_from_group","payload":{"cardId":"string","groupId":"string"}}');
+    expect(prompt.userPrompt).toContain('Use exact cardId and groupId values from the machine context');
+    expect(prompt.userPrompt).toContain('set description to null when no description is needed');
   });
 });

--- a/apps/web/src/lib/server/ai-prompts/chat.ts
+++ b/apps/web/src/lib/server/ai-prompts/chat.ts
@@ -6,18 +6,64 @@ function formatAllowedSuggestionTypes(allowedSuggestionTypes: readonly ChatSugge
 }
 
 function buildResponseShapeInstruction(allowedSuggestionTypes: readonly ChatSuggestionType[]) {
+  if (allowedSuggestionTypes.length === 0) {
+    return ['Return this JSON shape exactly:', '{"message":"string","suggestions":[]}'].join('\n');
+  }
+
+  const suggestionExamples: string[] = [];
+
+  if (allowedSuggestionTypes.includes('append_example_sentence')) {
+    suggestionExamples.push(
+      '{"type":"append_example_sentence","payload":{"cardId":"string","text":"string"}}',
+    );
+  }
+
+  if (allowedSuggestionTypes.includes('append_mnemonic')) {
+    suggestionExamples.push('{"type":"append_mnemonic","payload":{"cardId":"string","text":"string"}}');
+  }
+
+  if (allowedSuggestionTypes.includes('create_group')) {
+    suggestionExamples.push('{"type":"create_group","payload":{"name":"string","description":"string | null"}}');
+  }
+
+  if (allowedSuggestionTypes.includes('add_card_to_group')) {
+    suggestionExamples.push('{"type":"add_card_to_group","payload":{"cardId":"string","groupId":"string"}}');
+  }
+
+  if (allowedSuggestionTypes.includes('remove_card_from_group')) {
+    suggestionExamples.push('{"type":"remove_card_from_group","payload":{"cardId":"string","groupId":"string"}}');
+  }
+
+  return [
+    'Return this JSON shape exactly:',
+    '{"message":"string","suggestions":[{"type":"...","payload":{...}}]}',
+    'Each suggestion object must match one of these exact shapes:',
+    ...suggestionExamples,
+  ].join('\n');
+}
+
+function buildSuggestionGuidance(allowedSuggestionTypes: readonly ChatSuggestionType[]) {
+  const guidance: string[] = [];
+
   if (
     allowedSuggestionTypes.includes('append_example_sentence') ||
     allowedSuggestionTypes.includes('append_mnemonic')
   ) {
-    return [
-      'Return this JSON shape exactly:',
-      '{"message":"string","suggestions":[{"type":"append_example_sentence","payload":{"cardId":"string","text":"string"}}]}',
-      'If returning a mnemonic suggestion, replace the type value with "append_mnemonic".',
-    ].join('\n');
+    guidance.push('Use the exact cardId from the machine context when returning example or mnemonic suggestions.');
   }
 
-  return ['Return this JSON shape exactly:', '{"message":"string","suggestions":[]}'].join('\n');
+  if (
+    allowedSuggestionTypes.includes('add_card_to_group') ||
+    allowedSuggestionTypes.includes('remove_card_from_group')
+  ) {
+    guidance.push('Use exact cardId and groupId values from the machine context. Never substitute names for IDs.');
+  }
+
+  if (allowedSuggestionTypes.includes('create_group')) {
+    guidance.push('For create_group suggestions, set description to null when no description is needed.');
+  }
+
+  return guidance;
 }
 
 function buildCardEntryNoteWorkspaceContextBlock(context: CardEntryNoteWorkspaceContext): string {
@@ -84,6 +130,7 @@ export function buildStructuredChatPrompt(input: {
     `Allowed suggestion types: ${formatAllowedSuggestionTypes(input.allowedSuggestionTypes)}.`,
     'If no suggestion is appropriate, return an empty suggestions array.',
     buildResponseShapeInstruction(input.allowedSuggestionTypes),
+    ...buildSuggestionGuidance(input.allowedSuggestionTypes),
   ];
 
   if (historyBlock) {

--- a/apps/web/src/lib/server/chat-context.test.ts
+++ b/apps/web/src/lib/server/chat-context.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import { resolveRouteContext } from '$lib/command-bar/shared.js';
-import { getAllowedSuggestionTypes, resolveCanonicalChatContext } from './chat-context.js';
+import {
+  areChatSuggestionsValidForContext,
+  getAllowedSuggestionTypes,
+  resolveCanonicalChatContext,
+} from './chat-context.js';
 
 describe('resolveCanonicalChatContext', () => {
   it('returns a non-actionable context when no database is provided', async () => {
@@ -112,6 +116,7 @@ describe('resolveCanonicalChatContext', () => {
     expect(context).toMatchObject({
       contextType: 'card_library_list',
       languageId: 'es',
+      allowedSuggestionTypes: ['create_group'],
       listState: {
         searchText: 'tra',
         groupFilters: [{ groupId: 'group-1', groupName: 'Travel' }],
@@ -159,6 +164,7 @@ describe('resolveCanonicalChatContext', () => {
     expect(context).toMatchObject({
       contextType: 'groups_list',
       languageId: 'es',
+      allowedSuggestionTypes: ['create_group'],
       listState: {
         scope: 'all_groups_for_language',
         ordering: 'group_name_asc',
@@ -215,7 +221,7 @@ describe('resolveCanonicalChatContext', () => {
               groupIds: [],
               cardType: 'word',
             },
-            availableGroups: [],
+            availableGroups: [{ groupId: 'group-2', groupName: 'Favorites', activeCardCount: 3 }],
           },
           addableCards: {
             items: [],
@@ -228,10 +234,12 @@ describe('resolveCanonicalChatContext', () => {
     expect(context).toMatchObject({
       contextType: 'group_detail',
       languageId: 'es',
+      allowedSuggestionTypes: ['create_group', 'add_card_to_group', 'remove_card_from_group'],
       group: {
         groupId: 'group-1',
         groupName: 'Greetings',
       },
+      availableGroupsForAddition: [{ groupId: 'group-2', groupName: 'Favorites' }],
       listState: {
         searchText: 'hol',
         cardType: 'word',
@@ -308,6 +316,7 @@ describe('resolveCanonicalChatContext', () => {
     expect(context).toMatchObject({
       contextType: 'add_cards_to_group_drawer',
       languageId: 'es',
+      allowedSuggestionTypes: ['add_card_to_group'],
       group: {
         groupId: 'group-1',
         groupName: 'Greetings',
@@ -352,7 +361,10 @@ describe('resolveCanonicalChatContext', () => {
             updatedAtIso: null,
             groups: [{ groupId: 'group-1', groupName: 'Greetings' }],
           },
-          availableGroups: [{ groupId: 'group-1', groupName: 'Greetings' }],
+          availableGroups: [
+            { groupId: 'group-1', groupName: 'Greetings' },
+            { groupId: 'group-2', groupName: 'Favorites' },
+          ],
         }),
         loadCardLibraryData: vi.fn(),
         loadCardLibraryGroupsData: vi.fn(),
@@ -388,13 +400,20 @@ describe('resolveCanonicalChatContext', () => {
       sourceSurface: 'group_detail',
       likelyTargetCardId: 'card-1',
       likelyTargetFocusedField: 'mnemonics',
-      allowedSuggestionTypes: ['append_example_sentence', 'append_mnemonic'],
+      allowedSuggestionTypes: [
+        'append_example_sentence',
+        'append_mnemonic',
+        'add_card_to_group',
+        'remove_card_from_group',
+      ],
       card: {
         cardId: 'card-1',
         content: 'hola',
         examples: ['Hola, Marta.'],
         mnemonics: ['Think of waving hello in a hall.'],
       },
+      membershipGroups: [{ groupId: 'group-1', groupName: 'Greetings' }],
+      addableGroups: [{ groupId: 'group-2', groupName: 'Favorites' }],
       group: {
         groupId: 'group-1',
         groupName: 'Greetings',
@@ -404,7 +423,7 @@ describe('resolveCanonicalChatContext', () => {
 });
 
 describe('getAllowedSuggestionTypes', () => {
-  it('returns empty array for card-library contexts', async () => {
+  it('returns create-group suggestions for card-library contexts', async () => {
     const context = await resolveCanonicalChatContext(
       'user-1',
       {
@@ -439,10 +458,10 @@ describe('getAllowedSuggestionTypes', () => {
       },
     );
 
-    expect(getAllowedSuggestionTypes(context)).toEqual([]);
+    expect(getAllowedSuggestionTypes(context)).toEqual(['create_group']);
   });
 
-  it('returns mnemonic + example suggestion types for card-detail drawer context', async () => {
+  it('returns drawer suggestion types for card-detail drawer context', async () => {
     const context = await resolveCanonicalChatContext(
       'user-1',
       {
@@ -476,6 +495,73 @@ describe('getAllowedSuggestionTypes', () => {
       },
     );
 
-    expect(getAllowedSuggestionTypes(context)).toEqual(['append_example_sentence', 'append_mnemonic']);
+    expect(getAllowedSuggestionTypes(context)).toEqual([
+      'append_example_sentence',
+      'append_mnemonic',
+      'add_card_to_group',
+      'remove_card_from_group',
+    ]);
+  });
+});
+
+describe('areChatSuggestionsValidForContext', () => {
+  it('accepts only in-scope group-management suggestions for group detail context', () => {
+    const context = {
+      contextType: 'group_detail',
+      languageId: 'es',
+      allowedSuggestionTypes: ['create_group', 'add_card_to_group', 'remove_card_from_group'],
+      group: {
+        groupId: 'group-1',
+        groupName: 'Greetings',
+        description: 'Hello and goodbye',
+        activeCardCount: 1,
+      },
+      availableGroupsForAddition: [{ groupId: 'group-2', groupName: 'Favorites' }],
+      listState: {
+        searchText: '',
+        cardType: null,
+        scopeGroupId: 'group-1',
+        ordering: 'updated_desc',
+      },
+      resultCount: 1,
+      selectedCardIds: ['card-1'],
+      selectedCards: [
+        { cardId: 'card-1', content: 'hola', meaning: 'hello', cardType: 'word', groupNames: ['Greetings'] },
+      ],
+      visibleCards: [
+        { cardId: 'card-1', content: 'hola', meaning: 'hello', cardType: 'word', groupNames: ['Greetings'] },
+      ],
+    } as Awaited<ReturnType<typeof resolveCanonicalChatContext>>;
+
+    expect(
+      areChatSuggestionsValidForContext(context, [
+        {
+          type: 'add_card_to_group',
+          payload: { cardId: 'card-1', groupId: 'group-2' },
+        },
+        {
+          type: 'remove_card_from_group',
+          payload: { cardId: 'card-1', groupId: 'group-1' },
+        },
+      ]),
+    ).toBe(true);
+
+    expect(
+      areChatSuggestionsValidForContext(context, [
+        {
+          type: 'add_card_to_group',
+          payload: { cardId: 'card-999', groupId: 'group-2' },
+        },
+      ]),
+    ).toBe(false);
+
+    expect(
+      areChatSuggestionsValidForContext(context, [
+        {
+          type: 'remove_card_from_group',
+          payload: { cardId: 'card-1', groupId: 'group-999' },
+        },
+      ]),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/lib/server/chat-context.ts
+++ b/apps/web/src/lib/server/chat-context.ts
@@ -5,7 +5,7 @@ import {
   type CardEntryExampleSentenceFormat,
 } from '$lib/card-entry/example-sentence-format.js';
 import { filterAddableGroupCards } from '$lib/cards/group-detail.js';
-import type { ChatSuggestionType, ChatSurfaceContext } from '$lib/chat.js';
+import type { ChatSuggestion, ChatSuggestionType, ChatSurfaceContext } from '$lib/chat.js';
 import type { RouteContext } from '$lib/command-bar/shared.js';
 import { CardEntryRequestError } from '$lib/server/card-entry.js';
 import {
@@ -68,10 +68,15 @@ export type ChatGroupSnapshot = {
   activeCardCount: number;
 };
 
+export type ChatGroupReference = {
+  groupId: string;
+  groupName: string;
+};
+
 export type CardLibraryListContext = {
   contextType: 'card_library_list';
   languageId: string;
-  allowedSuggestionTypes: readonly [];
+  allowedSuggestionTypes: readonly ['create_group'];
   listState: {
     searchText: string;
     groupFilters: CardLibraryGroupData[];
@@ -87,7 +92,7 @@ export type CardLibraryListContext = {
 export type GroupsListContext = {
   contextType: 'groups_list';
   languageId: string;
-  allowedSuggestionTypes: readonly [];
+  allowedSuggestionTypes: readonly ['create_group'];
   listState: {
     scope: 'all_groups_for_language';
     ordering: 'group_name_asc';
@@ -99,8 +104,9 @@ export type GroupsListContext = {
 export type GroupDetailContext = {
   contextType: 'group_detail';
   languageId: string;
-  allowedSuggestionTypes: readonly [];
+  allowedSuggestionTypes: readonly ['create_group', 'add_card_to_group', 'remove_card_from_group'];
   group: ChatGroupSnapshot;
+  availableGroupsForAddition: ChatGroupReference[];
   listState: {
     searchText: string;
     cardType: string | null;
@@ -116,7 +122,7 @@ export type GroupDetailContext = {
 export type AddCardsToGroupDrawerContext = {
   contextType: 'add_cards_to_group_drawer';
   languageId: string;
-  allowedSuggestionTypes: readonly [];
+  allowedSuggestionTypes: readonly ['add_card_to_group'];
   group: ChatGroupSnapshot;
   listState: {
     searchText: string;
@@ -133,11 +139,18 @@ export type AddCardsToGroupDrawerContext = {
 export type CardDetailDrawerContext = {
   contextType: 'card_detail_drawer';
   languageId: string;
-  allowedSuggestionTypes: readonly ['append_example_sentence', 'append_mnemonic'];
+  allowedSuggestionTypes: readonly [
+    'append_example_sentence',
+    'append_mnemonic',
+    'add_card_to_group',
+    'remove_card_from_group',
+  ];
   sourceSurface: 'card_library_list' | 'group_detail';
   likelyTargetCardId: string;
   likelyTargetFocusedField: string | null;
   card: ChatCardDetailSnapshot;
+  membershipGroups: ChatGroupReference[];
+  addableGroups: ChatGroupReference[];
   group: ChatGroupSnapshot | null;
 };
 
@@ -265,6 +278,13 @@ function buildGroupSnapshot(item: CardLibraryGroupListItemData): ChatGroupSnapsh
   };
 }
 
+function buildGroupReference(item: Pick<CardLibraryGroupData, 'groupId' | 'groupName'>): ChatGroupReference {
+  return {
+    groupId: item.groupId,
+    groupName: item.groupName,
+  };
+}
+
 function selectCardSnapshots(items: CardLibraryCardListItemData[], selectedCardIds: string[]) {
   const itemsById = new Map(items.map((item) => [item.cardId, item]));
 
@@ -350,7 +370,7 @@ async function resolveCardLibraryListContext(
   return {
     contextType: 'card_library_list',
     languageId,
-    allowedSuggestionTypes: [],
+    allowedSuggestionTypes: ['create_group'],
     listState: {
       searchText: library.filters.searchText,
       groupFilters,
@@ -375,7 +395,7 @@ async function resolveGroupsListContext(
   return {
     contextType: 'groups_list',
     languageId,
-    allowedSuggestionTypes: [],
+    allowedSuggestionTypes: ['create_group'],
     listState: {
       scope: 'all_groups_for_language',
       ordering: 'group_name_asc',
@@ -404,8 +424,11 @@ async function resolveGroupDetailContext(
   return {
     contextType: 'group_detail',
     languageId,
-    allowedSuggestionTypes: [],
+    allowedSuggestionTypes: ['create_group', 'add_card_to_group', 'remove_card_from_group'],
     group: buildGroupSnapshot(groupDetail.group),
+    availableGroupsForAddition: groupDetail.cards.availableGroups
+      .filter((group) => group.groupId !== groupDetail.group.groupId)
+      .map((group) => buildGroupReference(group)),
     listState: {
       searchText: groupDetail.cards.filters.searchText,
       cardType: groupDetail.cards.filters.cardType,
@@ -439,7 +462,7 @@ async function resolveAddCardsToGroupDrawerContext(
   return {
     contextType: 'add_cards_to_group_drawer',
     languageId,
-    allowedSuggestionTypes: [],
+    allowedSuggestionTypes: ['add_card_to_group'],
     group: buildGroupSnapshot(groupDetail.group),
     listState: {
       searchText: surfaceContext.searchText.trim(),
@@ -498,11 +521,20 @@ async function resolveCardDetailDrawerContext(
   return {
     contextType: 'card_detail_drawer',
     languageId,
-    allowedSuggestionTypes: ['append_example_sentence', 'append_mnemonic'],
+    allowedSuggestionTypes: [
+      'append_example_sentence',
+      'append_mnemonic',
+      'add_card_to_group',
+      'remove_card_from_group',
+    ],
     sourceSurface: surfaceContext.sourceSurface,
     likelyTargetCardId: activeCard.card.cardId,
     likelyTargetFocusedField: hint.focusedField ?? null,
     card: buildCardDetailSnapshot(activeCard.card),
+    membershipGroups: activeCard.card.groups.map((item) => buildGroupReference(item)),
+    addableGroups: activeCard.availableGroups
+      .filter((availableGroup) => !activeCard.card.groups.some((groupItem) => groupItem.groupId === availableGroup.groupId))
+      .map((item) => buildGroupReference(item)),
     group,
   };
 }
@@ -638,4 +670,105 @@ export function getAllowedSuggestionTypes(
   context: CanonicalChatContext,
 ): readonly ChatSuggestionType[] {
   return context.allowedSuggestionTypes as readonly ChatSuggestionType[];
+}
+
+function getSuggestionCardIds(
+  cards: readonly Pick<ChatCardSnapshot, 'cardId'>[],
+) {
+  return new Set(cards.map((card) => card.cardId));
+}
+
+function getSuggestionGroupIds(
+  groups: readonly Pick<ChatGroupReference, 'groupId'>[],
+) {
+  return new Set(groups.map((group) => group.groupId));
+}
+
+function isCreateGroupSuggestionValid(context: CanonicalChatContext) {
+  return (
+    context.contextType === 'card_library_list' ||
+    context.contextType === 'groups_list' ||
+    context.contextType === 'group_detail'
+  );
+}
+
+function isAddCardToGroupSuggestionValid(
+  context: CanonicalChatContext,
+  payload: Extract<ChatSuggestion, { type: 'add_card_to_group' }>['payload'],
+) {
+  switch (context.contextType) {
+    case 'card_detail_drawer':
+      return (
+        payload.cardId === context.card.cardId &&
+        getSuggestionGroupIds(context.addableGroups).has(payload.groupId)
+      );
+    case 'group_detail':
+      return (
+        getSuggestionCardIds([...context.selectedCards, ...context.visibleCards]).has(payload.cardId) &&
+        getSuggestionGroupIds(context.availableGroupsForAddition).has(payload.groupId)
+      );
+    case 'add_cards_to_group_drawer':
+      return (
+        payload.groupId === context.group.groupId &&
+        getSuggestionCardIds([...context.selectedCards, ...context.visibleCards]).has(payload.cardId)
+      );
+    default:
+      return false;
+  }
+}
+
+function isRemoveCardFromGroupSuggestionValid(
+  context: CanonicalChatContext,
+  payload: Extract<ChatSuggestion, { type: 'remove_card_from_group' }>['payload'],
+) {
+  switch (context.contextType) {
+    case 'card_detail_drawer':
+      return (
+        payload.cardId === context.card.cardId &&
+        getSuggestionGroupIds(context.membershipGroups).has(payload.groupId)
+      );
+    case 'group_detail':
+      return (
+        payload.groupId === context.group.groupId &&
+        getSuggestionCardIds([...context.selectedCards, ...context.visibleCards]).has(payload.cardId)
+      );
+    default:
+      return false;
+  }
+}
+
+export function areChatSuggestionsValidForContext(
+  context: CanonicalChatContext,
+  suggestions: readonly ChatSuggestion[],
+) {
+  return suggestions.every((suggestion) => {
+    switch (suggestion.type) {
+      case 'append_example_sentence':
+        if (context.contextType === 'card_entry_note_workspace') {
+          return context.draftCards.some((card) => card.cardId === suggestion.payload.cardId);
+        }
+
+        if (context.contextType === 'card_detail_drawer') {
+          return context.card.cardId === suggestion.payload.cardId;
+        }
+
+        return false;
+      case 'append_mnemonic':
+        if (context.contextType === 'card_entry_note_workspace') {
+          return context.draftCards.some((card) => card.cardId === suggestion.payload.cardId);
+        }
+
+        if (context.contextType === 'card_detail_drawer') {
+          return context.card.cardId === suggestion.payload.cardId;
+        }
+
+        return false;
+      case 'create_group':
+        return isCreateGroupSuggestionValid(context);
+      case 'add_card_to_group':
+        return isAddCardToGroupSuggestionValid(context, suggestion.payload);
+      case 'remove_card_from_group':
+        return isRemoveCardFromGroupSuggestionValid(context, suggestion.payload);
+    }
+  });
 }

--- a/apps/web/src/lib/server/chat.ts
+++ b/apps/web/src/lib/server/chat.ts
@@ -7,7 +7,12 @@ import {
 } from '$lib/command-bar/shared.js';
 import type { ChatSurfaceContext } from '$lib/chat.js';
 import { buildStructuredChatPrompt } from '$lib/server/ai-prompts/chat.js';
-import { resolveCanonicalChatContext, getAllowedSuggestionTypes, type CanonicalChatContext } from '$lib/server/chat-context.js';
+import {
+  areChatSuggestionsValidForContext,
+  resolveCanonicalChatContext,
+  getAllowedSuggestionTypes,
+  type CanonicalChatContext,
+} from '$lib/server/chat-context.js';
 import { createAiService } from '$lib/server/ai-service.js';
 import { z } from 'zod';
 
@@ -61,8 +66,21 @@ function parseSlashCommand(input: string) {
 function normalizeChatResponse(
   response: unknown,
   allowedSuggestionTypes: readonly ChatSuggestionType[],
+  canonicalContext?: CanonicalChatContext,
 ) {
-  return createChatResponseSchema(allowedSuggestionTypes).parse(response);
+  const responseSchema = createChatResponseSchema(allowedSuggestionTypes).superRefine((value, refinementContext) => {
+    if (!canonicalContext || areChatSuggestionsValidForContext(canonicalContext, value.suggestions)) {
+      return;
+    }
+
+    refinementContext.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['suggestions'],
+      message: 'One or more suggestions reference cards or groups outside the canonical context.',
+    });
+  });
+
+  return responseSchema.parse(response);
 }
 
 function formatCommandList(commands: string[]) {
@@ -185,7 +203,19 @@ export async function handleStudyPuckChatRequest(
   );
 
   const allowedSuggestionTypes = getAllowedSuggestionTypes(canonicalContext);
-  const responseSchema = createChatResponseSchema(allowedSuggestionTypes);
+  const responseSchema = createChatResponseSchema(allowedSuggestionTypes).superRefine(
+    (value, refinementContext) => {
+      if (areChatSuggestionsValidForContext(canonicalContext, value.suggestions)) {
+        return;
+      }
+
+      refinementContext.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['suggestions'],
+        message: 'One or more suggestions reference cards or groups outside the canonical context.',
+      });
+    },
+  );
   const prompt = buildStructuredChatPrompt({
     canonicalContext,
     userInput: input.input,
@@ -211,5 +241,5 @@ export async function handleStudyPuckChatRequest(
     responseSchema,
   });
 
-  return normalizeChatResponse(response, allowedSuggestionTypes);
+  return normalizeChatResponse(response, allowedSuggestionTypes, canonicalContext);
 }

--- a/apps/web/src/lib/stores/activeCardSuggestionActions.ts
+++ b/apps/web/src/lib/stores/activeCardSuggestionActions.ts
@@ -3,17 +3,24 @@ import { writable } from 'svelte/store';
 export type ActiveCardSuggestionAction = {
   actionId: number;
   cardId: string;
-  suggestionType: 'append_example_sentence' | 'append_mnemonic';
-  text: string;
-};
+} & (
+  | {
+      suggestionType: 'append_example_sentence' | 'append_mnemonic';
+      text: string;
+    }
+  | {
+      suggestionType: 'add_card_to_group' | 'remove_card_from_group';
+      groupId: string;
+    }
+);
 
 function createActiveCardSuggestionActionsStore() {
   const { subscribe, set } = writable<ActiveCardSuggestionAction | null>(null);
   let actionCounter = 0;
 
-  function dispatchSuggestion(
+  function dispatchTextSuggestion(
     cardId: string,
-    suggestionType: ActiveCardSuggestionAction['suggestionType'],
+    suggestionType: 'append_example_sentence' | 'append_mnemonic',
     text: string,
   ) {
     actionCounter += 1;
@@ -25,13 +32,33 @@ function createActiveCardSuggestionActionsStore() {
     });
   }
 
+  function dispatchGroupSuggestion(
+    cardId: string,
+    suggestionType: 'add_card_to_group' | 'remove_card_from_group',
+    groupId: string,
+  ) {
+    actionCounter += 1;
+    set({
+      actionId: actionCounter,
+      cardId,
+      suggestionType,
+      groupId,
+    });
+  }
+
   return {
     subscribe,
     applyAppendExampleSentence(cardId: string, text: string) {
-      dispatchSuggestion(cardId, 'append_example_sentence', text);
+      dispatchTextSuggestion(cardId, 'append_example_sentence', text);
     },
     applyAppendMnemonic(cardId: string, text: string) {
-      dispatchSuggestion(cardId, 'append_mnemonic', text);
+      dispatchTextSuggestion(cardId, 'append_mnemonic', text);
+    },
+    applyAddCardToGroup(cardId: string, groupId: string) {
+      dispatchGroupSuggestion(cardId, 'add_card_to_group', groupId);
+    },
+    applyRemoveCardFromGroup(cardId: string, groupId: string) {
+      dispatchGroupSuggestion(cardId, 'remove_card_from_group', groupId);
     },
   };
 }


### PR DESCRIPTION
## Summary
- add typed chat suggestion support for Card Library group-management actions
- validate suggested card/group targets against canonical chat context data
- route accepted suggestions through existing group creation and membership flows
- add tests for prompts, context rules, drawer behavior, and command bar execution

## Testing
- pnpm turbo test lint build --filter=web

Closes #169