### PR TITLE
Add active-language inbox note chat suggestions

### DIFF
--- a/apps/web/src/lib/chat.test.ts
+++ b/apps/web/src/lib/chat.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { createChatResponseSchema } from '$lib/chat.js';
+
+describe('createChatResponseSchema', () => {
+  it('accepts add_inbox_note suggestions with minimal typed payload', () => {
+    const schema = createChatResponseSchema(['add_inbox_note']);
+
+    expect(
+      schema.parse({
+        message: 'This would make a good review note.',
+        suggestions: [{ type: 'add_inbox_note', payload: { text: 'Know when to use 谈论 vs 聊天' } }],
+      }),
+    ).toEqual({
+      message: 'This would make a good review note.',
+      suggestions: [{ type: 'add_inbox_note', payload: { text: 'Know when to use 谈论 vs 聊天' } }],
+    });
+  });
+
+  it('rejects add_inbox_note suggestions when that type is not allowed', () => {
+    const schema = createChatResponseSchema([]);
+
+    expect(() =>
+      schema.parse({
+        message: 'No action here.',
+        suggestions: [{ type: 'add_inbox_note', payload: { text: 'Review a durable distinction' } }],
+      }),
+    ).toThrow('expected never');
+  });
+});

--- a/apps/web/src/lib/chat.ts
+++ b/apps/web/src/lib/chat.ts
@@ -6,11 +6,16 @@ import {
   cardLibraryFiltersSchema,
   cardLibrarySearchSchema,
 } from '$lib/schemas/cards.js';
-import { editableCardOptionalTextSchema, editableGroupNameSchema } from '$lib/schemas/card-entry.js';
+import {
+  cardEntryNoteContentSchema,
+  editableCardOptionalTextSchema,
+  editableGroupNameSchema,
+} from '$lib/schemas/card-entry.js';
 
 export const CHAT_SUGGESTION_TYPES = [
   'append_example_sentence',
   'append_mnemonic',
+  'add_inbox_note',
   'create_group',
   'add_card_to_group',
   'remove_card_from_group',
@@ -105,6 +110,13 @@ export const createGroupSuggestionSchema = z.object({
   }),
 });
 
+export const addInboxNoteSuggestionSchema = z.object({
+  type: z.literal('add_inbox_note'),
+  payload: z.object({
+    text: cardEntryNoteContentSchema,
+  }),
+});
+
 export const addCardToGroupSuggestionSchema = z.object({
   type: z.literal('add_card_to_group'),
   payload: z.object({
@@ -124,6 +136,7 @@ export const removeCardFromGroupSuggestionSchema = z.object({
 export const chatSuggestionSchema = z.discriminatedUnion('type', [
   appendExampleSentenceSuggestionSchema,
   appendMnemonicSuggestionSchema,
+  addInboxNoteSuggestionSchema,
   createGroupSuggestionSchema,
   addCardToGroupSuggestionSchema,
   removeCardFromGroupSuggestionSchema,

--- a/apps/web/src/lib/components/CommandBar.dom.test.ts
+++ b/apps/web/src/lib/components/CommandBar.dom.test.ts
@@ -40,6 +40,12 @@ vi.mock('$lib/chat/client.js', () => ({
   requestStructuredChatResponse,
 }));
 
+const createInboxNoteRequest = vi.fn();
+
+vi.mock('$lib/card-entry/client.js', () => ({
+  createInboxNoteRequest,
+}));
+
 describe('CommandBar component behavior', () => {
   beforeEach(() => {
     vi.useRealTimers();
@@ -60,6 +66,7 @@ describe('CommandBar component behavior', () => {
     commandBar.setTargetHint(null, null);
     commandBar.setSurfaceContext(null);
     requestStructuredChatResponse.mockReset();
+    createInboxNoteRequest.mockReset();
   });
 
   it('opens command autocomplete for slash input and shows the current context', async () => {
@@ -266,6 +273,58 @@ describe('CommandBar component behavior', () => {
         groupName: 'Travel',
         description: 'Trips and transit',
       }),
+    });
+  });
+
+  it('creates active-language inbox notes through the existing note request helper', async () => {
+    pageStore.set({
+      params: { lang: 'zh' },
+      route: { id: '/[lang]/card-review' },
+      status: 200,
+      error: null,
+      data: {},
+      form: undefined,
+      state: {},
+      url: new URL('https://studypuck.test/zh/card-review'),
+    });
+
+    requestStructuredChatResponse.mockResolvedValue({
+      message: 'That belongs in your inbox.',
+      suggestions: [
+        {
+          type: 'add_inbox_note',
+          payload: { text: 'Know when to use 谈论 vs 聊天' },
+        },
+      ],
+    });
+    createInboxNoteRequest.mockResolvedValue({ noteId: 'note-1' });
+
+    const { default: CommandBar } = await import('./CommandBar.svelte');
+    const snippet = createRawSnippet(() => ({
+      render: () => '<section>context content</section>',
+    }));
+
+    render(CommandBar, {
+      props: {
+        children: snippet,
+      },
+    });
+
+    commandBar.setPathname('/zh/card-review');
+    commandBar.setWorkspaceContext('zh', null);
+
+    const textbox = screen.getByLabelText('Command bar');
+    await fireEvent.input(textbox, { target: { value: 'When would I use 谈论 vs 聊天?' } });
+    await fireEvent.keyDown(textbox, { key: 'Enter' });
+
+    expect(await screen.findAllByText('Know when to use 谈论 vs 聊天')).toHaveLength(2);
+    expect(screen.getAllByText('Add inbox note')).toHaveLength(2);
+
+    await fireEvent.click(screen.getAllByRole('button', { name: /Know when to use 谈论 vs 聊天/ })[0]);
+
+    expect(createInboxNoteRequest).toHaveBeenCalledWith({
+      languageId: 'zh',
+      content: 'Know when to use 谈论 vs 聊天',
     });
   });
 

--- a/apps/web/src/lib/components/CommandBar.svelte
+++ b/apps/web/src/lib/components/CommandBar.svelte
@@ -314,6 +314,8 @@
         return 'Add to examples';
       case 'append_mnemonic':
         return 'Add to mnemonics';
+      case 'add_inbox_note':
+        return 'Add inbox note';
       case 'create_group':
         return 'Create group';
       case 'add_card_to_group':
@@ -329,6 +331,7 @@
     switch (suggestion.type) {
       case 'append_example_sentence':
       case 'append_mnemonic':
+      case 'add_inbox_note':
         return suggestion.payload.text;
       case 'create_group':
         return suggestion.payload.name;
@@ -401,6 +404,16 @@
       }
 
       if (!currentLang) {
+        return;
+      }
+
+      if (suggestion.type === 'add_inbox_note') {
+        await createInboxNoteRequest({
+          languageId: currentLang,
+          content: suggestion.payload.text,
+        });
+        await invalidateAll();
+        commandBar.pushAssistantMessage('Added the suggested inbox note.');
         return;
       }
 

--- a/apps/web/src/lib/server/ai-prompts/chat.test.ts
+++ b/apps/web/src/lib/server/ai-prompts/chat.test.ts
@@ -11,7 +11,7 @@ describe('buildStructuredChatPrompt', () => {
       noteContent: 'Travel vocabulary',
       likelyTargetCardId: 'card-2',
       likelyTargetFocusedField: 'examples',
-      allowedSuggestionTypes: ['append_example_sentence', 'append_mnemonic'],
+      allowedSuggestionTypes: ['append_example_sentence', 'append_mnemonic', 'add_inbox_note'],
       exampleSentenceFormat: 'sentence_translation',
       exampleSentenceFormatInstruction: 'Format every example as "<sentence> | <translation>". Do not add transliteration.',
       draftCards: [
@@ -37,23 +37,25 @@ describe('buildStructuredChatPrompt', () => {
     const prompt = buildStructuredChatPrompt({
       canonicalContext,
       userInput: 'Give me another example sentence',
-      allowedSuggestionTypes: ['append_example_sentence', 'append_mnemonic'],
+      allowedSuggestionTypes: ['append_example_sentence', 'append_mnemonic', 'add_inbox_note'],
     });
 
     expect(prompt.userPrompt).toContain('"contextType": "card_entry_note_workspace"');
     expect(prompt.userPrompt).toContain('{"type":"append_example_sentence","payload":{"cardId":"string","text":"string"}}');
     expect(prompt.userPrompt).toContain('{"type":"append_mnemonic","payload":{"cardId":"string","text":"string"}}');
+    expect(prompt.userPrompt).toContain('{"type":"add_inbox_note","payload":{"text":"string"}}');
     expect(prompt.userPrompt).toContain('"cardId": "card-1"');
     expect(prompt.userPrompt).toContain('"cardId": "card-2"');
     expect(prompt.userPrompt).toContain('ask a clarifying question instead of guessing');
     expect(prompt.userPrompt).toContain('Use the exact cardId from the workspace data');
+    expect(prompt.userPrompt).toContain('Keep payload.text short, note-like');
   });
 
   it('includes card-library list state and snapshot data for card-library chat contexts', () => {
     const canonicalContext: CanonicalChatContext = {
       contextType: 'card_library_list',
       languageId: 'zh',
-      allowedSuggestionTypes: ['create_group'],
+      allowedSuggestionTypes: ['add_inbox_note', 'create_group'],
       listState: {
         searchText: 'train',
         groupFilters: [{ groupId: 'group-1', groupName: 'Travel' }],
@@ -85,7 +87,7 @@ describe('buildStructuredChatPrompt', () => {
     const prompt = buildStructuredChatPrompt({
       canonicalContext,
       userInput: 'What should I study first from this list?',
-      allowedSuggestionTypes: ['create_group'],
+      allowedSuggestionTypes: ['add_inbox_note', 'create_group'],
     });
 
     expect(prompt.userPrompt).toContain('"contextType": "card_library_list"');
@@ -93,13 +95,14 @@ describe('buildStructuredChatPrompt', () => {
     expect(prompt.userPrompt).toContain('"groupName": "Travel"');
     expect(prompt.userPrompt).toContain('"selectedCardIds": [');
     expect(prompt.userPrompt).toContain('"content": "火车"');
+    expect(prompt.userPrompt).toContain('{"type":"add_inbox_note","payload":{"text":"string"}}');
   });
 
   it('includes exact ID guidance for group-management suggestion types', () => {
     const canonicalContext: CanonicalChatContext = {
       contextType: 'group_detail',
       languageId: 'zh',
-      allowedSuggestionTypes: ['create_group', 'add_card_to_group', 'remove_card_from_group'],
+      allowedSuggestionTypes: ['add_inbox_note', 'create_group', 'add_card_to_group', 'remove_card_from_group'],
       group: {
         groupId: 'group-current',
         groupName: 'Travel',
@@ -138,9 +141,10 @@ describe('buildStructuredChatPrompt', () => {
     const prompt = buildStructuredChatPrompt({
       canonicalContext,
       userInput: 'Put this card into Favorites too',
-      allowedSuggestionTypes: ['create_group', 'add_card_to_group', 'remove_card_from_group'],
+      allowedSuggestionTypes: ['add_inbox_note', 'create_group', 'add_card_to_group', 'remove_card_from_group'],
     });
 
+    expect(prompt.userPrompt).toContain('{"type":"add_inbox_note","payload":{"text":"string"}}');
     expect(prompt.userPrompt).toContain('{"type":"create_group","payload":{"name":"string","description":"string | null"}}');
     expect(prompt.userPrompt).toContain('{"type":"add_card_to_group","payload":{"cardId":"string","groupId":"string"}}');
     expect(prompt.userPrompt).toContain('{"type":"remove_card_from_group","payload":{"cardId":"string","groupId":"string"}}');
@@ -148,18 +152,18 @@ describe('buildStructuredChatPrompt', () => {
     expect(prompt.userPrompt).toContain('set description to null when no description is needed');
   });
 
-  it('makes clear that study-language help is still allowed when no suggestions are available', () => {
+  it('makes clear that study-language help is still allowed when only inbox-note suggestions are available', () => {
     const canonicalContext: CanonicalChatContext = {
       contextType: 'non_actionable',
       routeContextType: 'card-review',
       languageId: 'zh',
-      allowedSuggestionTypes: [],
+      allowedSuggestionTypes: ['add_inbox_note'],
     };
 
     const prompt = buildStructuredChatPrompt({
       canonicalContext,
       userInput: 'Why is 了 used here?',
-      allowedSuggestionTypes: [],
+      allowedSuggestionTypes: ['add_inbox_note'],
     });
 
     expect(prompt.systemPrompt).toContain(
@@ -168,6 +172,7 @@ describe('buildStructuredChatPrompt', () => {
     expect(prompt.userPrompt).toContain(
       'Suggestions are only for typed app actions. They do not limit normal study-language help.',
     );
-    expect(prompt.userPrompt).toContain('Allowed suggestion types: none.');
+    expect(prompt.userPrompt).toContain('Allowed suggestion types: add_inbox_note.');
+    expect(prompt.userPrompt).toContain('Never assume add_inbox_note creates anything automatically');
   });
 });

--- a/apps/web/src/lib/server/ai-prompts/chat.ts
+++ b/apps/web/src/lib/server/ai-prompts/chat.ts
@@ -22,6 +22,10 @@ function buildResponseShapeInstruction(allowedSuggestionTypes: readonly ChatSugg
     suggestionExamples.push('{"type":"append_mnemonic","payload":{"cardId":"string","text":"string"}}');
   }
 
+  if (allowedSuggestionTypes.includes('add_inbox_note')) {
+    suggestionExamples.push('{"type":"add_inbox_note","payload":{"text":"string"}}');
+  }
+
   if (allowedSuggestionTypes.includes('create_group')) {
     suggestionExamples.push('{"type":"create_group","payload":{"name":"string","description":"string | null"}}');
   }
@@ -61,6 +65,13 @@ function buildSuggestionGuidance(allowedSuggestionTypes: readonly ChatSuggestion
 
   if (allowedSuggestionTypes.includes('create_group')) {
     guidance.push('For create_group suggestions, set description to null when no description is needed.');
+  }
+
+  if (allowedSuggestionTypes.includes('add_inbox_note')) {
+    guidance.push(
+      'Use add_inbox_note only for durable, study-worthy future review items. Keep payload.text short, note-like, and ready to save directly to the active language inbox.',
+    );
+    guidance.push('Never assume add_inbox_note creates anything automatically; it is only a suggestion until the user accepts it.');
   }
 
   return guidance;

--- a/apps/web/src/lib/server/chat-context.test.ts
+++ b/apps/web/src/lib/server/chat-context.test.ts
@@ -20,7 +20,7 @@ describe('resolveCanonicalChatContext', () => {
     );
 
     expect(context.contextType).toBe('non_actionable');
-    expect(context.allowedSuggestionTypes).toEqual([]);
+    expect(context.allowedSuggestionTypes).toEqual(['add_inbox_note']);
   });
 
   it('includes the languageId and routeContextType in non-actionable context', async () => {
@@ -37,6 +37,7 @@ describe('resolveCanonicalChatContext', () => {
     if (context.contextType === 'non_actionable') {
       expect(context.languageId).toBe('zh');
       expect(context.routeContextType).toBe('translation-drills');
+      expect(context.allowedSuggestionTypes).toEqual(['add_inbox_note']);
     }
   });
 
@@ -116,7 +117,7 @@ describe('resolveCanonicalChatContext', () => {
     expect(context).toMatchObject({
       contextType: 'card_library_list',
       languageId: 'es',
-      allowedSuggestionTypes: ['create_group'],
+      allowedSuggestionTypes: ['add_inbox_note', 'create_group'],
       listState: {
         searchText: 'tra',
         groupFilters: [{ groupId: 'group-1', groupName: 'Travel' }],
@@ -164,7 +165,7 @@ describe('resolveCanonicalChatContext', () => {
     expect(context).toMatchObject({
       contextType: 'groups_list',
       languageId: 'es',
-      allowedSuggestionTypes: ['create_group'],
+      allowedSuggestionTypes: ['add_inbox_note', 'create_group'],
       listState: {
         scope: 'all_groups_for_language',
         ordering: 'group_name_asc',
@@ -234,7 +235,7 @@ describe('resolveCanonicalChatContext', () => {
     expect(context).toMatchObject({
       contextType: 'group_detail',
       languageId: 'es',
-      allowedSuggestionTypes: ['create_group', 'add_card_to_group', 'remove_card_from_group'],
+      allowedSuggestionTypes: ['add_inbox_note', 'create_group', 'add_card_to_group', 'remove_card_from_group'],
       group: {
         groupId: 'group-1',
         groupName: 'Greetings',
@@ -316,7 +317,7 @@ describe('resolveCanonicalChatContext', () => {
     expect(context).toMatchObject({
       contextType: 'add_cards_to_group_drawer',
       languageId: 'es',
-      allowedSuggestionTypes: ['add_card_to_group'],
+      allowedSuggestionTypes: ['add_inbox_note', 'add_card_to_group'],
       group: {
         groupId: 'group-1',
         groupName: 'Greetings',
@@ -403,6 +404,7 @@ describe('resolveCanonicalChatContext', () => {
       allowedSuggestionTypes: [
         'append_example_sentence',
         'append_mnemonic',
+        'add_inbox_note',
         'add_card_to_group',
         'remove_card_from_group',
       ],
@@ -458,7 +460,7 @@ describe('getAllowedSuggestionTypes', () => {
       },
     );
 
-    expect(getAllowedSuggestionTypes(context)).toEqual(['create_group']);
+    expect(getAllowedSuggestionTypes(context)).toEqual(['add_inbox_note', 'create_group']);
   });
 
   it('returns drawer suggestion types for card-detail drawer context', async () => {
@@ -498,6 +500,7 @@ describe('getAllowedSuggestionTypes', () => {
     expect(getAllowedSuggestionTypes(context)).toEqual([
       'append_example_sentence',
       'append_mnemonic',
+      'add_inbox_note',
       'add_card_to_group',
       'remove_card_from_group',
     ]);
@@ -505,11 +508,45 @@ describe('getAllowedSuggestionTypes', () => {
 });
 
 describe('areChatSuggestionsValidForContext', () => {
+  it('accepts add_inbox_note suggestions whenever the active language is known', () => {
+    const actionableContext = {
+      contextType: 'non_actionable',
+      routeContextType: 'card-review',
+      languageId: 'es',
+      allowedSuggestionTypes: ['add_inbox_note'],
+    } as Awaited<ReturnType<typeof resolveCanonicalChatContext>>;
+
+    expect(
+      areChatSuggestionsValidForContext(actionableContext, [
+        {
+          type: 'add_inbox_note',
+          payload: { text: 'Know when to use hablar vs conversar' },
+        },
+      ]),
+    ).toBe(true);
+
+    const noLanguageContext = {
+      contextType: 'non_actionable',
+      routeContextType: 'settings',
+      languageId: null,
+      allowedSuggestionTypes: [],
+    } as Awaited<ReturnType<typeof resolveCanonicalChatContext>>;
+
+    expect(
+      areChatSuggestionsValidForContext(noLanguageContext, [
+        {
+          type: 'add_inbox_note',
+          payload: { text: 'Review a future point' },
+        },
+      ]),
+    ).toBe(false);
+  });
+
   it('accepts only in-scope group-management suggestions for group detail context', () => {
     const context = {
       contextType: 'group_detail',
       languageId: 'es',
-      allowedSuggestionTypes: ['create_group', 'add_card_to_group', 'remove_card_from_group'],
+      allowedSuggestionTypes: ['add_inbox_note', 'create_group', 'add_card_to_group', 'remove_card_from_group'],
       group: {
         groupId: 'group-1',
         groupName: 'Greetings',

--- a/apps/web/src/lib/server/chat-context.ts
+++ b/apps/web/src/lib/server/chat-context.ts
@@ -41,7 +41,7 @@ export type CardEntryNoteWorkspaceContext = {
   noteContent: string;
   likelyTargetCardId: string | null;
   likelyTargetFocusedField: string | null;
-  allowedSuggestionTypes: readonly ChatSuggestionType[];
+  allowedSuggestionTypes: readonly ['append_example_sentence', 'append_mnemonic', 'add_inbox_note'];
   exampleSentenceFormat: CardEntryExampleSentenceFormat;
   exampleSentenceFormatInstruction: string;
   draftCards: NoteWorkspaceDraftCardSummary[];
@@ -76,7 +76,7 @@ export type ChatGroupReference = {
 export type CardLibraryListContext = {
   contextType: 'card_library_list';
   languageId: string;
-  allowedSuggestionTypes: readonly ['create_group'];
+  allowedSuggestionTypes: readonly ['add_inbox_note', 'create_group'];
   listState: {
     searchText: string;
     groupFilters: CardLibraryGroupData[];
@@ -92,7 +92,7 @@ export type CardLibraryListContext = {
 export type GroupsListContext = {
   contextType: 'groups_list';
   languageId: string;
-  allowedSuggestionTypes: readonly ['create_group'];
+  allowedSuggestionTypes: readonly ['add_inbox_note', 'create_group'];
   listState: {
     scope: 'all_groups_for_language';
     ordering: 'group_name_asc';
@@ -104,7 +104,7 @@ export type GroupsListContext = {
 export type GroupDetailContext = {
   contextType: 'group_detail';
   languageId: string;
-  allowedSuggestionTypes: readonly ['create_group', 'add_card_to_group', 'remove_card_from_group'];
+  allowedSuggestionTypes: readonly ['add_inbox_note', 'create_group', 'add_card_to_group', 'remove_card_from_group'];
   group: ChatGroupSnapshot;
   availableGroupsForAddition: ChatGroupReference[];
   listState: {
@@ -122,7 +122,7 @@ export type GroupDetailContext = {
 export type AddCardsToGroupDrawerContext = {
   contextType: 'add_cards_to_group_drawer';
   languageId: string;
-  allowedSuggestionTypes: readonly ['add_card_to_group'];
+  allowedSuggestionTypes: readonly ['add_inbox_note', 'add_card_to_group'];
   group: ChatGroupSnapshot;
   listState: {
     searchText: string;
@@ -142,6 +142,7 @@ export type CardDetailDrawerContext = {
   allowedSuggestionTypes: readonly [
     'append_example_sentence',
     'append_mnemonic',
+    'add_inbox_note',
     'add_card_to_group',
     'remove_card_from_group',
   ];
@@ -158,7 +159,7 @@ export type NonActionableContext = {
   contextType: 'non_actionable';
   routeContextType: RouteContext['routeContextType'];
   languageId: string | null;
-  allowedSuggestionTypes: readonly [];
+  allowedSuggestionTypes: readonly ['add_inbox_note'] | readonly [];
 };
 
 export type CanonicalChatContext =
@@ -336,7 +337,7 @@ async function resolveCardEntryNoteWorkspaceContext(
     noteContent: workspace.note.content,
     likelyTargetCardId,
     likelyTargetFocusedField: likelyTargetCardId ? hint.focusedField ?? null : null,
-    allowedSuggestionTypes: ['append_example_sentence', 'append_mnemonic'],
+    allowedSuggestionTypes: ['append_example_sentence', 'append_mnemonic', 'add_inbox_note'],
     exampleSentenceFormat,
     exampleSentenceFormatInstruction: buildCardEntryExampleSentenceFormatInstruction({
       exampleSentenceFormat,
@@ -370,7 +371,7 @@ async function resolveCardLibraryListContext(
   return {
     contextType: 'card_library_list',
     languageId,
-    allowedSuggestionTypes: ['create_group'],
+    allowedSuggestionTypes: ['add_inbox_note', 'create_group'],
     listState: {
       searchText: library.filters.searchText,
       groupFilters,
@@ -395,7 +396,7 @@ async function resolveGroupsListContext(
   return {
     contextType: 'groups_list',
     languageId,
-    allowedSuggestionTypes: ['create_group'],
+    allowedSuggestionTypes: ['add_inbox_note', 'create_group'],
     listState: {
       scope: 'all_groups_for_language',
       ordering: 'group_name_asc',
@@ -424,7 +425,7 @@ async function resolveGroupDetailContext(
   return {
     contextType: 'group_detail',
     languageId,
-    allowedSuggestionTypes: ['create_group', 'add_card_to_group', 'remove_card_from_group'],
+    allowedSuggestionTypes: ['add_inbox_note', 'create_group', 'add_card_to_group', 'remove_card_from_group'],
     group: buildGroupSnapshot(groupDetail.group),
     availableGroupsForAddition: groupDetail.cards.availableGroups
       .filter((group) => group.groupId !== groupDetail.group.groupId)
@@ -462,7 +463,7 @@ async function resolveAddCardsToGroupDrawerContext(
   return {
     contextType: 'add_cards_to_group_drawer',
     languageId,
-    allowedSuggestionTypes: ['add_card_to_group'],
+    allowedSuggestionTypes: ['add_inbox_note', 'add_card_to_group'],
     group: buildGroupSnapshot(groupDetail.group),
     listState: {
       searchText: surfaceContext.searchText.trim(),
@@ -521,12 +522,13 @@ async function resolveCardDetailDrawerContext(
   return {
     contextType: 'card_detail_drawer',
     languageId,
-    allowedSuggestionTypes: [
-      'append_example_sentence',
-      'append_mnemonic',
-      'add_card_to_group',
-      'remove_card_from_group',
-    ],
+      allowedSuggestionTypes: [
+        'append_example_sentence',
+        'append_mnemonic',
+        'add_inbox_note',
+        'add_card_to_group',
+        'remove_card_from_group',
+      ],
     sourceSurface: surfaceContext.sourceSurface,
     likelyTargetCardId: activeCard.card.cardId,
     likelyTargetFocusedField: hint.focusedField ?? null,
@@ -548,7 +550,7 @@ function resolveNonActionableContext(
     contextType: 'non_actionable',
     routeContextType: hint.routeContext.routeContextType,
     languageId: hint.languageId ?? null,
-    allowedSuggestionTypes: [],
+    allowedSuggestionTypes: hint.languageId ? ['add_inbox_note'] : [],
   };
 }
 
@@ -763,6 +765,8 @@ export function areChatSuggestionsValidForContext(
         }
 
         return false;
+      case 'add_inbox_note':
+        return context.languageId !== null;
       case 'create_group':
         return isCreateGroupSuggestionValid(context);
       case 'add_card_to_group':

--- a/apps/web/src/lib/server/chat.test.ts
+++ b/apps/web/src/lib/server/chat.test.ts
@@ -108,9 +108,12 @@ describe('handleStudyPuckChatRequest', () => {
     expect(generateStructured).not.toHaveBeenCalled();
   });
 
-  it('passes no allowed suggestion types for non-actionable card review context', async () => {
+  it('passes inbox-note suggestion allowance for non-actionable card review context', async () => {
     const generateStructured = vi.fn(async (request: { responseSchema: { parse: (value: unknown) => unknown } }) =>
-      request.responseSchema.parse({ message: 'Hello from card review.' }),
+      request.responseSchema.parse({
+        message: 'That is worth revisiting later.',
+        suggestions: [{ type: 'add_inbox_note', payload: { text: 'Review ser vs estar triggers' } }],
+      }),
     );
 
     const response = await handleStudyPuckChatRequest({
@@ -122,8 +125,9 @@ describe('handleStudyPuckChatRequest', () => {
       generateStructured,
     });
 
-    // Card Review is non-actionable in the current implementation – no suggestions
-    expect(response.suggestions).toEqual([]);
+    expect(response.suggestions).toEqual([
+      { type: 'add_inbox_note', payload: { text: 'Review ser vs estar triggers' } },
+    ]);
     expect(generateStructured).toHaveBeenCalledWith(
       expect.objectContaining({
         userPrompt: expect.stringContaining('"contextType": "non_actionable"'),
@@ -145,13 +149,13 @@ describe('handleStudyPuckChatRequest', () => {
       routeContext: resolveRouteContext('/es/card-entry'),
       languageId: 'es',
       noteId: 'note-1',
-        cardId: 'card-1',
-        privateEnv: {},
-        generateStructured,
-      });
+      cardId: 'card-1',
+      privateEnv: {},
+      generateStructured,
+    });
 
-    // Without a database the context resolver cannot load the note workspace, so no
-    // actionable suggestion types are allowed.
+    // Without a database the context resolver cannot load the note workspace, but
+    // the active language still allows inbox-note suggestions.
     expect(response.suggestions).toEqual([]);
     expect(generateStructured).toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
## Summary
- add the typed `add_inbox_note` chat suggestion with minimal `{ text }` payload
- allow the suggestion anywhere chat has an active language and validate it against canonical context
- render and execute the suggestion through the existing inbox note creation path
- update prompt guidance and tests for schema, context allowance, prompt construction, and UI execution

Closes #166