### PR TITLE
Add cards/groups sub-navigation

### DIFF
--- a/apps/web/src/lib/components/cards/CardsSubnav.svelte
+++ b/apps/web/src/lib/components/cards/CardsSubnav.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  export let lang: string;
+  export let activeSection: 'cards' | 'groups';
+
+  let navItems: ReadonlyArray<{
+    id: 'cards' | 'groups';
+    label: 'Cards' | 'Groups';
+    href: string;
+  }> = [];
+
+  $: navItems = [
+    { id: 'cards', label: 'Cards', href: `/${lang}/cards` },
+    { id: 'groups', label: 'Groups', href: `/${lang}/cards/groups` },
+  ] as const;
+</script>
+
+<nav class="cards-subnav cluster" aria-label="Cards navigation">
+  {#each navItems as item}
+    <a
+      href={item.href}
+      class:cards-subnav__link--active={item.id === activeSection}
+      class="cards-subnav__link"
+      aria-current={item.id === activeSection ? 'page' : undefined}
+    >
+      {item.label}
+    </a>
+  {/each}
+</nav>
+
+<style>
+  .cards-subnav {
+    --cluster-space: var(--space-2);
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .cards-subnav__link {
+    display: inline-flex;
+    align-items: center;
+    min-block-size: 2.25rem;
+    padding: 0 var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-pill);
+    background: var(--color-surface);
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+    font-weight: var(--font-weight-medium);
+    text-decoration: none;
+    transition:
+      border-color 120ms ease,
+      background-color 120ms ease,
+      color 120ms ease;
+  }
+
+  .cards-subnav__link:hover {
+    border-color: var(--color-border-strong);
+    color: var(--color-text-primary);
+  }
+
+  .cards-subnav__link--active {
+    border-color: color-mix(in srgb, var(--color-link) 35%, var(--color-border));
+    background: color-mix(in srgb, var(--color-link) 12%, var(--color-surface));
+    color: var(--color-link);
+  }
+
+  .cards-subnav__link:focus-visible {
+    outline: 2px solid var(--color-focus-ring);
+    outline-offset: 2px;
+  }
+</style>

--- a/apps/web/src/lib/components/cards/CardsSubnav.test.ts
+++ b/apps/web/src/lib/components/cards/CardsSubnav.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import CardsSubnav from './CardsSubnav.svelte';
+
+describe('CardsSubnav', () => {
+  it('renders cards and groups links with the correct active state', () => {
+    render(CardsSubnav, {
+      props: {
+        lang: 'zh',
+        activeSection: 'groups',
+      },
+    });
+
+    const cardsLink = screen.getByRole('link', { name: 'Cards' });
+    const groupsLink = screen.getByRole('link', { name: 'Groups' });
+
+    expect(cardsLink.getAttribute('href')).toBe('/zh/cards');
+    expect(groupsLink.getAttribute('href')).toBe('/zh/cards/groups');
+    expect(cardsLink.getAttribute('aria-current')).toBeNull();
+    expect(groupsLink.getAttribute('aria-current')).toBe('page');
+  });
+});

--- a/apps/web/src/routes/[lang]/cards/+page.svelte
+++ b/apps/web/src/routes/[lang]/cards/+page.svelte
@@ -3,6 +3,7 @@
   import { page } from '$app/stores';
   import { onDestroy, onMount } from 'svelte';
   import ActiveCardDrawer from '$lib/components/cards/ActiveCardDrawer.svelte';
+  import CardsSubnav from '$lib/components/cards/CardsSubnav.svelte';
   import CardListBulkActionBar from '$lib/components/card-list/CardListBulkActionBar.svelte';
   import CardListColumns from '$lib/components/card-list/CardListColumns.svelte';
   import CardListFilterBar from '$lib/components/card-list/CardListFilterBar.svelte';
@@ -358,6 +359,7 @@
   <header class="cards-page__header stack" style="--stack-space: var(--space-2)">
     <p class="cards-page__eyebrow">Cards</p>
     <h1>Cards</h1>
+    <CardsSubnav lang={currentLang} activeSection="cards" />
   </header>
 
   <CardListFilterBar

--- a/apps/web/src/routes/[lang]/cards/groups/+page.svelte
+++ b/apps/web/src/routes/[lang]/cards/groups/+page.svelte
@@ -3,6 +3,7 @@
   import { page } from '$app/stores';
   import { onMount, tick } from 'svelte';
   import { buildDeleteGroupMessage, sortCardLibraryGroupItems } from '$lib/cards/groups.js';
+  import CardsSubnav from '$lib/components/cards/CardsSubnav.svelte';
   import { commandBar } from '$lib/stores/commandBar.js';
   import type { CardLibraryGroupListItemData, CardLibraryGroupsData } from '$lib/server/cards.js';
   import type { PageData } from './$types.js';
@@ -275,6 +276,7 @@
     <div class="stack" style="--stack-space: var(--space-2)">
       <p class="groups-page__eyebrow">Cards</p>
       <h1>Groups</h1>
+      <CardsSubnav lang={currentLang} activeSection="groups" />
     </div>
 
     <button type="button" class="groups-page__new-button" on:click={openCreateDrawer}>

--- a/apps/web/src/routes/[lang]/cards/groups/[groupId]/+page.svelte
+++ b/apps/web/src/routes/[lang]/cards/groups/[groupId]/+page.svelte
@@ -3,6 +3,7 @@
   import { page } from '$app/stores';
   import { onDestroy, onMount, tick } from 'svelte';
   import ActiveCardDrawer from '$lib/components/cards/ActiveCardDrawer.svelte';
+  import CardsSubnav from '$lib/components/cards/CardsSubnav.svelte';
   import CardListBulkActionBar from '$lib/components/card-list/CardListBulkActionBar.svelte';
   import CardListColumns from '$lib/components/card-list/CardListColumns.svelte';
   import CardListFilterBar from '$lib/components/card-list/CardListFilterBar.svelte';
@@ -726,6 +727,7 @@
 <section class="group-detail-page stack" style="--stack-space: var(--space-5)">
   <header class="group-detail-page__header stack" style="--stack-space: var(--space-3)">
     <a class="group-detail-page__back-link" href={`/${currentLang}/cards/groups`}>← Back to Groups</a>
+    <CardsSubnav lang={currentLang} activeSection="groups" />
 
     <div class="group-detail-page__header-main">
       <div class="stack" style="--stack-space: var(--space-2)">


### PR DESCRIPTION
## Summary
- add a shared Cards sub-navigation component for the Cards mini-app
- surface Cards and Groups navigation on the cards list, groups list, and group detail screens
- add component coverage for the active navigation state

Fixes #181