### PR TITLE
Refactor shared card editor logic

### DIFF
--- a/apps/web/src/lib/card-editor/shared.test.ts
+++ b/apps/web/src/lib/card-editor/shared.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+  addEditableGroup,
+  addEditableListValue,
+  appendEditableListValue,
+  buildEditableCardPayload,
+  canCreateEditorGroup,
+  filterAvailableEditorGroups,
+  removeEditableGroup,
+  removeEditableListValue,
+  updateEditableListValue,
+} from './shared.js';
+
+const baseCard = {
+  content: '火车',
+  meaning: 'train',
+  examples: ['  例子  '],
+  mnemonics: [],
+  llmInstructions: null,
+  groups: [{ groupId: 'group-2', groupName: 'Travel' }],
+};
+
+describe('card editor shared helpers', () => {
+  it('builds normalized payloads for editable cards', () => {
+    expect(
+      buildEditableCardPayload({
+        ...baseCard,
+        groups: [
+          { groupId: 'group-2', groupName: 'Travel' },
+          { groupId: '', groupName: 'New Group' },
+        ],
+      }),
+    ).toEqual({
+      content: '火车',
+      meaning: 'train',
+      examples: ['例子'],
+      mnemonics: [],
+      llmInstructions: '',
+      groups: [
+        { groupId: 'group-2', groupName: 'Travel' },
+        { groupId: null, groupName: 'New Group' },
+      ],
+    });
+  });
+
+  it('updates, appends, and removes list values immutably', () => {
+    const withEmptyExample = addEditableListValue(baseCard, 'examples');
+    expect(withEmptyExample.examples).toEqual(['  例子  ', '']);
+
+    const updatedExample = updateEditableListValue(withEmptyExample, 'examples', 1, '新例句');
+    expect(updatedExample.examples).toEqual(['  例子  ', '新例句']);
+
+    const appendedMnemonic = appendEditableListValue(updatedExample, 'mnemonics', '  Hook  ');
+    expect(appendedMnemonic.mnemonics).toEqual(['Hook']);
+
+    const unchangedMnemonic = appendEditableListValue(appendedMnemonic, 'mnemonics', '   ');
+    expect(unchangedMnemonic).toBe(appendedMnemonic);
+
+    const removedExample = removeEditableListValue(updatedExample, 'examples', 0);
+    expect(removedExample.examples).toEqual(['新例句']);
+  });
+
+  it('adds and removes groups while keeping alphabetical order', () => {
+    const withGroup = addEditableGroup(baseCard, { groupId: 'group-1', groupName: 'Basics' });
+    expect(withGroup.groups).toEqual([
+      { groupId: 'group-1', groupName: 'Basics' },
+      { groupId: 'group-2', groupName: 'Travel' },
+    ]);
+
+    const withoutGroup = removeEditableGroup(withGroup, 'group-2');
+    expect(withoutGroup.groups).toEqual([{ groupId: 'group-1', groupName: 'Basics' }]);
+  });
+
+  it('filters existing groups and reports whether a typed group can be created', () => {
+    const availableGroups = [
+      { groupId: 'group-1', groupName: 'Basics' },
+      { groupId: 'group-2', groupName: 'Travel' },
+      { groupId: 'group-3', groupName: 'Favorites' },
+    ];
+
+    expect(filterAvailableEditorGroups(availableGroups, baseCard.groups, 'fav')).toEqual([
+      { groupId: 'group-3', groupName: 'Favorites' },
+    ]);
+    expect(canCreateEditorGroup(availableGroups, 'travel')).toBe(false);
+    expect(canCreateEditorGroup(availableGroups, '  New Group  ')).toBe(true);
+  });
+});

--- a/apps/web/src/lib/card-editor/shared.ts
+++ b/apps/web/src/lib/card-editor/shared.ts
@@ -1,0 +1,158 @@
+export type EditableListField = 'examples' | 'mnemonics';
+
+export type EditableCardGroup = {
+  groupId: string;
+  groupName: string;
+};
+
+export type EditableCardLike<Group extends EditableCardGroup = EditableCardGroup> = {
+  content: string;
+  meaning: string | null;
+  examples: string[];
+  mnemonics: string[];
+  llmInstructions: string | null;
+  groups: Group[];
+};
+
+export type EditableCardPayload = {
+  content: string;
+  meaning: string;
+  examples: string[];
+  mnemonics: string[];
+  llmInstructions: string;
+  groups: Array<{
+    groupId: string | null;
+    groupName: string;
+  }>;
+};
+
+export function normalizeEditorList(values: string[]) {
+  return values.map((value) => value.trim()).filter(Boolean);
+}
+
+export function buildEditableCardPayload<Card extends EditableCardLike>(source: Card): EditableCardPayload {
+  return {
+    content: source.content,
+    meaning: source.meaning ?? '',
+    examples: normalizeEditorList(source.examples),
+    mnemonics: normalizeEditorList(source.mnemonics),
+    llmInstructions: source.llmInstructions ?? '',
+    groups: source.groups.map((group) => ({
+      groupId: group.groupId.trim() ? group.groupId : null,
+      groupName: group.groupName,
+    })),
+  };
+}
+
+export function updateEditableListValue<Card extends EditableCardLike>(
+  draft: Card,
+  field: EditableListField,
+  index: number,
+  value: string,
+) {
+  const nextValues = [...draft[field]];
+  nextValues[index] = value;
+
+  return {
+    ...draft,
+    [field]: nextValues,
+  };
+}
+
+export function addEditableListValue<Card extends EditableCardLike>(draft: Card, field: EditableListField) {
+  return {
+    ...draft,
+    [field]: [...draft[field], ''],
+  };
+}
+
+export function appendEditableListValue<Card extends EditableCardLike>(
+  draft: Card,
+  field: EditableListField,
+  text: string,
+) {
+  const trimmedText = text.trim();
+
+  if (!trimmedText) {
+    return draft;
+  }
+
+  return {
+    ...draft,
+    [field]: [...draft[field], trimmedText],
+  };
+}
+
+export function removeEditableListValue<Card extends EditableCardLike>(
+  draft: Card,
+  field: EditableListField,
+  index: number,
+) {
+  return {
+    ...draft,
+    [field]: draft[field].filter((_, currentIndex) => currentIndex !== index),
+  };
+}
+
+export function addEditableGroup<Card extends EditableCardLike<Group>, Group extends EditableCardGroup>(
+  draft: Card,
+  group: Group,
+) {
+  return {
+    ...draft,
+    groups: [...draft.groups, group].sort((left, right) => left.groupName.localeCompare(right.groupName)),
+  };
+}
+
+export function createEditableGroupFromQuery<Card extends EditableCardLike<Group>, Group extends EditableCardGroup>(
+  draft: Card,
+  groupName: string,
+) {
+  return {
+    ...draft,
+    groups: [
+      ...draft.groups,
+      {
+        groupId: '',
+        groupName: groupName.trim(),
+      } as Group,
+    ],
+  };
+}
+
+export function removeEditableGroup<Card extends EditableCardLike<Group>, Group extends EditableCardGroup>(
+  draft: Card,
+  groupId: string,
+) {
+  return {
+    ...draft,
+    groups: draft.groups.filter((group) => group.groupId !== groupId),
+  };
+}
+
+export function filterAvailableEditorGroups<Group extends EditableCardGroup>(
+  availableGroups: readonly Group[],
+  selectedGroups: readonly Group[],
+  query: string,
+) {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  const selectedGroupIds = new Set(selectedGroups.map((group) => group.groupId));
+
+  return availableGroups.filter(
+    (group) =>
+      !selectedGroupIds.has(group.groupId) &&
+      group.groupName.toLocaleLowerCase().includes(normalizedQuery),
+  );
+}
+
+export function canCreateEditorGroup<Group extends EditableCardGroup>(
+  availableGroups: readonly Group[],
+  query: string,
+) {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+
+  return (
+    normalizedQuery.length > 0 &&
+    !availableGroups.some((group) => group.groupName.trim().toLocaleLowerCase() === normalizedQuery)
+  );
+}

--- a/apps/web/src/lib/components/card-entry/DraftCardEditor.svelte
+++ b/apps/web/src/lib/components/card-entry/DraftCardEditor.svelte
@@ -1,6 +1,19 @@
 <script lang="ts">
   import { createEventDispatcher, onDestroy, tick } from 'svelte';
   import { get } from 'svelte/store';
+  import {
+    addEditableGroup,
+    addEditableListValue,
+    appendEditableListValue,
+    buildEditableCardPayload,
+    canCreateEditorGroup,
+    createEditableGroupFromQuery,
+    filterAvailableEditorGroups,
+    removeEditableGroup,
+    removeEditableListValue,
+    type EditableListField,
+    updateEditableListValue,
+  } from '$lib/card-editor/shared.js';
   import type {
     CardEntryGroupData,
     CardEntryNoteDraftCardData,
@@ -9,7 +22,6 @@
   import { commandBar } from '$lib/stores/commandBar.js';
   import { cardEntrySuggestionActions } from '$lib/stores/cardEntrySuggestionActions.js';
 
-  type EditableListField = 'examples' | 'mnemonics';
   type DraftCardFocusedField =
     | 'content'
     | 'meaning'
@@ -70,16 +82,8 @@
     }
   }
 
-  $: normalizedGroupQuery = groupQuery.trim().toLocaleLowerCase();
-  $: selectedGroupIds = new Set(draft.groups.map((group) => group.groupId));
-  $: filteredGroups = availableGroups.filter(
-    (group) =>
-      !selectedGroupIds.has(group.groupId) &&
-      group.groupName.toLocaleLowerCase().includes(normalizedGroupQuery)
-  );
-  $: canCreateGroup =
-    normalizedGroupQuery.length > 0 &&
-    !availableGroups.some((group) => group.groupName.trim().toLocaleLowerCase() === normalizedGroupQuery);
+  $: filteredGroups = filterAvailableEditorGroups(availableGroups, draft.groups, groupQuery);
+  $: canCreateGroup = canCreateEditorGroup(availableGroups, groupQuery);
   $: signpostLabel =
     saveState === 'saving'
       ? 'Saving...'
@@ -103,10 +107,6 @@
     savedIndicatorTimer = setTimeout(() => {
       saveState = 'idle';
     }, 2_000);
-  }
-
-  function normalizeList(values: string[]) {
-    return values.map((value) => value.trim()).filter(Boolean);
   }
 
   function closeGroupMenu() {
@@ -140,17 +140,7 @@
   }
 
   function buildPayload() {
-    return {
-      content: draft.content,
-      meaning: draft.meaning ?? '',
-      examples: normalizeList(draft.examples),
-      mnemonics: normalizeList(draft.mnemonics),
-      llmInstructions: draft.llmInstructions ?? '',
-      groups: draft.groups.map((group) => ({
-        groupId: group.groupId?.trim() ? group.groupId : null,
-        groupName: group.groupName,
-      })),
-    };
+    return buildEditableCardPayload(draft);
   }
 
   async function persistDraft() {
@@ -207,12 +197,7 @@
   }
 
   function updateListValue(field: EditableListField, index: number, value: string) {
-    const nextValues = [...draft[field]];
-    nextValues[index] = value;
-    draft = {
-      ...draft,
-      [field]: nextValues,
-    };
+    draft = updateEditableListValue(draft, field, index, value);
   }
 
   function addListValue(field: EditableListField) {
@@ -220,17 +205,11 @@
     // user clicked "+").  Without this, a stale save response can overwrite the
     // newly-added empty item before the user has a chance to type into it.
     saveToken++;
-    draft = {
-      ...draft,
-      [field]: [...draft[field], ''],
-    };
+    draft = addEditableListValue(draft, field);
   }
 
   async function removeListValue(field: EditableListField, index: number) {
-    draft = {
-      ...draft,
-      [field]: draft[field].filter((_, currentIndex) => currentIndex !== index),
-    };
+    draft = removeEditableListValue(draft, field, index);
 
     await persistDraft();
   }
@@ -248,17 +227,14 @@
       return;
     }
 
-    const trimmedText = text.trim();
+    const nextDraft = appendEditableListValue(draft, field, text);
 
-    if (!trimmedText) {
+    if (nextDraft === draft) {
       return;
     }
 
     saveToken++;
-    draft = {
-      ...draft,
-      [field]: [...draft[field], trimmedText],
-    };
+    draft = nextDraft;
     commandBar.setTargetHint(card.cardId, field);
 
     await persistDraft();
@@ -283,10 +259,7 @@
       return;
     }
 
-    draft = {
-      ...draft,
-      groups: [...draft.groups, group].sort((left, right) => left.groupName.localeCompare(right.groupName)),
-    };
+    draft = addEditableGroup(draft, group);
 
     closeGroupMenu();
     await persistDraft();
@@ -297,16 +270,7 @@
       return;
     }
 
-    draft = {
-      ...draft,
-      groups: [
-        ...draft.groups,
-        {
-          groupId: '',
-          groupName: groupQuery.trim(),
-        },
-      ],
-    };
+    draft = createEditableGroupFromQuery(draft, groupQuery);
 
     closeGroupMenu();
     await persistDraft();
@@ -317,10 +281,7 @@
       return;
     }
 
-    draft = {
-      ...draft,
-      groups: draft.groups.filter((group) => group.groupId !== groupId),
-    };
+    draft = removeEditableGroup(draft, groupId);
 
     await persistDraft();
   }

--- a/apps/web/src/lib/components/card-entry/DraftCardEditor.test.ts
+++ b/apps/web/src/lib/components/card-entry/DraftCardEditor.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { render, screen, waitFor } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import DraftCardEditor from './DraftCardEditor.svelte';
 import { cardEntrySuggestionActions } from '$lib/stores/cardEntrySuggestionActions.js';
@@ -139,5 +139,49 @@ describe('DraftCardEditor suggestion application', () => {
     });
 
     expect(await screen.findByDisplayValue('Train tracks look like parallel rails carrying the word forward.')).toBeTruthy();
+  });
+
+  it('creates a group from the typed query through the normal draft-card save endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        card: createCard({ groups: [{ groupId: 'group-9', groupName: 'Travel' }] }),
+        availableGroups: [{ groupId: 'group-9', groupName: 'Travel' }],
+      }),
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(DraftCardEditor, {
+      props: {
+        lang: 'zh',
+        noteId: 'note-1',
+        card: createCard(),
+        availableGroups: [],
+      },
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: '+ Add group' }));
+    await fireEvent.input(screen.getByPlaceholderText('Search groups...'), {
+      target: { value: 'Travel' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: '+ Create "Travel"' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/zh/card-entry/notes/note-1/draft-cards/card-1', {
+        method: 'PATCH',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          content: '火车',
+          meaning: 'train',
+          examples: [],
+          mnemonics: [],
+          llmInstructions: '',
+          groups: [{ groupId: null, groupName: 'Travel' }],
+        }),
+      });
+    });
   });
 });

--- a/apps/web/src/lib/components/cards/ActiveCardDrawer.svelte
+++ b/apps/web/src/lib/components/cards/ActiveCardDrawer.svelte
@@ -1,12 +1,24 @@
 <script lang="ts">
   import { createEventDispatcher, onDestroy, tick } from 'svelte';
   import { get } from 'svelte/store';
+  import {
+    addEditableGroup,
+    addEditableListValue,
+    appendEditableListValue,
+    buildEditableCardPayload,
+    canCreateEditorGroup,
+    createEditableGroupFromQuery,
+    filterAvailableEditorGroups,
+    removeEditableGroup,
+    removeEditableListValue,
+    type EditableListField,
+    updateEditableListValue,
+  } from '$lib/card-editor/shared.js';
   import CardListStatusBadge from '$lib/components/card-list/CardListStatusBadge.svelte';
   import type { CardLibraryCardDetailData, CardLibraryGroupData } from '$lib/server/cards.js';
   import { commandBar } from '$lib/stores/commandBar.js';
   import { activeCardSuggestionActions } from '$lib/stores/activeCardSuggestionActions.js';
 
-  type EditableListField = 'examples' | 'mnemonics';
   type ActiveCardFocusedField =
     | 'content'
     | 'meaning'
@@ -57,26 +69,12 @@
   let llmInstructionsOpen = Boolean(card.llmInstructions);
   let lastHandledSuggestionActionId = get(activeCardSuggestionActions)?.actionId ?? 0;
 
-  function normalizeList(values: string[]) {
-    return values.map((value) => value.trim()).filter(Boolean);
-  }
-
   function serializePayload(payload: ReturnType<typeof buildPayload>) {
     return JSON.stringify(payload);
   }
 
   function buildPayloadFromCard(source: CardLibraryCardDetailData) {
-    return {
-      content: source.content,
-      meaning: source.meaning ?? '',
-      examples: normalizeList(source.examples),
-      mnemonics: normalizeList(source.mnemonics),
-      llmInstructions: source.llmInstructions ?? '',
-      groups: source.groups.map((group) => ({
-        groupId: group.groupId?.trim() ? group.groupId : null,
-        groupName: group.groupName,
-      })),
-    };
+    return buildEditableCardPayload(source);
   }
 
   function buildPayload() {
@@ -130,16 +128,8 @@
     }
   }
 
-  $: normalizedGroupQuery = groupQuery.trim().toLocaleLowerCase();
-  $: selectedGroupIds = new Set(draft.groups.map((group) => group.groupId));
-  $: filteredGroups = availableGroups.filter(
-    (group) =>
-      !selectedGroupIds.has(group.groupId) &&
-      group.groupName.toLocaleLowerCase().includes(normalizedGroupQuery)
-  );
-  $: canCreateGroup =
-    normalizedGroupQuery.length > 0 &&
-    !availableGroups.some((group) => group.groupName.trim().toLocaleLowerCase() === normalizedGroupQuery);
+  $: filteredGroups = filterAvailableEditorGroups(availableGroups, draft.groups, groupQuery);
+  $: canCreateGroup = canCreateEditorGroup(availableGroups, groupQuery);
   $: signpostLabel =
     saveState === 'saving'
       ? 'Saving...'
@@ -258,27 +248,16 @@
   }
 
   function updateListValue(field: EditableListField, index: number, value: string) {
-    const nextValues = [...draft[field]];
-    nextValues[index] = value;
-    draft = {
-      ...draft,
-      [field]: nextValues,
-    };
+    draft = updateEditableListValue(draft, field, index, value);
   }
 
   function addListValue(field: EditableListField) {
     saveToken++;
-    draft = {
-      ...draft,
-      [field]: [...draft[field], ''],
-    };
+    draft = addEditableListValue(draft, field);
   }
 
   async function removeListValue(field: EditableListField, index: number) {
-    draft = {
-      ...draft,
-      [field]: draft[field].filter((_, currentIndex) => currentIndex !== index),
-    };
+    draft = removeEditableListValue(draft, field, index);
 
     await persistDraft();
   }
@@ -294,17 +273,14 @@
       return;
     }
 
-    const trimmedText = text.trim();
+    const nextDraft = appendEditableListValue(draft, field, text);
 
-    if (!trimmedText) {
+    if (nextDraft === draft) {
       return;
     }
 
     saveToken++;
-    draft = {
-      ...draft,
-      [field]: [...draft[field], trimmedText],
-    };
+    draft = nextDraft;
     commandBar.setTargetHint(card.cardId, field);
 
     await persistDraft();
@@ -315,10 +291,7 @@
       return;
     }
 
-    draft = {
-      ...draft,
-      groups: [...draft.groups, group].sort((left, right) => left.groupName.localeCompare(right.groupName)),
-    };
+    draft = addEditableGroup(draft, group);
 
     closeGroupMenu();
     await persistDraft();
@@ -355,16 +328,7 @@
       return;
     }
 
-    draft = {
-      ...draft,
-      groups: [
-        ...draft.groups,
-        {
-          groupId: '',
-          groupName: groupQuery.trim(),
-        },
-      ],
-    };
+    draft = createEditableGroupFromQuery(draft, groupQuery);
 
     closeGroupMenu();
     await persistDraft();
@@ -375,10 +339,7 @@
       return;
     }
 
-    draft = {
-      ...draft,
-      groups: draft.groups.filter((group) => group.groupId !== groupId),
-    };
+    draft = removeEditableGroup(draft, groupId);
 
     await persistDraft();
   }

--- a/apps/web/src/lib/components/cards/ActiveCardDrawer.test.ts
+++ b/apps/web/src/lib/components/cards/ActiveCardDrawer.test.ts
@@ -246,4 +246,49 @@ describe('ActiveCardDrawer', () => {
       });
     });
   });
+
+  it('creates a group from the typed query through the active-card PATCH endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        card: createCard({ groups: [{ groupId: 'group-9', groupName: 'Travel' }] }),
+        availableGroups: [{ groupId: 'group-9', groupName: 'Travel' }],
+      }),
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(ActiveCardDrawer, {
+      props: {
+        lang: 'zh',
+        card: createCard(),
+        availableGroups: [],
+        selectedIndex: 0,
+        totalCount: 1,
+      },
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: '+ Add group' }));
+    await fireEvent.input(screen.getByPlaceholderText('Search groups...'), {
+      target: { value: 'Travel' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: '+ Create "Travel"' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/zh/cards/card-1', {
+        method: 'PATCH',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          content: '谈论',
+          meaning: 'to discuss',
+          examples: [],
+          mnemonics: [],
+          llmInstructions: '',
+          groups: [{ groupId: null, groupName: 'Travel' }],
+        }),
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- extract shared pure card-editor helpers for payload building, list edits, and group edits/filtering
- keep DraftCardEditor and ActiveCardDrawer separate at the shell/persistence layer
- add characterization tests for the shared helper layer and manual group-creation flows in both editors

## Refactor boundary
This refactor intentionally avoids merging the two components. It shares only the duplicated pure editing mechanics while leaving draft-only and active-only responsibilities isolated.

## Testing
- pnpm turbo test lint build --filter=web

Closes #172