### PR TITLE
Investigate chat regression failures

### DIFF
--- a/apps/web/src/lib/server/ai-prompts/chat.test.ts
+++ b/apps/web/src/lib/server/ai-prompts/chat.test.ts
@@ -147,4 +147,27 @@ describe('buildStructuredChatPrompt', () => {
     expect(prompt.userPrompt).toContain('Use exact cardId and groupId values from the machine context');
     expect(prompt.userPrompt).toContain('set description to null when no description is needed');
   });
+
+  it('makes clear that study-language help is still allowed when no suggestions are available', () => {
+    const canonicalContext: CanonicalChatContext = {
+      contextType: 'non_actionable',
+      routeContextType: 'card-review',
+      languageId: 'zh',
+      allowedSuggestionTypes: [],
+    };
+
+    const prompt = buildStructuredChatPrompt({
+      canonicalContext,
+      userInput: 'Why is 了 used here?',
+      allowedSuggestionTypes: [],
+    });
+
+    expect(prompt.systemPrompt).toContain(
+      'You should still answer study-language questions, explain vocabulary or grammar, give practice ideas, and discuss the visible study content even when no app action is available.',
+    );
+    expect(prompt.userPrompt).toContain(
+      'Suggestions are only for typed app actions. They do not limit normal study-language help.',
+    );
+    expect(prompt.userPrompt).toContain('Allowed suggestion types: none.');
+  });
 });

--- a/apps/web/src/lib/server/ai-prompts/chat.ts
+++ b/apps/web/src/lib/server/ai-prompts/chat.ts
@@ -128,6 +128,7 @@ export function buildStructuredChatPrompt(input: {
   const userPromptParts = [
     contextBlock,
     `Allowed suggestion types: ${formatAllowedSuggestionTypes(input.allowedSuggestionTypes)}.`,
+    'Suggestions are only for typed app actions. They do not limit normal study-language help.',
     'If no suggestion is appropriate, return an empty suggestions array.',
     buildResponseShapeInstruction(input.allowedSuggestionTypes),
     ...buildSuggestionGuidance(input.allowedSuggestionTypes),
@@ -143,6 +144,7 @@ export function buildStructuredChatPrompt(input: {
     systemPrompt: [
       'You are the StudyPuck assistant.',
       'Primary role: help with the active study language and supported StudyPuck tasks for that language.',
+      'You should still answer study-language questions, explain vocabulary or grammar, give practice ideas, and discuss the visible study content even when no app action is available.',
       'If asked about unrelated topics or unsupported product capabilities, respond tersely that you cannot help with that.',
       'Return only JSON.',
       'Do not invent StudyPuck features or product-help details.',

--- a/apps/web/src/lib/server/ai-service.test.ts
+++ b/apps/web/src/lib/server/ai-service.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
-import { AiServiceConfigurationError, createAiService } from './ai-service.js';
+import { AiServiceConfigurationError, AiServiceRequestError, createAiService } from './ai-service.js';
 
 const responseSchema = z.object({
   draftCards: z.array(z.object({ content: z.string() })),
@@ -142,6 +142,44 @@ describe('createAiService', () => {
       userPrompt: 'user',
       responseSchema,
     })).rejects.toBeInstanceOf(AiServiceConfigurationError);
+  });
+
+  it('captures structured failure details when all providers fail to return a valid response', async () => {
+    const geminiGenerator = vi.fn(async () => 'I can help with that.');
+    const service = createAiService({
+      privateEnv: {
+        GEMINI_API_KEY: 'test-gemini-key',
+      },
+      hooks: silentHooks,
+      providerGenerators: {
+        gemini: geminiGenerator,
+      },
+    });
+
+    await expect(
+      service.generateStructured({
+        metadata: {
+          feature: 'chat',
+          operation: 'conversation',
+          userId: 'user-1',
+          languageId: 'zh',
+          routeContextType: 'card-entry',
+        },
+        systemPrompt: 'system',
+        userPrompt: 'user',
+        responseSchema,
+      }),
+    ).rejects.toMatchObject({
+      providerName: 'gemini',
+      attempts: [
+        expect.objectContaining({
+          provider: 'gemini',
+          stage: 'json_extract',
+          message: 'The AI response did not contain valid JSON.',
+          rawTextPreview: 'I can help with that.',
+        }),
+      ],
+    });
   });
 
   it('generates embeddings from the configured primary provider', async () => {

--- a/apps/web/src/lib/server/ai-service.ts
+++ b/apps/web/src/lib/server/ai-service.ts
@@ -95,14 +95,54 @@ export class AiServiceConfigurationError extends Error {
 export class AiServiceRequestError extends Error {
   providerName: AiProviderName;
   cause: unknown;
+  attempts: AiProviderAttemptFailure[];
 
-  constructor(providerName: AiProviderName, message: string, cause?: unknown) {
+  constructor(
+    providerName: AiProviderName,
+    message: string,
+    cause?: unknown,
+    attempts: AiProviderAttemptFailure[] = [],
+  ) {
     super(message);
     this.name = 'AiServiceRequestError';
     this.providerName = providerName;
     this.cause = cause;
+    this.attempts = attempts;
   }
 }
+
+export type AiStructuredResponseFailureStage = 'json_extract' | 'json_parse' | 'schema_validation';
+
+export class AiStructuredResponseError extends Error {
+  stage: AiStructuredResponseFailureStage;
+  cause: unknown;
+  rawTextPreview: string | null;
+  issues: z.ZodIssue[];
+
+  constructor(input: {
+    stage: AiStructuredResponseFailureStage;
+    message: string;
+    cause?: unknown;
+    rawTextPreview?: string | null;
+    issues?: z.ZodIssue[];
+  }) {
+    super(input.message);
+    this.name = 'AiStructuredResponseError';
+    this.stage = input.stage;
+    this.cause = input.cause;
+    this.rawTextPreview = input.rawTextPreview ?? null;
+    this.issues = input.issues ?? [];
+  }
+}
+
+export type AiProviderAttemptFailure = {
+  provider: AiProviderName;
+  model: string;
+  message: string;
+  stage: AiStructuredResponseFailureStage | 'provider_request';
+  rawTextPreview: string | null;
+  issues: z.ZodIssue[];
+};
 
 function normalizeProviderOrder(primaryProvider: AiProviderName): AiProviderName[] {
   return primaryProvider === 'openai' ? ['openai', 'gemini'] : ['gemini', 'openai'];
@@ -159,9 +199,50 @@ function extractJsonText(rawText: string): string {
   throw new Error('The AI response did not contain valid JSON.');
 }
 
+function buildRawTextPreview(rawText: string): string {
+  const normalized = rawText.replace(/\s+/g, ' ').trim();
+  return normalized.length > 400 ? `${normalized.slice(0, 400)}…` : normalized;
+}
+
 async function parseStructuredResponse<T>(rawText: string, responseSchema: z.ZodType<T>): Promise<T> {
-  const parsedJson = JSON.parse(extractJsonText(rawText));
-  return responseSchema.parse(parsedJson);
+  let jsonText = '';
+
+  try {
+    jsonText = extractJsonText(rawText);
+  } catch (error) {
+    throw new AiStructuredResponseError({
+      stage: 'json_extract',
+      message: 'The AI response did not contain valid JSON.',
+      cause: error,
+      rawTextPreview: buildRawTextPreview(rawText),
+    });
+  }
+
+  let parsedJson: unknown;
+
+  try {
+    parsedJson = JSON.parse(jsonText);
+  } catch (error) {
+    throw new AiStructuredResponseError({
+      stage: 'json_parse',
+      message: 'The AI response contained malformed JSON.',
+      cause: error,
+      rawTextPreview: buildRawTextPreview(jsonText),
+    });
+  }
+
+  const parsed = responseSchema.safeParse(parsedJson);
+
+  if (!parsed.success) {
+    throw new AiStructuredResponseError({
+      stage: 'schema_validation',
+      message: 'The AI response did not match the expected schema.',
+      rawTextPreview: buildRawTextPreview(jsonText),
+      issues: parsed.error.issues,
+    });
+  }
+
+  return parsed.data;
 }
 
 async function callGemini(request: ProviderRequest): Promise<string> {
@@ -271,7 +352,8 @@ async function callOpenAi(request: ProviderRequest): Promise<string> {
   });
 
   if (!response.ok) {
-    throw new Error(`OpenAI request failed with status ${response.status}`);
+    const errorText = await response.text().catch(() => '');
+    throw new Error(`OpenAI request failed with status ${response.status}${errorText ? `: ${errorText}` : ''}`);
   }
 
   const body = await response.json();
@@ -325,6 +407,32 @@ const DEFAULT_EMBEDDING_GENERATORS: Record<AiProviderName, ProviderGenerateEmbed
   openai: callOpenAiEmbedding,
 };
 
+function summarizeAttemptFailure(
+  provider: AiProviderName,
+  model: string,
+  error: unknown,
+): AiProviderAttemptFailure {
+  if (error instanceof AiStructuredResponseError) {
+    return {
+      provider,
+      model,
+      message: error.message,
+      stage: error.stage,
+      rawTextPreview: error.rawTextPreview,
+      issues: error.issues,
+    };
+  }
+
+  return {
+    provider,
+    model,
+    message: error instanceof Error ? error.message : String(error),
+    stage: 'provider_request',
+    rawTextPreview: null,
+    issues: [],
+  };
+}
+
 export function createAiService(options: {
   privateEnv: Record<string, string | undefined>;
   hooks?: Partial<AiRequestHooks>;
@@ -364,6 +472,7 @@ export function createAiService(options: {
       }
 
       let lastError: unknown;
+      const attempts: AiProviderAttemptFailure[] = [];
 
       for (const provider of providers) {
         try {
@@ -394,6 +503,7 @@ export function createAiService(options: {
           return parsed;
         } catch (error) {
           lastError = error;
+          attempts.push(summarizeAttemptFailure(provider.name, provider.textModel, error));
           await hooks.onRequestFailure({
             provider: provider.name,
             metadata: request.metadata,
@@ -406,7 +516,8 @@ export function createAiService(options: {
       throw new AiServiceRequestError(
         providers[0]!.name,
         'All configured AI providers failed to return a valid response.',
-        lastError
+        lastError,
+        attempts,
       );
     },
 

--- a/apps/web/src/routes/api/chat/+server.ts
+++ b/apps/web/src/routes/api/chat/+server.ts
@@ -3,6 +3,7 @@ import { getDb, withTransactionDb } from '@studypuck/database';
 import { env } from '$env/dynamic/private';
 import { chatRequestSchema } from '$lib/chat.js';
 import { resolveRouteContext } from '$lib/command-bar/shared.js';
+import { AiServiceRequestError } from '$lib/server/ai-service.js';
 import { CardEntryRequestError, createCardEntryNoteForLanguage } from '$lib/server/card-entry.js';
 import { CardLibraryRequestError } from '$lib/server/cards.js';
 import { handleStudyPuckChatRequest } from '$lib/server/chat.js';
@@ -54,6 +55,25 @@ export const POST: RequestHandler = async (event) => {
   } catch (requestError) {
     if (requestError instanceof CardEntryRequestError || requestError instanceof CardLibraryRequestError) {
       throw error(requestError.status, requestError.message);
+    }
+
+    if (requestError instanceof AiServiceRequestError) {
+      console.error('StudyPuck chat AI request failed:', {
+        routeContextType: routeContext.routeContextType,
+        languageId: parsedBody.data.languageId ?? null,
+        noteIdPresent: Boolean(parsedBody.data.noteId),
+        cardIdPresent: Boolean(parsedBody.data.cardId),
+        surface: parsedBody.data.surfaceContext?.surface ?? null,
+        attempts: requestError.attempts.map((attempt) => ({
+          provider: attempt.provider,
+          model: attempt.model,
+          stage: attempt.stage,
+          message: attempt.message,
+          rawTextPreview: attempt.rawTextPreview,
+          issues: attempt.issues,
+        })),
+      });
+      throw error(500, 'The chat assistant could not respond right now.');
     }
 
     console.error('StudyPuck chat request failed:', requestError);


### PR DESCRIPTION
## Summary
- tighten the chat prompt so study-language help is still allowed when no typed app action applies
- add structured AI failure diagnostics so chat 500s report provider, failure stage, and schema issues without logging full prompts
- add regression coverage for prompt behavior and provider failure classification

## Why
- production is showing two separate chat regressions: refusal-style answers for legitimate study help, and production-only 500s for some actionable requests
- this PR is intended to diagnose the production-only 500 safely in a branch deployment while also preserving the prompt fix for the refusal behavior