### PR TITLE
Build Card Review backend and SRS foundations

### DIFF
--- a/apps/web/src/lib/server/card-review.test.ts
+++ b/apps/web/src/lib/server/card-review.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CardReviewRequestError,
+  type CardReviewLoaderDeps,
+  loadCardReviewHomeData,
+  loadCardReviewSessionData,
+} from './card-review.js';
+
+describe('Card Review server helpers', () => {
+  const database = {} as never;
+
+  const baseDeps = {
+    getActiveUserLanguages: vi.fn(async () => [{
+      userId: 'user-1',
+      languageId: 'zh',
+      languageName: 'Chinese',
+      isActive: true,
+      cefrLevel: null,
+      settings: null,
+      createdAt: null,
+    }]),
+    getCardReviewHomeStats: vi.fn(async () => ({
+      cardsInRotation: 12,
+      dueNowCount: 5,
+      reviewedTodayCount: 2,
+      currentStreakDays: 3,
+      lastReviewedAt: new Date('2026-05-09T12:00:00.000Z'),
+    })),
+    listCardReviewGroupSummaries: vi.fn(async () => [
+      {
+        groupId: 'group-core',
+        groupName: 'Core',
+        activeCardCount: 7,
+        dueCardCount: 3,
+        nextDueAt: null,
+      },
+      {
+        groupId: 'group-extended',
+        groupName: 'Extended',
+        activeCardCount: 5,
+        dueCardCount: 2,
+        nextDueAt: new Date('2026-05-11T12:00:00.000Z'),
+      },
+    ]),
+    listCardReviewSessionCards: vi.fn(async () => [
+      {
+        cardId: 'card-1',
+        content: '补偿',
+        meaning: 'to compensate',
+        cardType: 'word',
+        examples: ['我们以后再补偿这次错过的时间。'],
+        mnemonics: ['compensate later'],
+        llmInstructions: null,
+        updatedAt: new Date('2026-05-01T12:00:00.000Z'),
+        groups: [{ groupId: 'group-core', groupName: 'Core' }],
+        nextDueAt: new Date('2026-05-09T12:00:00.000Z'),
+        intervalDays: 2,
+        easeFactor: 2.5,
+        reviewCount: 1,
+        lastReviewedAt: new Date('2026-05-07T12:00:00.000Z'),
+        state: 'active' as const,
+        snoozedUntil: null,
+      },
+    ]),
+  };
+  const deps = baseDeps as unknown as CardReviewLoaderDeps;
+
+  it('loads card review home data with parsed selection and preview totals', async () => {
+    const url = new URL('https://studypuck.test/zh/card-review?group=group-core&group=group-extended&limit=10');
+
+    const result = await loadCardReviewHomeData('user-1', 'zh', url, database, deps);
+
+    expect(result.selection).toEqual({
+      groupIds: ['group-core', 'group-extended'],
+      limit: 10,
+      countMode: 'limit',
+    });
+    expect(result.stats).toEqual({
+      cardsInRotation: 12,
+      dueNowCount: 5,
+      reviewedTodayCount: 2,
+      currentStreakDays: 3,
+      lastReviewedAtIso: '2026-05-09T12:00:00.000Z',
+    });
+    expect(result.sessionPreview).toEqual({
+      selectedGroupCount: 2,
+      selectedDueCount: 5,
+      nextDueAtIso: '2026-05-11T12:00:00.000Z',
+    });
+  });
+
+  it('loads card review session data from the parsed URL state', async () => {
+    const url = new URL('https://studypuck.test/zh/card-review/session?group=group-core&limit=5');
+
+    const result = await loadCardReviewSessionData('user-1', 'zh', url, database, deps);
+
+    expect(baseDeps.listCardReviewSessionCards).toHaveBeenCalledWith(
+      'user-1',
+      'zh',
+      {
+        groupIds: ['group-core'],
+        limit: 5,
+      },
+      database,
+    );
+    expect(result.items[0]).toMatchObject({
+      cardId: 'card-1',
+      nextDueAtIso: '2026-05-09T12:00:00.000Z',
+    });
+  });
+
+  it('rejects invalid session input before hitting the data layer', async () => {
+    const url = new URL('https://studypuck.test/zh/card-review/session?group=group-core&limit=0');
+
+    await expect(loadCardReviewSessionData('user-1', 'zh', url, database, deps)).rejects.toMatchObject({
+      status: 400,
+    } satisfies Partial<CardReviewRequestError>);
+  });
+
+  it('requires at least one selected group before loading a review session', async () => {
+    const url = new URL('https://studypuck.test/zh/card-review/session');
+
+    await expect(loadCardReviewSessionData('user-1', 'zh', url, database, deps)).rejects.toMatchObject({
+      status: 400,
+      message: 'Select at least one group before starting a review session.',
+    } satisfies Partial<CardReviewRequestError>);
+  });
+
+  it('returns 404 when the requested language is not active for the user', async () => {
+    baseDeps.getActiveUserLanguages.mockResolvedValueOnce([]);
+    const url = new URL('https://studypuck.test/ja/card-review');
+
+    await expect(loadCardReviewHomeData('user-1', 'ja', url, database, deps)).rejects.toMatchObject({
+      status: 404,
+    } satisfies Partial<CardReviewRequestError>);
+  });
+});

--- a/apps/web/src/lib/server/card-review.ts
+++ b/apps/web/src/lib/server/card-review.ts
@@ -1,0 +1,256 @@
+import {
+  getActiveUserLanguages,
+  getCardReviewHomeStats,
+  getDb,
+  listCardReviewGroupSummaries,
+  listCardReviewSessionCards,
+  type CardReviewGroupSummary,
+  type CardReviewHomeStats,
+  type CardReviewQueueItem,
+} from '@studypuck/database';
+import { z } from 'zod';
+import { activeGroupIdSchema } from '$lib/schemas/cards.js';
+
+type DatabaseClient = ReturnType<typeof getDb>;
+
+export type CardReviewLoaderDeps = {
+  getActiveUserLanguages: typeof getActiveUserLanguages;
+  getCardReviewHomeStats: typeof getCardReviewHomeStats;
+  listCardReviewGroupSummaries: typeof listCardReviewGroupSummaries;
+  listCardReviewSessionCards: typeof listCardReviewSessionCards;
+};
+
+const defaultLoaderDeps: CardReviewLoaderDeps = {
+  getActiveUserLanguages,
+  getCardReviewHomeStats,
+  listCardReviewGroupSummaries,
+  listCardReviewSessionCards,
+};
+
+const cardReviewSessionLimitSchema = z.coerce.number().int().min(1, 'Session size must be at least 1 card.').max(100, 'Session size must be 100 cards or fewer.');
+
+export class CardReviewRequestError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'CardReviewRequestError';
+    this.status = status;
+  }
+}
+
+export type CardReviewSessionSelection = {
+  groupIds: string[];
+  limit: number | null;
+  countMode: 'all_due' | 'limit';
+};
+
+export type CardReviewGroupSummaryData = {
+  groupId: string;
+  groupName: string;
+  activeCardCount: number;
+  dueCardCount: number;
+  nextDueAtIso: string | null;
+};
+
+export type CardReviewHomeData = {
+  stats: {
+    cardsInRotation: number;
+    dueNowCount: number;
+    reviewedTodayCount: number;
+    currentStreakDays: number;
+    lastReviewedAtIso: string | null;
+  };
+  groups: CardReviewGroupSummaryData[];
+  selection: CardReviewSessionSelection;
+  sessionPreview: {
+    selectedGroupCount: number;
+    selectedDueCount: number;
+    nextDueAtIso: string | null;
+  };
+};
+
+export type CardReviewSessionItemData = {
+  cardId: string;
+  content: string;
+  meaning: string | null;
+  cardType: string | null;
+  examples: string[];
+  mnemonics: string[];
+  llmInstructions: string | null;
+  updatedAtIso: string | null;
+  groups: Array<{ groupId: string; groupName: string }>;
+  nextDueAtIso: string | null;
+  intervalDays: number;
+  easeFactor: number;
+  reviewCount: number;
+  lastReviewedAtIso: string | null;
+  state: 'active' | 'snoozed' | 'disabled';
+  snoozedUntilIso: string | null;
+};
+
+export type CardReviewSessionData = {
+  selection: CardReviewSessionSelection;
+  totalCount: number;
+  items: CardReviewSessionItemData[];
+};
+
+async function assertUserHasLanguage(
+  userId: string,
+  languageId: string,
+  database: DatabaseClient,
+  deps: Pick<CardReviewLoaderDeps, 'getActiveUserLanguages'> = defaultLoaderDeps,
+): Promise<void> {
+  const activeLanguages = await deps.getActiveUserLanguages(userId, database as never);
+  const languageExists = activeLanguages.some((language) => language.languageId === languageId);
+
+  if (!languageExists) {
+    throw new CardReviewRequestError(404, 'That language is not available for this user.');
+  }
+}
+
+function parseSessionSelection(url: URL): CardReviewSessionSelection {
+  const groupIds = [...new Set(url.searchParams.getAll('group').map((groupId) => {
+    const parsed = activeGroupIdSchema.safeParse(groupId);
+
+    if (!parsed.success) {
+      throw new CardReviewRequestError(400, parsed.error.issues[0]?.message ?? 'Group identifier is invalid.');
+    }
+
+    return parsed.data;
+  }))];
+
+  const rawLimit = url.searchParams.get('limit');
+  const limit = rawLimit === null || rawLimit.trim().length === 0
+    ? null
+    : (() => {
+      const parsed = cardReviewSessionLimitSchema.safeParse(rawLimit);
+
+      if (!parsed.success) {
+        throw new CardReviewRequestError(400, parsed.error.issues[0]?.message ?? 'Session size is invalid.');
+      }
+
+      return parsed.data;
+    })();
+
+  return {
+    groupIds,
+    limit,
+    countMode: limit === null ? 'all_due' : 'limit',
+  };
+}
+
+function toIsoString(date: Date | null): string | null {
+  return date ? date.toISOString() : null;
+}
+
+function mapHomeStats(stats: CardReviewHomeStats) {
+  return {
+    cardsInRotation: stats.cardsInRotation,
+    dueNowCount: stats.dueNowCount,
+    reviewedTodayCount: stats.reviewedTodayCount,
+    currentStreakDays: stats.currentStreakDays,
+    lastReviewedAtIso: toIsoString(stats.lastReviewedAt),
+  };
+}
+
+function mapGroupSummary(group: CardReviewGroupSummary): CardReviewGroupSummaryData {
+  return {
+    groupId: group.groupId,
+    groupName: group.groupName,
+    activeCardCount: group.activeCardCount,
+    dueCardCount: group.dueCardCount,
+    nextDueAtIso: toIsoString(group.nextDueAt),
+  };
+}
+
+function mapSessionItem(item: CardReviewQueueItem): CardReviewSessionItemData {
+  return {
+    cardId: item.cardId,
+    content: item.content,
+    meaning: item.meaning,
+    cardType: item.cardType,
+    examples: item.examples,
+    mnemonics: item.mnemonics,
+    llmInstructions: item.llmInstructions,
+    updatedAtIso: toIsoString(item.updatedAt),
+    groups: item.groups,
+    nextDueAtIso: toIsoString(item.nextDueAt),
+    intervalDays: item.intervalDays,
+    easeFactor: item.easeFactor,
+    reviewCount: item.reviewCount,
+    lastReviewedAtIso: toIsoString(item.lastReviewedAt),
+    state: item.state,
+    snoozedUntilIso: toIsoString(item.snoozedUntil),
+  };
+}
+
+function findNextDue(groups: CardReviewGroupSummary[]): string | null {
+  const nextDueAt = groups.reduce<Date | null>((soonest, group) => {
+    if (!group.nextDueAt) {
+      return soonest;
+    }
+
+    return soonest === null || group.nextDueAt < soonest ? group.nextDueAt : soonest;
+  }, null);
+
+  return toIsoString(nextDueAt);
+}
+
+export async function loadCardReviewHomeData(
+  userId: string,
+  languageId: string,
+  url: URL,
+  database: DatabaseClient,
+  deps: CardReviewLoaderDeps = defaultLoaderDeps,
+): Promise<CardReviewHomeData> {
+  await assertUserHasLanguage(userId, languageId, database, deps);
+
+  const selection = parseSessionSelection(url);
+  const [stats, groups] = await Promise.all([
+    deps.getCardReviewHomeStats(userId, languageId, {}, database as never),
+    deps.listCardReviewGroupSummaries(userId, languageId, {}, database as never),
+  ]);
+
+  const selectedGroups = selection.groupIds.length === 0
+    ? []
+    : groups.filter((group) => selection.groupIds.includes(group.groupId));
+
+  return {
+    stats: mapHomeStats(stats),
+    groups: groups.map((group) => mapGroupSummary(group)),
+    selection,
+    sessionPreview: {
+      selectedGroupCount: selectedGroups.length,
+      selectedDueCount: selectedGroups.reduce((count, group) => count + group.dueCardCount, 0),
+      nextDueAtIso: findNextDue(selectedGroups),
+    },
+  };
+}
+
+export async function loadCardReviewSessionData(
+  userId: string,
+  languageId: string,
+  url: URL,
+  database: DatabaseClient,
+  deps: CardReviewLoaderDeps = defaultLoaderDeps,
+): Promise<CardReviewSessionData> {
+  await assertUserHasLanguage(userId, languageId, database, deps);
+
+  const selection = parseSessionSelection(url);
+
+  if (selection.groupIds.length === 0) {
+    throw new CardReviewRequestError(400, 'Select at least one group before starting a review session.');
+  }
+
+  const items = await deps.listCardReviewSessionCards(userId, languageId, {
+    groupIds: selection.groupIds,
+    limit: selection.limit,
+  }, database as never);
+
+  return {
+    selection,
+    totalCount: items.length,
+    items: items.map((item) => mapSessionItem(item)),
+  };
+}

--- a/packages/database/migrations/0008_oval_metal_master.sql
+++ b/packages/database/migrations/0008_oval_metal_master.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "card_review_events" (
+	"event_id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"language_id" text NOT NULL,
+	"card_id" text NOT NULL,
+	"event_type" text NOT NULL,
+	"rating" text,
+	"previous_state" text,
+	"next_state" text,
+	"previous_interval_days" integer,
+	"next_interval_days" integer,
+	"previous_due" integer,
+	"next_due" integer,
+	"occurred_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"metadata" jsonb
+);
+--> statement-breakpoint
+ALTER TABLE "inbox_notes" ALTER COLUMN "ai_state" SET DEFAULT 'queued';--> statement-breakpoint
+ALTER TABLE "card_review_srs" ADD COLUMN "state" text DEFAULT 'active' NOT NULL;--> statement-breakpoint
+ALTER TABLE "card_review_srs" ADD COLUMN "snoozed_until" timestamp with time zone;--> statement-breakpoint
+CREATE INDEX "idx_card_review_events_card_timeline" ON "card_review_events" USING btree ("user_id","language_id","card_id","occurred_at");--> statement-breakpoint
+CREATE INDEX "idx_card_review_events_type" ON "card_review_events" USING btree ("user_id","language_id","event_type");--> statement-breakpoint
+CREATE INDEX "idx_card_review_srs_state" ON "card_review_srs" USING btree ("user_id","language_id","state");

--- a/packages/database/migrations/meta/0008_snapshot.json
+++ b/packages/database/migrations/meta/0008_snapshot.json
@@ -1,0 +1,2018 @@
+{
+  "id": "fc7e30ec-d741-46ed-b88b-32b5e1153b56",
+  "prevId": "f07d7350-3fd3-41dd-8af3-ee14fa94f26f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.study_languages": {
+      "name": "study_languages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_name": {
+          "name": "language_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "cefr_level": {
+          "name": "cefr_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'A1'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "study_languages_user_id_language_id_pk": {
+          "name": "study_languages_user_id_language_id_pk",
+          "columns": [
+            "user_id",
+            "language_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.card_groups": {
+      "name": "card_groups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_card_groups_by_group": {
+          "name": "idx_card_groups_by_group",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_card_groups_by_card": {
+          "name": "idx_card_groups_by_card",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "card_groups_user_id_language_id_card_id_group_id_pk": {
+          "name": "card_groups_user_id_language_id_card_id_group_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "card_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cards": {
+      "name": "cards",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "card_type": {
+          "name": "card_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'word'"
+        },
+        "meaning": {
+          "name": "meaning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "examples": {
+          "name": "examples",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mnemonics": {
+          "name": "mnemonics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llm_instructions": {
+          "name": "llm_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_generated_at": {
+          "name": "embedding_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cards_status_type": {
+          "name": "idx_cards_status_type",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "card_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cards_status_updated": {
+          "name": "idx_cards_status_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cards_embedding_similarity": {
+          "name": "idx_cards_embedding_similarity",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "idx_cards_active_type": {
+          "name": "idx_cards_active_type",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "card_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cards_active_updated": {
+          "name": "idx_cards_active_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cards_fulltext": {
+          "name": "idx_cards_fulltext",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"content\" || ' ' || COALESCE(\"meaning\", '') || ' ' || COALESCE(\"examples\"::text, '') || ' ' || COALESCE(\"mnemonics\"::text, ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_cards_fulltext_simple": {
+          "name": "idx_cards_fulltext_simple",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', \"content\" || ' ' || COALESCE(\"meaning\", '') || ' ' || COALESCE(\"examples\"::text, '') || ' ' || COALESCE(\"mnemonics\"::text, ''))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "cards_user_id_language_id_card_id_pk": {
+          "name": "cards_user_id_language_id_card_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "card_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_generated_at": {
+          "name": "embedding_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_groups_embedding_similarity": {
+          "name": "idx_groups_embedding_similarity",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "groups_user_id_language_id_group_id_pk": {
+          "name": "groups_user_id_language_id_group_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.card_entry_daily_stats": {
+      "name": "card_entry_daily_stats",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes_captured": {
+          "name": "notes_captured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "notes_processed": {
+          "name": "notes_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "notes_deferred": {
+          "name": "notes_deferred",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "notes_deleted": {
+          "name": "notes_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "draft_cards_created": {
+          "name": "draft_cards_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_promoted_to_active": {
+          "name": "cards_promoted_to_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "groups_created": {
+          "name": "groups_created",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_card_entry_stats_date": {
+          "name": "idx_card_entry_stats_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "card_entry_daily_stats_user_id_language_id_date_pk": {
+          "name": "card_entry_daily_stats_user_id_language_id_date_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_notes": {
+      "name": "inbox_notes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'unprocessed'"
+        },
+        "ai_state": {
+          "name": "ai_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'queued'"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'manual'"
+        },
+        "source_metadata": {
+          "name": "source_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_inbox_state": {
+          "name": "idx_inbox_state",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbox_ai_state": {
+          "name": "idx_inbox_ai_state",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ai_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbox_source": {
+          "name": "idx_inbox_source",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inbox_notes_user_id_language_id_note_id_pk": {
+          "name": "inbox_notes_user_id_language_id_note_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "note_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.note_card_links": {
+      "name": "note_card_links",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_note_card_links_note": {
+          "name": "idx_note_card_links_note",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_note_card_links_card": {
+          "name": "idx_note_card_links_card",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "note_card_links_user_id_language_id_note_id_card_id_pk": {
+          "name": "note_card_links_user_id_language_id_note_id_card_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "note_id",
+            "card_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.card_review_daily_stats": {
+      "name": "card_review_daily_stats",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cards_reviewed": {
+          "name": "cards_reviewed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "total_review_time_minutes": {
+          "name": "total_review_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_rated_easy": {
+          "name": "cards_rated_easy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_rated_medium": {
+          "name": "cards_rated_medium",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_rated_hard": {
+          "name": "cards_rated_hard",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_snoozed": {
+          "name": "cards_snoozed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_disabled": {
+          "name": "cards_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_pinned_to_drills": {
+          "name": "cards_pinned_to_drills",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_card_review_stats_date": {
+          "name": "idx_card_review_stats_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "card_review_daily_stats_user_id_language_id_date_pk": {
+          "name": "card_review_daily_stats_user_id_language_id_date_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.card_review_events": {
+      "name": "card_review_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state": {
+          "name": "previous_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_state": {
+          "name": "next_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_interval_days": {
+          "name": "previous_interval_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_interval_days": {
+          "name": "next_interval_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_due": {
+          "name": "previous_due",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_due": {
+          "name": "next_due",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_card_review_events_card_timeline": {
+          "name": "idx_card_review_events_card_timeline",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_card_review_events_type": {
+          "name": "idx_card_review_events_type",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.card_review_srs": {
+      "name": "card_review_srs",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_due": {
+          "name": "next_due",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "interval_days": {
+          "name": "interval_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "ease_factor": {
+          "name": "ease_factor",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2.5
+        },
+        "review_count": {
+          "name": "review_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_reviewed": {
+          "name": "last_reviewed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_card_review_srs_due": {
+          "name": "idx_card_review_srs_due",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_card_review_srs_interval": {
+          "name": "idx_card_review_srs_interval",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "interval_days",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_card_review_srs_state": {
+          "name": "idx_card_review_srs_state",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "card_review_srs_user_id_language_id_card_id_pk": {
+          "name": "card_review_srs_user_id_language_id_card_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "card_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_drill_context": {
+      "name": "translation_drill_context",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "added_from": {
+          "name": "added_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "state_until": {
+          "name": "state_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cefr_override": {
+          "name": "cefr_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_translation_context_state": {
+          "name": "idx_translation_context_state",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_context_added": {
+          "name": "idx_translation_context_added",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "added_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_translation_context_rotation": {
+          "name": "idx_translation_context_rotation",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_used",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "translation_drill_context_user_id_language_id_card_id_pk": {
+          "name": "translation_drill_context_user_id_language_id_card_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "card_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_drill_daily_stats": {
+      "name": "translation_drill_daily_stats",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sentences_translated": {
+          "name": "sentences_translated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "total_session_time_minutes": {
+          "name": "total_session_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_dismissed": {
+          "name": "cards_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_snoozed": {
+          "name": "cards_snoozed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cards_drawn": {
+          "name": "cards_drawn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "new_context_groups_added": {
+          "name": "new_context_groups_added",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_translation_drill_stats_date": {
+          "name": "idx_translation_drill_stats_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "translation_drill_daily_stats_user_id_language_id_date_pk": {
+          "name": "translation_drill_daily_stats_user_id_language_id_date_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_drill_draw_piles": {
+      "name": "translation_drill_draw_piles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "draw_pile_name": {
+          "name": "draw_pile_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pile_size_limit": {
+          "name": "pile_size_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_draw_piles_enabled": {
+          "name": "idx_draw_piles_enabled",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "translation_drill_draw_piles_user_id_language_id_group_id_pk": {
+          "name": "translation_drill_draw_piles_user_id_language_id_group_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_drill_srs": {
+      "name": "translation_drill_srs",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_due": {
+          "name": "next_due",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "interval_days": {
+          "name": "interval_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performance_score": {
+          "name": "performance_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_translation_drill_srs_due": {
+          "name": "idx_translation_drill_srs_due",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "language_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "translation_drill_srs_user_id_language_id_card_id_pk": {
+          "name": "translation_drill_srs_user_id_language_id_card_id_pk",
+          "columns": [
+            "user_id",
+            "language_id",
+            "card_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1776486900000,
       "tag": "0007_repair_cards_schema",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1778384492627,
+      "tag": "0008_oval_metal_master",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -48,6 +48,7 @@
     "./users": "./src/users.ts",
 		"./cards": "./src/cards.ts",
 		"./card-entry": "./src/card-entry.ts",
+		"./card-review": "./src/card-review.ts",
 		"./test-utils": "./src/test-utils.ts"
 	}
 }

--- a/packages/database/src/card-review.ts
+++ b/packages/database/src/card-review.ts
@@ -1,0 +1,908 @@
+import { and, asc, desc, eq, inArray, sql } from 'drizzle-orm';
+import type { PgDatabase } from 'drizzle-orm/pg-core';
+import { db, type TransactionCapableDatabaseConnection } from './index.js';
+import { cards, cardGroups, groups, cardReviewDailyStats, cardReviewEvents, cardReviewSrs } from './schema.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyDb = PgDatabase<any, any, any>;
+
+export type CardReviewRating = 'easy' | 'medium' | 'hard';
+export type CardReviewState = 'active' | 'snoozed' | 'disabled';
+export type CardReviewEventType = 'rated' | 'snoozed' | 'disabled' | 'reactivated' | 'pinned_to_drills';
+
+type ReviewCardRow = {
+  cardId: string;
+  content: string;
+  meaning: string | null;
+  cardType: string | null;
+  examples: unknown;
+  mnemonics: unknown;
+  llmInstructions: string | null;
+  updatedAt: Date | null;
+  nextDue: number | null;
+  intervalDays: number | null;
+  easeFactor: number | null;
+  reviewCount: number | null;
+  lastReviewed: number | null;
+  state: string | null;
+  snoozedUntil: Date | null;
+};
+
+type ReviewGroupRow = {
+  cardId: string;
+  groupId: string;
+  groupName: string;
+};
+
+type ReviewSchedule = {
+  nextDue: number;
+  intervalDays: number;
+  easeFactor: number;
+  reviewCount: number;
+  lastReviewed: number;
+  state: CardReviewState;
+  snoozedUntil: Date | null;
+};
+
+type DailyStatIncrements = {
+  cardsReviewed?: number;
+  totalReviewTimeMinutes?: number;
+  cardsRatedEasy?: number;
+  cardsRatedMedium?: number;
+  cardsRatedHard?: number;
+  cardsSnoozed?: number;
+  cardsDisabled?: number;
+  cardsPinnedToDrills?: number;
+};
+
+export type CardReviewGroupSummary = {
+  groupId: string;
+  groupName: string;
+  activeCardCount: number;
+  dueCardCount: number;
+  nextDueAt: Date | null;
+};
+
+export type CardReviewHomeStats = {
+  cardsInRotation: number;
+  dueNowCount: number;
+  reviewedTodayCount: number;
+  currentStreakDays: number;
+  lastReviewedAt: Date | null;
+};
+
+export type CardReviewQueueItem = {
+  cardId: string;
+  content: string;
+  meaning: string | null;
+  cardType: string | null;
+  examples: string[];
+  mnemonics: string[];
+  llmInstructions: string | null;
+  updatedAt: Date | null;
+  groups: Array<{ groupId: string; groupName: string }>;
+  nextDueAt: Date | null;
+  intervalDays: number;
+  easeFactor: number;
+  reviewCount: number;
+  lastReviewedAt: Date | null;
+  state: CardReviewState;
+  snoozedUntil: Date | null;
+};
+
+export type CardReviewMutationResult = {
+  eventId: string;
+  cardId: string;
+  eventType: CardReviewEventType;
+  rating: CardReviewRating | null;
+  occurredAt: Date;
+  state: CardReviewState;
+  snoozedUntil: Date | null;
+  nextDueAt: Date | null;
+  intervalDays: number | null;
+  easeFactor: number | null;
+  reviewCount: number | null;
+};
+
+function getConn(database?: AnyDb) {
+  return database ?? (db as AnyDb);
+}
+
+function normalizeGroupIds(groupIds?: string[] | null): string[] {
+  return [...new Set((groupIds ?? []).map((groupId) => groupId.trim()).filter(Boolean))];
+}
+
+function createEventId(): string {
+  return `review-event-${globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`}`;
+}
+
+function normalizeStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+}
+
+function toUnixSeconds(date: Date): number {
+  return Math.floor(date.getTime() / 1_000);
+}
+
+function fromUnixSeconds(value: number | null | undefined): Date | null {
+  return typeof value === 'number' ? new Date(value * 1_000) : null;
+}
+
+function toStatsDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function getStoredState(row: Pick<ReviewCardRow, 'state'>): CardReviewState {
+  return (row.state === 'snoozed' || row.state === 'disabled') ? row.state : 'active';
+}
+
+function getEffectiveState(row: Pick<ReviewCardRow, 'state' | 'snoozedUntil'>, now: Date): CardReviewState {
+  if (row.state === 'disabled') {
+    return 'disabled';
+  }
+
+  if (row.state === 'snoozed') {
+    if (row.snoozedUntil && row.snoozedUntil.getTime() <= now.getTime()) {
+      return 'active';
+    }
+
+    return 'snoozed';
+  }
+
+  return 'active';
+}
+
+function isInRotation(row: Pick<ReviewCardRow, 'state' | 'snoozedUntil'>, now: Date): boolean {
+  return getEffectiveState(row, now) === 'active';
+}
+
+function isDueForReview(row: Pick<ReviewCardRow, 'state' | 'snoozedUntil' | 'nextDue'>, now: Date): boolean {
+  if (!isInRotation(row, now)) {
+    return false;
+  }
+
+  const nowSeconds = toUnixSeconds(now);
+  return row.nextDue === null || row.nextDue <= nowSeconds;
+}
+
+function getNextUpcomingDueSeconds(
+  row: Pick<ReviewCardRow, 'state' | 'snoozedUntil' | 'nextDue'>,
+  now: Date,
+): number | null {
+  if (row.state === 'disabled') {
+    return null;
+  }
+
+  const nowSeconds = toUnixSeconds(now);
+  const nextDue = row.nextDue;
+  const snoozedUntilSeconds = row.snoozedUntil ? toUnixSeconds(row.snoozedUntil) : null;
+
+  if (row.state === 'snoozed' && snoozedUntilSeconds !== null && snoozedUntilSeconds > nowSeconds) {
+    return Math.max(nextDue ?? 0, snoozedUntilSeconds);
+  }
+
+  if (typeof nextDue !== 'number' || nextDue <= nowSeconds) {
+    return null;
+  }
+
+  return nextDue;
+}
+
+function computeNextReviewSchedule(
+  row: Pick<ReviewCardRow, 'intervalDays' | 'easeFactor' | 'reviewCount'> | null,
+  rating: CardReviewRating,
+  reviewedAt: Date,
+): ReviewSchedule {
+  const previousInterval = Math.max(row?.intervalDays ?? 1, 1);
+  const previousEase = row?.easeFactor ?? 2.5;
+  const previousReviewCount = row?.reviewCount ?? 0;
+
+  const intervalDays = previousReviewCount === 0
+    ? ({ easy: 3, medium: 2, hard: 1 } satisfies Record<CardReviewRating, number>)[rating]
+    : Math.max(
+      ({ easy: 3, medium: 2, hard: 1 } satisfies Record<CardReviewRating, number>)[rating],
+      Math.round(previousInterval * ({ easy: 2, medium: 1.5, hard: 1 } satisfies Record<CardReviewRating, number>)[rating]),
+    );
+
+  const easeFactor = Math.min(
+    3.0,
+    Math.max(
+      1.3,
+      previousEase + ({ easy: 0.15, medium: 0, hard: -0.2 } satisfies Record<CardReviewRating, number>)[rating],
+    ),
+  );
+
+  const lastReviewed = toUnixSeconds(reviewedAt);
+
+  return {
+    nextDue: lastReviewed + (intervalDays * 86_400),
+    intervalDays,
+    easeFactor,
+    reviewCount: previousReviewCount + 1,
+    lastReviewed,
+    state: 'active',
+    snoozedUntil: null,
+  };
+}
+
+async function runInTransaction<T>(database: AnyDb | undefined, callback: (tx: AnyDb) => Promise<T>): Promise<T> {
+  const connection = getConn(database);
+
+  if ('transaction' in connection && typeof connection.transaction === 'function') {
+    return await (connection as TransactionCapableDatabaseConnection).transaction(async (tx: AnyDb) => callback(tx));
+  }
+
+  return await callback(connection);
+}
+
+async function loadReviewCardRows(
+  userId: string,
+  languageId: string,
+  database?: AnyDb,
+  cardIds?: string[],
+): Promise<ReviewCardRow[]> {
+  const normalizedCardIds = normalizeGroupIds(cardIds);
+
+  if (cardIds && normalizedCardIds.length === 0) {
+    return [];
+  }
+
+  const conditions = [
+    eq(cards.userId, userId),
+    eq(cards.languageId, languageId),
+    eq(cards.status, 'active'),
+  ];
+
+  if (normalizedCardIds.length > 0) {
+    conditions.push(inArray(cards.cardId, normalizedCardIds));
+  }
+
+  return await getConn(database)
+    .select({
+      cardId: cards.cardId,
+      content: cards.content,
+      meaning: cards.meaning,
+      cardType: cards.cardType,
+      examples: cards.examples,
+      mnemonics: cards.mnemonics,
+      llmInstructions: cards.llmInstructions,
+      updatedAt: cards.updatedAt,
+      nextDue: cardReviewSrs.nextDue,
+      intervalDays: cardReviewSrs.intervalDays,
+      easeFactor: cardReviewSrs.easeFactor,
+      reviewCount: cardReviewSrs.reviewCount,
+      lastReviewed: cardReviewSrs.lastReviewed,
+      state: cardReviewSrs.state,
+      snoozedUntil: cardReviewSrs.snoozedUntil,
+    })
+    .from(cards)
+    .leftJoin(cardReviewSrs, and(
+      eq(cardReviewSrs.userId, cards.userId),
+      eq(cardReviewSrs.languageId, cards.languageId),
+      eq(cardReviewSrs.cardId, cards.cardId),
+    ))
+    .where(and(...conditions))
+    .orderBy(asc(sql<number>`COALESCE(${cardReviewSrs.nextDue}, 0)`), desc(cards.updatedAt));
+}
+
+async function loadReviewGroupRows(
+  userId: string,
+  languageId: string,
+  cardIds: string[],
+  database?: AnyDb,
+): Promise<ReviewGroupRow[]> {
+  const normalizedCardIds = normalizeGroupIds(cardIds);
+
+  if (normalizedCardIds.length === 0) {
+    return [];
+  }
+
+  return await getConn(database)
+    .select({
+      cardId: cardGroups.cardId,
+      groupId: groups.groupId,
+      groupName: groups.groupName,
+    })
+    .from(cardGroups)
+    .innerJoin(groups, and(
+      eq(groups.userId, cardGroups.userId),
+      eq(groups.languageId, cardGroups.languageId),
+      eq(groups.groupId, cardGroups.groupId),
+    ))
+    .where(and(
+      eq(cardGroups.userId, userId),
+      eq(cardGroups.languageId, languageId),
+      inArray(cardGroups.cardId, normalizedCardIds),
+    ));
+}
+
+async function loadGroups(
+  userId: string,
+  languageId: string,
+  database?: AnyDb,
+  groupIds?: string[],
+) {
+  const normalizedGroupIds = normalizeGroupIds(groupIds);
+
+  if (groupIds && normalizedGroupIds.length === 0) {
+    return [];
+  }
+
+  return await getConn(database)
+    .select({
+      groupId: groups.groupId,
+      groupName: groups.groupName,
+    })
+    .from(groups)
+    .where(and(
+      eq(groups.userId, userId),
+      eq(groups.languageId, languageId),
+      ...(normalizedGroupIds.length > 0 ? [inArray(groups.groupId, normalizedGroupIds)] : []),
+    ))
+    .orderBy(asc(groups.groupName));
+}
+
+async function loadCardIdsForGroups(
+  userId: string,
+  languageId: string,
+  groupIds: string[],
+  database?: AnyDb,
+): Promise<string[]> {
+  const normalizedGroupIds = normalizeGroupIds(groupIds);
+
+  if (normalizedGroupIds.length === 0) {
+    return [];
+  }
+
+  const rows = await getConn(database)
+    .select({ cardId: cardGroups.cardId })
+    .from(cardGroups)
+    .where(and(
+      eq(cardGroups.userId, userId),
+      eq(cardGroups.languageId, languageId),
+      inArray(cardGroups.groupId, normalizedGroupIds),
+    ));
+
+  return [...new Set(rows.map((row) => row.cardId))];
+}
+
+function groupRowsByCard(rows: ReviewGroupRow[]): Map<string, Array<{ groupId: string; groupName: string }>> {
+  const groupsByCardId = new Map<string, Array<{ groupId: string; groupName: string }>>();
+
+  for (const row of rows) {
+    const existing = groupsByCardId.get(row.cardId) ?? [];
+    existing.push({ groupId: row.groupId, groupName: row.groupName });
+    groupsByCardId.set(row.cardId, existing);
+  }
+
+  return groupsByCardId;
+}
+
+function toQueueItem(
+  row: ReviewCardRow,
+  groupsForCard: Array<{ groupId: string; groupName: string }>,
+  now: Date,
+): CardReviewQueueItem {
+  return {
+    cardId: row.cardId,
+    content: row.content,
+    meaning: row.meaning,
+    cardType: row.cardType,
+    examples: normalizeStringList(row.examples),
+    mnemonics: normalizeStringList(row.mnemonics),
+    llmInstructions: row.llmInstructions,
+    updatedAt: row.updatedAt,
+    groups: groupsForCard,
+    nextDueAt: fromUnixSeconds(row.nextDue),
+    intervalDays: Math.max(row.intervalDays ?? 1, 1),
+    easeFactor: row.easeFactor ?? 2.5,
+    reviewCount: Math.max(row.reviewCount ?? 0, 0),
+    lastReviewedAt: fromUnixSeconds(row.lastReviewed),
+    state: getEffectiveState(row, now),
+    snoozedUntil: row.snoozedUntil,
+  };
+}
+
+async function getReviewCardRow(
+  userId: string,
+  languageId: string,
+  cardId: string,
+  database?: AnyDb,
+): Promise<ReviewCardRow | null> {
+  const rows = await loadReviewCardRows(userId, languageId, database, [cardId]);
+  return rows[0] ?? null;
+}
+
+async function upsertDailyStats(
+  userId: string,
+  languageId: string,
+  occurredAt: Date,
+  increments: DailyStatIncrements,
+  database: AnyDb,
+): Promise<void> {
+  await database
+    .insert(cardReviewDailyStats)
+    .values({
+      userId,
+      languageId,
+      date: toStatsDate(occurredAt),
+      cardsReviewed: increments.cardsReviewed ?? 0,
+      totalReviewTimeMinutes: increments.totalReviewTimeMinutes ?? 0,
+      cardsRatedEasy: increments.cardsRatedEasy ?? 0,
+      cardsRatedMedium: increments.cardsRatedMedium ?? 0,
+      cardsRatedHard: increments.cardsRatedHard ?? 0,
+      cardsSnoozed: increments.cardsSnoozed ?? 0,
+      cardsDisabled: increments.cardsDisabled ?? 0,
+      cardsPinnedToDrills: increments.cardsPinnedToDrills ?? 0,
+    })
+    .onConflictDoUpdate({
+      target: [cardReviewDailyStats.userId, cardReviewDailyStats.languageId, cardReviewDailyStats.date],
+      set: {
+        cardsReviewed: sql`${cardReviewDailyStats.cardsReviewed} + ${increments.cardsReviewed ?? 0}`,
+        totalReviewTimeMinutes: sql`${cardReviewDailyStats.totalReviewTimeMinutes} + ${increments.totalReviewTimeMinutes ?? 0}`,
+        cardsRatedEasy: sql`${cardReviewDailyStats.cardsRatedEasy} + ${increments.cardsRatedEasy ?? 0}`,
+        cardsRatedMedium: sql`${cardReviewDailyStats.cardsRatedMedium} + ${increments.cardsRatedMedium ?? 0}`,
+        cardsRatedHard: sql`${cardReviewDailyStats.cardsRatedHard} + ${increments.cardsRatedHard ?? 0}`,
+        cardsSnoozed: sql`${cardReviewDailyStats.cardsSnoozed} + ${increments.cardsSnoozed ?? 0}`,
+        cardsDisabled: sql`${cardReviewDailyStats.cardsDisabled} + ${increments.cardsDisabled ?? 0}`,
+        cardsPinnedToDrills: sql`${cardReviewDailyStats.cardsPinnedToDrills} + ${increments.cardsPinnedToDrills ?? 0}`,
+      },
+    });
+}
+
+async function insertEvent(
+  userId: string,
+  languageId: string,
+  cardId: string,
+  eventType: CardReviewEventType,
+  occurredAt: Date,
+  database: AnyDb,
+  options: {
+    rating?: CardReviewRating | null;
+    previousState?: CardReviewState | null;
+    nextState?: CardReviewState | null;
+    previousIntervalDays?: number | null;
+    nextIntervalDays?: number | null;
+    previousDue?: number | null;
+    nextDue?: number | null;
+    metadata?: Record<string, unknown> | null;
+  } = {},
+): Promise<string> {
+  const eventId = createEventId();
+
+  await database.insert(cardReviewEvents).values({
+    eventId,
+    userId,
+    languageId,
+    cardId,
+    eventType,
+    rating: options.rating ?? null,
+    previousState: options.previousState ?? null,
+    nextState: options.nextState ?? null,
+    previousIntervalDays: options.previousIntervalDays ?? null,
+    nextIntervalDays: options.nextIntervalDays ?? null,
+    previousDue: options.previousDue ?? null,
+    nextDue: options.nextDue ?? null,
+    occurredAt,
+    metadata: options.metadata ?? null,
+  });
+
+  return eventId;
+}
+
+export async function getCardReviewHomeStats(
+  userId: string,
+  languageId: string,
+  options: { now?: Date } = {},
+  database?: AnyDb,
+): Promise<CardReviewHomeStats> {
+  const now = options.now ?? new Date();
+  const [rows, statRows] = await Promise.all([
+    loadReviewCardRows(userId, languageId, database),
+    getConn(database)
+      .select({
+        date: cardReviewDailyStats.date,
+        cardsReviewed: cardReviewDailyStats.cardsReviewed,
+      })
+      .from(cardReviewDailyStats)
+      .where(and(
+        eq(cardReviewDailyStats.userId, userId),
+        eq(cardReviewDailyStats.languageId, languageId),
+      ))
+      .orderBy(desc(cardReviewDailyStats.date)),
+  ]);
+
+  const cardsInRotation = rows.filter((row) => isInRotation(row, now)).length;
+  const dueNowCount = rows.filter((row) => isDueForReview(row, now)).length;
+  const todayStats = statRows.find((row) => row.date === toStatsDate(now));
+
+  let currentStreakDays = 0;
+
+  if (statRows.length > 0) {
+    let expectedDate = statRows[0]!.date;
+
+    for (const row of statRows) {
+      if ((row.cardsReviewed ?? 0) <= 0 || row.date !== expectedDate) {
+        break;
+      }
+
+      currentStreakDays += 1;
+      expectedDate = toStatsDate(new Date(new Date(`${expectedDate}T00:00:00.000Z`).getTime() - 86_400_000));
+    }
+  }
+
+  const lastReviewedSeconds = rows.reduce<number | null>((latest, row) => {
+    if (typeof row.lastReviewed !== 'number') {
+      return latest;
+    }
+
+    return latest === null ? row.lastReviewed : Math.max(latest, row.lastReviewed);
+  }, null);
+
+  return {
+    cardsInRotation,
+    dueNowCount,
+    reviewedTodayCount: todayStats?.cardsReviewed ?? 0,
+    currentStreakDays,
+    lastReviewedAt: fromUnixSeconds(lastReviewedSeconds),
+  };
+}
+
+export async function listCardReviewGroupSummaries(
+  userId: string,
+  languageId: string,
+  options: { now?: Date; groupIds?: string[] } = {},
+  database?: AnyDb,
+): Promise<CardReviewGroupSummary[]> {
+  const now = options.now ?? new Date();
+  const rows = await loadReviewCardRows(userId, languageId, database);
+  const reviewGroupRows = await loadReviewGroupRows(userId, languageId, rows.map((row) => row.cardId), database);
+  const availableGroups = await loadGroups(userId, languageId, database, options.groupIds);
+  const groupsByCardId = groupRowsByCard(reviewGroupRows);
+
+  const summaries = new Map<string, CardReviewGroupSummary>(
+    availableGroups.map((group) => [group.groupId, {
+      groupId: group.groupId,
+      groupName: group.groupName,
+      activeCardCount: 0,
+      dueCardCount: 0,
+      nextDueAt: null,
+    }]),
+  );
+
+  for (const row of rows) {
+    const cardGroupsForRow = groupsByCardId.get(row.cardId) ?? [];
+
+    for (const group of cardGroupsForRow) {
+      const summary = summaries.get(group.groupId);
+
+      if (!summary) {
+        continue;
+      }
+
+      if (isInRotation(row, now)) {
+        summary.activeCardCount += 1;
+      }
+
+      if (isDueForReview(row, now)) {
+        summary.dueCardCount += 1;
+      } else {
+        const nextDueSeconds = getNextUpcomingDueSeconds(row, now);
+
+        if (nextDueSeconds !== null) {
+          const nextDueAt = fromUnixSeconds(nextDueSeconds);
+
+          if (!summary.nextDueAt || (nextDueAt && nextDueAt < summary.nextDueAt)) {
+            summary.nextDueAt = nextDueAt;
+          }
+        }
+      }
+    }
+  }
+
+  return [...summaries.values()].sort((left, right) => left.groupName.localeCompare(right.groupName));
+}
+
+export async function listCardReviewSessionCards(
+  userId: string,
+  languageId: string,
+  options: { now?: Date; groupIds?: string[] | null; limit?: number | null } = {},
+  database?: AnyDb,
+): Promise<CardReviewQueueItem[]> {
+  const now = options.now ?? new Date();
+  const normalizedGroupIds = options.groupIds === undefined || options.groupIds === null
+    ? null
+    : normalizeGroupIds(options.groupIds);
+
+  if (normalizedGroupIds !== null && normalizedGroupIds.length === 0) {
+    return [];
+  }
+
+  const scopedCardIds = normalizedGroupIds === null
+    ? undefined
+    : await loadCardIdsForGroups(userId, languageId, normalizedGroupIds, database);
+
+  if (scopedCardIds && scopedCardIds.length === 0) {
+    return [];
+  }
+
+  const rows = (await loadReviewCardRows(userId, languageId, database, scopedCardIds))
+    .filter((row) => isDueForReview(row, now));
+  const groupsByCardId = groupRowsByCard(await loadReviewGroupRows(userId, languageId, rows.map((row) => row.cardId), database));
+
+  const sortedRows = rows.sort((left, right) => {
+    const leftDue = left.nextDue ?? 0;
+    const rightDue = right.nextDue ?? 0;
+
+    if (leftDue !== rightDue) {
+      return leftDue - rightDue;
+    }
+
+    return (right.updatedAt?.getTime() ?? 0) - (left.updatedAt?.getTime() ?? 0);
+  });
+
+  const limitedRows = typeof options.limit === 'number' ? sortedRows.slice(0, options.limit) : sortedRows;
+
+  return limitedRows.map((row) => toQueueItem(row, groupsByCardId.get(row.cardId) ?? [], now));
+}
+
+export async function recordCardReviewRating(
+  userId: string,
+  languageId: string,
+  cardId: string,
+  rating: CardReviewRating,
+  options: { reviewedAt?: Date; reviewTimeMinutes?: number } = {},
+  database?: AnyDb,
+): Promise<CardReviewMutationResult> {
+  const reviewedAt = options.reviewedAt ?? new Date();
+
+  return await runInTransaction(database, async (tx) => {
+    const current = await getReviewCardRow(userId, languageId, cardId, tx);
+
+    if (!current) {
+      throw new Error('That card is not available for review.');
+    }
+
+    const nextSchedule = computeNextReviewSchedule(current, rating, reviewedAt);
+
+    await tx
+      .insert(cardReviewSrs)
+      .values({
+        userId,
+        languageId,
+        cardId,
+        nextDue: nextSchedule.nextDue,
+        intervalDays: nextSchedule.intervalDays,
+        easeFactor: nextSchedule.easeFactor,
+        reviewCount: nextSchedule.reviewCount,
+        lastReviewed: nextSchedule.lastReviewed,
+        state: nextSchedule.state,
+        snoozedUntil: nextSchedule.snoozedUntil,
+      })
+      .onConflictDoUpdate({
+        target: [cardReviewSrs.userId, cardReviewSrs.languageId, cardReviewSrs.cardId],
+        set: {
+          nextDue: nextSchedule.nextDue,
+          intervalDays: nextSchedule.intervalDays,
+          easeFactor: nextSchedule.easeFactor,
+          reviewCount: nextSchedule.reviewCount,
+          lastReviewed: nextSchedule.lastReviewed,
+          state: nextSchedule.state,
+          snoozedUntil: nextSchedule.snoozedUntil,
+        },
+      });
+
+    const eventId = await insertEvent(userId, languageId, cardId, 'rated', reviewedAt, tx, {
+      rating,
+      previousState: getStoredState(current),
+      nextState: nextSchedule.state,
+      previousIntervalDays: current.intervalDays ?? 1,
+      nextIntervalDays: nextSchedule.intervalDays,
+      previousDue: current.nextDue,
+      nextDue: nextSchedule.nextDue,
+      metadata: options.reviewTimeMinutes ? { reviewTimeMinutes: options.reviewTimeMinutes } : null,
+    });
+
+    await upsertDailyStats(userId, languageId, reviewedAt, {
+      cardsReviewed: 1,
+      totalReviewTimeMinutes: options.reviewTimeMinutes ?? 0,
+      cardsRatedEasy: rating === 'easy' ? 1 : 0,
+      cardsRatedMedium: rating === 'medium' ? 1 : 0,
+      cardsRatedHard: rating === 'hard' ? 1 : 0,
+    }, tx);
+
+    return {
+      eventId,
+      cardId,
+      eventType: 'rated',
+      rating,
+      occurredAt: reviewedAt,
+      state: nextSchedule.state,
+      snoozedUntil: nextSchedule.snoozedUntil,
+      nextDueAt: fromUnixSeconds(nextSchedule.nextDue),
+      intervalDays: nextSchedule.intervalDays,
+      easeFactor: nextSchedule.easeFactor,
+      reviewCount: nextSchedule.reviewCount,
+    };
+  });
+}
+
+async function updateCardReviewState(
+  userId: string,
+  languageId: string,
+  cardId: string,
+  eventType: Extract<CardReviewEventType, 'snoozed' | 'disabled' | 'reactivated'>,
+  options: { occurredAt?: Date; snoozedUntil?: Date | null },
+  dailyStatIncrements: DailyStatIncrements,
+  database?: AnyDb,
+): Promise<CardReviewMutationResult> {
+  const occurredAt = options.occurredAt ?? new Date();
+
+  return await runInTransaction(database, async (tx) => {
+    const current = await getReviewCardRow(userId, languageId, cardId, tx);
+
+    if (!current) {
+      throw new Error('That card is not available for review.');
+    }
+
+    const nextState = eventType === 'disabled'
+      ? 'disabled'
+      : eventType === 'snoozed'
+        ? 'snoozed'
+        : 'active';
+    const nextSnoozedUntil = nextState === 'snoozed' ? (options.snoozedUntil ?? null) : null;
+
+    await tx
+      .insert(cardReviewSrs)
+      .values({
+        userId,
+        languageId,
+        cardId,
+        nextDue: current.nextDue ?? 0,
+        intervalDays: current.intervalDays ?? 1,
+        easeFactor: current.easeFactor ?? 2.5,
+        reviewCount: current.reviewCount ?? 0,
+        lastReviewed: current.lastReviewed ?? null,
+        state: nextState,
+        snoozedUntil: nextSnoozedUntil,
+      })
+      .onConflictDoUpdate({
+        target: [cardReviewSrs.userId, cardReviewSrs.languageId, cardReviewSrs.cardId],
+        set: {
+          state: nextState,
+          snoozedUntil: nextSnoozedUntil,
+        },
+      });
+
+    const eventId = await insertEvent(userId, languageId, cardId, eventType, occurredAt, tx, {
+      previousState: getStoredState(current),
+      nextState,
+      previousIntervalDays: current.intervalDays,
+      nextIntervalDays: current.intervalDays,
+      previousDue: current.nextDue,
+      nextDue: current.nextDue,
+      metadata: nextSnoozedUntil ? { snoozedUntil: nextSnoozedUntil.toISOString() } : null,
+    });
+
+    await upsertDailyStats(userId, languageId, occurredAt, dailyStatIncrements, tx);
+
+    return {
+      eventId,
+      cardId,
+      eventType,
+      rating: null,
+      occurredAt,
+      state: nextState,
+      snoozedUntil: nextSnoozedUntil,
+      nextDueAt: fromUnixSeconds(current.nextDue),
+      intervalDays: current.intervalDays ?? 1,
+      easeFactor: current.easeFactor ?? 2.5,
+      reviewCount: current.reviewCount ?? 0,
+    };
+  });
+}
+
+export async function snoozeCardForReview(
+  userId: string,
+  languageId: string,
+  cardId: string,
+  snoozedUntil: Date,
+  options: { occurredAt?: Date } = {},
+  database?: AnyDb,
+): Promise<CardReviewMutationResult> {
+  return await updateCardReviewState(
+    userId,
+    languageId,
+    cardId,
+    'snoozed',
+    { occurredAt: options.occurredAt, snoozedUntil },
+    { cardsSnoozed: 1 },
+    database,
+  );
+}
+
+export async function disableCardForReview(
+  userId: string,
+  languageId: string,
+  cardId: string,
+  options: { occurredAt?: Date } = {},
+  database?: AnyDb,
+): Promise<CardReviewMutationResult> {
+  return await updateCardReviewState(
+    userId,
+    languageId,
+    cardId,
+    'disabled',
+    { occurredAt: options.occurredAt },
+    { cardsDisabled: 1 },
+    database,
+  );
+}
+
+export async function reactivateCardForReview(
+  userId: string,
+  languageId: string,
+  cardId: string,
+  options: { occurredAt?: Date } = {},
+  database?: AnyDb,
+): Promise<CardReviewMutationResult> {
+  return await updateCardReviewState(
+    userId,
+    languageId,
+    cardId,
+    'reactivated',
+    { occurredAt: options.occurredAt },
+    {},
+    database,
+  );
+}
+
+export async function recordCardReviewPinToDrills(
+  userId: string,
+  languageId: string,
+  cardId: string,
+  options: { occurredAt?: Date; metadata?: Record<string, unknown> | null } = {},
+  database?: AnyDb,
+): Promise<CardReviewMutationResult> {
+  const occurredAt = options.occurredAt ?? new Date();
+
+  return await runInTransaction(database, async (tx) => {
+    const current = await getReviewCardRow(userId, languageId, cardId, tx);
+
+    if (!current) {
+      throw new Error('That card is not available for review.');
+    }
+
+    const eventId = await insertEvent(userId, languageId, cardId, 'pinned_to_drills', occurredAt, tx, {
+      previousState: getStoredState(current),
+      nextState: getStoredState(current),
+      previousIntervalDays: current.intervalDays,
+      nextIntervalDays: current.intervalDays,
+      previousDue: current.nextDue,
+      nextDue: current.nextDue,
+      metadata: options.metadata ?? null,
+    });
+
+    await upsertDailyStats(userId, languageId, occurredAt, {
+      cardsPinnedToDrills: 1,
+    }, tx);
+
+    return {
+      eventId,
+      cardId,
+      eventType: 'pinned_to_drills',
+      rating: null,
+      occurredAt,
+      state: getStoredState(current),
+      snoozedUntil: current.snoozedUntil,
+      nextDueAt: fromUnixSeconds(current.nextDue),
+      intervalDays: current.intervalDays ?? 1,
+      easeFactor: current.easeFactor ?? 2.5,
+      reviewCount: current.reviewCount ?? 0,
+    };
+  });
+}

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -141,6 +141,7 @@ export * from './schema.js';
 export * from './users.js';
 export * from './cards.js';
 export * from './card-entry.js';
+export * from './card-review.js';
 
 // Re-export relations and types
 // Note: validation schemas are NOT re-exported here to avoid pulling drizzle-zod

--- a/packages/database/src/schema/card-review.ts
+++ b/packages/database/src/schema/card-review.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, integer, real, jsonb, index, primaryKey } from 'drizzle-orm/pg-core';
+import { pgTable, text, integer, real, timestamp, jsonb, index, primaryKey } from 'drizzle-orm/pg-core';
 
 export const cardReviewSrs = pgTable('card_review_srs', {
   userId: text('user_id').notNull(),
@@ -9,11 +9,39 @@ export const cardReviewSrs = pgTable('card_review_srs', {
   easeFactor: real('ease_factor').default(2.5),
   reviewCount: integer('review_count').default(0),
   lastReviewed: integer('last_reviewed'),
+  state: text('state').notNull().default('active'),
+  snoozedUntil: timestamp('snoozed_until', { withTimezone: true }),
   metadata: jsonb('metadata'),
 }, (table) => ({
   pk: primaryKey({ columns: [table.userId, table.languageId, table.cardId] }),
   dueIdx: index('idx_card_review_srs_due').on(table.userId, table.languageId, table.nextDue),
   intervalIdx: index('idx_card_review_srs_interval').on(table.userId, table.languageId, table.intervalDays),
+  stateIdx: index('idx_card_review_srs_state').on(table.userId, table.languageId, table.state),
+}));
+
+export const cardReviewEvents = pgTable('card_review_events', {
+  eventId: text('event_id').primaryKey(),
+  userId: text('user_id').notNull(),
+  languageId: text('language_id').notNull(),
+  cardId: text('card_id').notNull(),
+  eventType: text('event_type').notNull(),
+  rating: text('rating'),
+  previousState: text('previous_state'),
+  nextState: text('next_state'),
+  previousIntervalDays: integer('previous_interval_days'),
+  nextIntervalDays: integer('next_interval_days'),
+  previousDue: integer('previous_due'),
+  nextDue: integer('next_due'),
+  occurredAt: timestamp('occurred_at', { withTimezone: true }).notNull().defaultNow(),
+  metadata: jsonb('metadata'),
+}, (table) => ({
+  cardTimelineIdx: index('idx_card_review_events_card_timeline').on(
+    table.userId,
+    table.languageId,
+    table.cardId,
+    table.occurredAt,
+  ),
+  eventTypeIdx: index('idx_card_review_events_type').on(table.userId, table.languageId, table.eventType),
 }));
 
 export const cardReviewDailyStats = pgTable('card_review_daily_stats', {
@@ -35,5 +63,7 @@ export const cardReviewDailyStats = pgTable('card_review_daily_stats', {
 
 export type CardReviewSrs = typeof cardReviewSrs.$inferSelect;
 export type NewCardReviewSrs = typeof cardReviewSrs.$inferInsert;
+export type CardReviewEvent = typeof cardReviewEvents.$inferSelect;
+export type NewCardReviewEvent = typeof cardReviewEvents.$inferInsert;
 export type CardReviewDailyStats = typeof cardReviewDailyStats.$inferSelect;
 export type NewCardReviewDailyStats = typeof cardReviewDailyStats.$inferInsert;

--- a/packages/database/src/test-utils.ts
+++ b/packages/database/src/test-utils.ts
@@ -7,7 +7,7 @@ import * as schema from './schema.js';
 import { users, studyLanguages } from './schema/users.js';
 import { groups, cards, cardGroups } from './schema/cards.js';
 import { inboxNotes, noteCardLinks, cardEntryDailyStats } from './schema/card-entry.js';
-import { cardReviewSrs, cardReviewDailyStats } from './schema/card-review.js';
+import { cardReviewSrs, cardReviewEvents, cardReviewDailyStats } from './schema/card-review.js';
 import {
   translationDrillSrs,
   translationDrillDrawPiles,
@@ -57,6 +57,7 @@ export async function resetTestTables(db: TestDb) {
   // Delete in reverse FK dependency order (leaf tables first, then parents)
   await db.delete(cardEntryDailyStats);
   await db.delete(cardReviewDailyStats);
+  await db.delete(cardReviewEvents);
   await db.delete(translationDrillDailyStats);
   await db.delete(translationDrillContext);
   await db.delete(translationDrillSrs);

--- a/packages/database/src/tests/card-review.test.ts
+++ b/packages/database/src/tests/card-review.test.ts
@@ -1,0 +1,386 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import postgres from 'postgres';
+import { eq } from 'drizzle-orm';
+import { setupTestDatabase, cleanupTestDatabase, resetTestTables, type TestDb } from '../test-utils.js';
+import { cardGroups, cards, cardReviewDailyStats, cardReviewEvents, cardReviewSrs, groups, studyLanguages, users } from '../schema.js';
+import {
+  disableCardForReview,
+  getCardReviewHomeStats,
+  listCardReviewGroupSummaries,
+  listCardReviewSessionCards,
+  recordCardReviewPinToDrills,
+  recordCardReviewRating,
+  snoozeCardForReview,
+} from '../card-review.js';
+
+const TEST_USER = { userId: 'auth0|card-review-user', email: 'card-review@example.com' };
+const TEST_LANG = { userId: TEST_USER.userId, languageId: 'zh', languageName: 'Chinese' };
+const NOW = new Date('2026-05-10T12:00:00.000Z');
+
+describe('Card Review database operations', () => {
+  let db: TestDb;
+  let sql: ReturnType<typeof postgres>;
+
+  beforeAll(async () => {
+    ({ db, sql } = await setupTestDatabase());
+  });
+
+  afterAll(async () => {
+    if (sql) {
+      await cleanupTestDatabase(sql);
+    }
+  });
+
+  beforeEach(async () => {
+    await resetTestTables(db);
+    await db.insert(users).values(TEST_USER);
+    await db.insert(studyLanguages).values(TEST_LANG);
+  });
+
+  async function seedReviewLibrary() {
+    await db.insert(groups).values([
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        groupId: 'group-core',
+        groupName: 'Core',
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        groupId: 'group-extended',
+        groupName: 'Extended',
+      },
+    ]);
+
+    await db.insert(cards).values([
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-due',
+        content: '补偿',
+        status: 'active',
+        cardType: 'word',
+        meaning: 'to compensate',
+        examples: ['我们以后再补偿这次错过的时间。'],
+        updatedAt: new Date('2026-05-01T12:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-new',
+        content: '巩固',
+        status: 'active',
+        cardType: 'word',
+        meaning: 'to consolidate',
+        mnemonics: ['solid core'],
+        updatedAt: new Date('2026-05-02T12:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-future',
+        content: '逐渐',
+        status: 'active',
+        cardType: 'pattern',
+        meaning: 'gradually',
+        updatedAt: new Date('2026-05-03T12:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-snoozed',
+        content: '搁置',
+        status: 'active',
+        cardType: 'word',
+        meaning: 'to set aside',
+        updatedAt: new Date('2026-05-04T12:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-disabled',
+        content: '停用',
+        status: 'active',
+        cardType: 'word',
+        meaning: 'to disable',
+        updatedAt: new Date('2026-05-05T12:00:00.000Z'),
+      },
+    ]);
+
+    await db.insert(cardGroups).values([
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-due',
+        groupId: 'group-core',
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-new',
+        groupId: 'group-core',
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-future',
+        groupId: 'group-extended',
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-snoozed',
+        groupId: 'group-extended',
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-disabled',
+        groupId: 'group-extended',
+      },
+    ]);
+
+    await db.insert(cardReviewSrs).values([
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-due',
+        nextDue: Math.floor(new Date('2026-05-09T12:00:00.000Z').getTime() / 1_000),
+        intervalDays: 2,
+        easeFactor: 2.5,
+        reviewCount: 1,
+        lastReviewed: Math.floor(new Date('2026-05-07T12:00:00.000Z').getTime() / 1_000),
+        state: 'active',
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-future',
+        nextDue: Math.floor(new Date('2026-05-12T12:00:00.000Z').getTime() / 1_000),
+        intervalDays: 4,
+        easeFactor: 2.6,
+        reviewCount: 2,
+        lastReviewed: Math.floor(new Date('2026-05-08T12:00:00.000Z').getTime() / 1_000),
+        state: 'active',
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-snoozed',
+        nextDue: Math.floor(new Date('2026-05-09T08:00:00.000Z').getTime() / 1_000),
+        intervalDays: 1,
+        easeFactor: 2.3,
+        reviewCount: 3,
+        lastReviewed: Math.floor(new Date('2026-05-08T08:00:00.000Z').getTime() / 1_000),
+        state: 'snoozed',
+        snoozedUntil: new Date('2026-05-11T12:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-disabled',
+        nextDue: Math.floor(new Date('2026-05-09T10:00:00.000Z').getTime() / 1_000),
+        intervalDays: 2,
+        easeFactor: 2.1,
+        reviewCount: 4,
+        lastReviewed: Math.floor(new Date('2026-05-06T10:00:00.000Z').getTime() / 1_000),
+        state: 'disabled',
+      },
+    ]);
+
+    await db.insert(cardReviewDailyStats).values([
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        date: '2026-05-09',
+        cardsReviewed: 4,
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        date: '2026-05-08',
+        cardsReviewed: 2,
+      },
+    ]);
+  }
+
+  it('computes home stats and per-group due summaries with snooze-aware upcoming dates', async () => {
+    await seedReviewLibrary();
+
+    const [stats, groups] = await Promise.all([
+      getCardReviewHomeStats(TEST_USER.userId, TEST_LANG.languageId, { now: NOW }, db),
+      listCardReviewGroupSummaries(TEST_USER.userId, TEST_LANG.languageId, { now: NOW }, db),
+    ]);
+
+    expect(stats).toMatchObject({
+      cardsInRotation: 3,
+      dueNowCount: 2,
+      reviewedTodayCount: 0,
+      currentStreakDays: 2,
+    });
+    expect(stats.lastReviewedAt?.toISOString()).toBe('2026-05-08T12:00:00.000Z');
+    expect(groups).toEqual([
+      {
+        groupId: 'group-core',
+        groupName: 'Core',
+        activeCardCount: 2,
+        dueCardCount: 2,
+        nextDueAt: null,
+      },
+      {
+        groupId: 'group-extended',
+        groupName: 'Extended',
+        activeCardCount: 1,
+        dueCardCount: 0,
+        nextDueAt: new Date('2026-05-11T12:00:00.000Z'),
+      },
+    ]);
+  });
+
+  it('builds a due-card session queue scoped to the selected groups and limit', async () => {
+    await seedReviewLibrary();
+
+    const queue = await listCardReviewSessionCards(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      {
+        now: NOW,
+        groupIds: ['group-core', 'group-extended'],
+        limit: 2,
+      },
+      db,
+    );
+
+    expect(queue.map((item) => item.cardId)).toEqual(['card-new', 'card-due']);
+    expect(queue[0]?.groups).toEqual([{ groupId: 'group-core', groupName: 'Core' }]);
+    expect(queue[0]?.mnemonics).toEqual(['solid core']);
+    expect(queue[1]?.nextDueAt?.toISOString()).toBe('2026-05-09T12:00:00.000Z');
+  });
+
+  it('records review ratings by updating SRS, event history, and daily stats', async () => {
+    await db.insert(cards).values({
+      userId: TEST_USER.userId,
+      languageId: TEST_LANG.languageId,
+      cardId: 'card-rating',
+      content: '熟悉',
+      status: 'active',
+      cardType: 'word',
+      meaning: 'to become familiar with',
+    });
+
+    const result = await recordCardReviewRating(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      'card-rating',
+      'easy',
+      {
+        reviewedAt: NOW,
+        reviewTimeMinutes: 4,
+      },
+      db,
+    );
+
+    const [storedSrs] = await db
+      .select()
+      .from(cardReviewSrs)
+      .where(eq(cardReviewSrs.cardId, 'card-rating'));
+    const [storedEvent] = await db
+      .select()
+      .from(cardReviewEvents)
+      .where(eq(cardReviewEvents.eventId, result.eventId));
+    const [storedStats] = await db
+      .select()
+      .from(cardReviewDailyStats)
+      .where(eq(cardReviewDailyStats.date, '2026-05-10'));
+
+    expect(result.intervalDays).toBe(3);
+    expect(result.nextDueAt?.toISOString()).toBe('2026-05-13T12:00:00.000Z');
+    expect(storedSrs).toMatchObject({
+      state: 'active',
+      intervalDays: 3,
+      reviewCount: 1,
+      nextDue: Math.floor(new Date('2026-05-13T12:00:00.000Z').getTime() / 1_000),
+    });
+    expect(storedEvent).toMatchObject({
+      eventType: 'rated',
+      rating: 'easy',
+      previousState: 'active',
+      nextState: 'active',
+      nextIntervalDays: 3,
+    });
+    expect(storedStats).toMatchObject({
+      cardsReviewed: 1,
+      cardsRatedEasy: 1,
+      totalReviewTimeMinutes: 4,
+    });
+  });
+
+  it('persists snooze, disable, and pin events with daily stat counters', async () => {
+    await db.insert(cards).values({
+      userId: TEST_USER.userId,
+      languageId: TEST_LANG.languageId,
+      cardId: 'card-actions',
+      content: '暂缓',
+      status: 'active',
+      cardType: 'word',
+    });
+    await db.insert(cardReviewSrs).values({
+      userId: TEST_USER.userId,
+      languageId: TEST_LANG.languageId,
+      cardId: 'card-actions',
+      nextDue: Math.floor(NOW.getTime() / 1_000),
+      intervalDays: 1,
+      easeFactor: 2.5,
+      reviewCount: 1,
+      state: 'active',
+    });
+
+    await snoozeCardForReview(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      'card-actions',
+      new Date('2026-05-11T12:00:00.000Z'),
+      { occurredAt: NOW },
+      db,
+    );
+    await disableCardForReview(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      'card-actions',
+      { occurredAt: NOW },
+      db,
+    );
+    await recordCardReviewPinToDrills(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      'card-actions',
+      {
+        occurredAt: NOW,
+        metadata: { source: 'card-review-test' },
+      },
+      db,
+    );
+
+    const [storedSrs] = await db
+      .select()
+      .from(cardReviewSrs)
+      .where(eq(cardReviewSrs.cardId, 'card-actions'));
+    const storedEvents = await db
+      .select()
+      .from(cardReviewEvents)
+      .where(eq(cardReviewEvents.cardId, 'card-actions'));
+    const [storedStats] = await db
+      .select()
+      .from(cardReviewDailyStats)
+      .where(eq(cardReviewDailyStats.date, '2026-05-10'));
+
+    expect(storedSrs.state).toBe('disabled');
+    expect(storedEvents.map((event) => event.eventType).sort()).toEqual(['disabled', 'pinned_to_drills', 'snoozed']);
+    expect(storedStats).toMatchObject({
+      cardsSnoozed: 1,
+      cardsDisabled: 1,
+      cardsPinnedToDrills: 1,
+    });
+  });
+});

--- a/packages/database/src/tests/schema.test.ts
+++ b/packages/database/src/tests/schema.test.ts
@@ -5,7 +5,7 @@ import { eq, and } from 'drizzle-orm';
 import { users, studyLanguages } from '../schema/users.js';
 import { cards, groups } from '../schema/cards.js';
 import { inboxNotes, noteCardLinks, cardEntryDailyStats } from '../schema/card-entry.js';
-import { cardReviewSrs, cardReviewDailyStats } from '../schema/card-review.js';
+import { cardReviewSrs, cardReviewEvents, cardReviewDailyStats } from '../schema/card-review.js';
 import {
   translationDrillSrs,
   translationDrillDrawPiles,
@@ -56,7 +56,7 @@ describe('Full schema — Card Entry tables', () => {
     expect(retrieved).toBeDefined();
     expect(retrieved.content).toBe(note.content);
     expect(retrieved.state).toBe('unprocessed');
-    expect(retrieved.aiState).toBe('complete');
+    expect(retrieved.aiState).toBe('queued');
     expect(retrieved.sourceType).toBe('manual');
   });
 
@@ -133,6 +133,7 @@ describe('Full schema — Card Review tables', () => {
   });
 
   beforeEach(async () => {
+    await db.delete(cardReviewEvents);
     await db.delete(cardReviewDailyStats);
     await db.delete(cardReviewSrs);
   });
@@ -169,6 +170,7 @@ describe('Full schema — Card Review tables', () => {
     const [retrieved] = await db.select().from(cardReviewSrs);
     expect(retrieved.easeFactor).toBeCloseTo(2.5, 1);
     expect(retrieved.reviewCount).toBe(0);
+    expect(retrieved.state).toBe('active');
   });
 
   it('should record card review daily stats', async () => {
@@ -188,6 +190,32 @@ describe('Full schema — Card Review tables', () => {
     expect(retrieved.cardsReviewed).toBe(20);
     expect(retrieved.cardsRatedEasy).toBe(10);
     expect(retrieved.cardsSnoozed).toBe(0);
+  });
+
+  it('should store card review events', async () => {
+    await db.insert(cardReviewEvents).values({
+      eventId: 'review-event-001',
+      userId: TEST_USER.userId,
+      languageId: 'zh',
+      cardId: TEST_CARD.cardId,
+      eventType: 'rated',
+      rating: 'easy',
+      previousState: 'active',
+      nextState: 'active',
+      previousIntervalDays: 1,
+      nextIntervalDays: 3,
+      previousDue: 0,
+      nextDue: 1000000,
+    });
+
+    const [retrieved] = await db
+      .select()
+      .from(cardReviewEvents)
+      .where(eq(cardReviewEvents.eventId, 'review-event-001'));
+
+    expect(retrieved.eventType).toBe('rated');
+    expect(retrieved.rating).toBe('easy');
+    expect(retrieved.nextIntervalDays).toBe(3);
   });
 });
 

--- a/packages/database/src/validation.ts
+++ b/packages/database/src/validation.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { users, studyLanguages } from './schema/users.js';
 import { groups, cards, cardGroups } from './schema/cards.js';
 import { inboxNotes, noteCardLinks, cardEntryDailyStats } from './schema/card-entry.js';
-import { cardReviewSrs, cardReviewDailyStats } from './schema/card-review.js';
+import { cardReviewSrs, cardReviewEvents, cardReviewDailyStats } from './schema/card-review.js';
 import {
   translationDrillSrs,
   translationDrillDrawPiles,
@@ -19,6 +19,9 @@ export const inboxNoteStateSchema = z.enum(['unprocessed', 'deferred', 'processe
 export const inboxNoteAiStateSchema = z.enum(['queued', 'processing', 'complete', 'failed']);
 export const inboxSourceTypeSchema = z.enum(['manual', 'api', 'browser_extension', 'ifttt', 'zapier', 'n8n']);
 export const drillContextStateSchema = z.enum(['active', 'snoozed', 'dismissed']);
+export const cardReviewStateSchema = z.enum(['active', 'snoozed', 'disabled']);
+export const cardReviewRatingSchema = z.enum(['easy', 'medium', 'hard']);
+export const cardReviewEventTypeSchema = z.enum(['rated', 'snoozed', 'disabled', 'reactivated', 'pinned_to_drills']);
 
 // === Users ===
 export const insertUserSchema = createInsertSchema(users);
@@ -62,6 +65,14 @@ export const selectCardEntryDailyStatsSchema = createSelectSchema(cardEntryDaily
 // === Card Review ===
 export const insertCardReviewSrsSchema = createInsertSchema(cardReviewSrs);
 export const selectCardReviewSrsSchema = createSelectSchema(cardReviewSrs);
+
+export const insertCardReviewEventSchema = createInsertSchema(cardReviewEvents).extend({
+  eventType: cardReviewEventTypeSchema,
+  rating: cardReviewRatingSchema.nullable().optional(),
+  previousState: cardReviewStateSchema.nullable().optional(),
+  nextState: cardReviewStateSchema.nullable().optional(),
+});
+export const selectCardReviewEventSchema = createSelectSchema(cardReviewEvents);
 
 export const insertCardReviewDailyStatsSchema = createInsertSchema(cardReviewDailyStats);
 export const selectCardReviewDailyStatsSchema = createSelectSchema(cardReviewDailyStats);


### PR DESCRIPTION
## Summary
- add Card Review persistence, migration, database operations, and tests
- add Card Review server helpers for home/setup and session data
- align schema coverage with the queued inbox note AI default

## Testing
- pnpm test:db:branch:secure
- pnpm turbo test lint build --filter=web