### PR TITLE
Implement Card Review home and session setup

### DIFF
--- a/apps/web/src/routes/[lang]/card-review/+page.server.ts
+++ b/apps/web/src/routes/[lang]/card-review/+page.server.ts
@@ -1,0 +1,48 @@
+import { error, redirect } from '@sveltejs/kit';
+import { getDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import { CardReviewRequestError, loadCardReviewHomeData } from '$lib/server/card-review.js';
+import type { PageServerLoad } from './$types.js';
+
+export const load: PageServerLoad = async (event) => {
+  const { session } = await event.parent();
+  const languageCode = event.params.lang;
+
+  if (!languageCode) {
+    throw redirect(303, '/');
+  }
+
+  if (!session?.user?.id) {
+    return {
+      home: null,
+      loadError: 'You must be signed in to view Card Review.',
+    };
+  }
+
+  if (!env.DATABASE_URL) {
+    return {
+      home: null,
+      loadError: 'Card Review is not configured right now.',
+    };
+  }
+
+  const database = getDb(env.DATABASE_URL);
+
+  try {
+    return {
+      home: await loadCardReviewHomeData(session.user.id, languageCode, event.url, database),
+      loadError: null,
+    };
+  } catch (requestError) {
+    if (requestError instanceof CardReviewRequestError) {
+      throw error(requestError.status, requestError.message);
+    }
+
+    console.error('Failed to load Card Review home:', requestError);
+
+    return {
+      home: null,
+      loadError: 'The Card Review home could not be loaded right now.',
+    };
+  }
+};

--- a/apps/web/src/routes/[lang]/card-review/+page.svelte
+++ b/apps/web/src/routes/[lang]/card-review/+page.svelte
@@ -1,120 +1,473 @@
 <script lang="ts">
-  import MiniAppPlaceholder from '$lib/components/MiniAppPlaceholder.svelte';
   import { page } from '$app/stores';
+  import type { PageData } from './$types.js';
+
+  export let data: PageData;
+
+  type ReviewHomeData = NonNullable<PageData['home']>;
+
+  const shortDateFormatter = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+
+  let selectedGroupIds = data.home?.selection.groupIds ?? [];
+  let countMode: ReviewHomeData['selection']['countMode'] = data.home?.selection.countMode ?? 'all_due';
+  let sessionLimit: number | undefined = data.home?.selection.limit ?? 10;
+
+  $: home = data.home;
+  $: currentLanguage = $page.params.lang ?? '';
+  $: allGroups = home?.groups ?? [];
+  $: selectedGroups = allGroups.filter((group) => selectedGroupIds.includes(group.groupId));
+  $: selectedDueCount = selectedGroups.reduce((count, group) => count + group.dueCardCount, 0);
+  $: selectedRotationCount = selectedGroups.reduce((count, group) => count + group.activeCardCount, 0);
+  $: allGroupsSelected = allGroups.length > 0 && selectedGroupIds.length === allGroups.length;
+  $: parsedLimit = typeof sessionLimit === 'number' && Number.isInteger(sessionLimit) ? sessionLimit : null;
+  $: effectiveLimit = countMode === 'limit' && parsedLimit !== null && parsedLimit >= 1 && parsedLimit <= 100
+    ? parsedLimit
+    : null;
+  $: startDisabled = !home
+    || selectedGroupIds.length === 0
+    || selectedDueCount === 0
+    || (countMode === 'limit' && effectiveLimit === null);
+  $: selectedNextDueIso = selectedGroups.reduce<string | null>((soonest, group) => {
+    if (!group.nextDueAtIso) {
+      return soonest;
+    }
+
+    if (!soonest) {
+      return group.nextDueAtIso;
+    }
+
+    return new Date(group.nextDueAtIso) < new Date(soonest) ? group.nextDueAtIso : soonest;
+  }, null);
+  $: setupHint = getSetupHint();
+
+  function formatRelativeDateLabel(value: string | null): string {
+    if (!value) {
+      return 'Never';
+    }
+
+    const target = new Date(value);
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const targetDay = new Date(target.getFullYear(), target.getMonth(), target.getDate());
+    const differenceInDays = Math.round((today.getTime() - targetDay.getTime()) / 86_400_000);
+
+    if (differenceInDays <= 0) {
+      return 'Today';
+    }
+
+    if (differenceInDays === 1) {
+      return 'Yesterday';
+    }
+
+    return `${differenceInDays} days ago`;
+  }
+
+  function formatShortDate(value: string | null): string {
+    return value ? shortDateFormatter.format(new Date(value)) : 'No date available';
+  }
+
+  function formatCardLabel(count: number, noun = 'card'): string {
+    return `${count} ${noun}${count === 1 ? '' : 's'}`;
+  }
+
+  function selectAllGroups() {
+    selectedGroupIds = allGroups.map((group) => group.groupId);
+  }
+
+  function getSetupHint(): string | null {
+    if (!home) {
+      return null;
+    }
+
+    if (selectedGroupIds.length === 0) {
+      return 'Select one or more groups to build a Card Review session.';
+    }
+
+    if (countMode === 'limit' && effectiveLimit === null) {
+      if (parsedLimit !== null && parsedLimit > 100) {
+        return 'Use a session size of 100 cards or fewer.';
+      }
+
+      return 'Enter a session size of at least 1 card.';
+    }
+
+    if (selectedDueCount > 0) {
+      return `Ready to review ${formatCardLabel(selectedDueCount, 'due card')} across ${formatCardLabel(selectedGroups.length, 'group')}.`;
+    }
+
+    if (selectedNextDueIso) {
+      return `No cards are due in the selected groups. Next due: ${formatShortDate(selectedNextDueIso)}.`;
+    }
+
+    return 'No cards are due in the selected groups yet.';
+  }
 </script>
 
 <svelte:head>
   <title>Card Review – StudyPuck</title>
 </svelte:head>
 
-<MiniAppPlaceholder
-  title="Card Review"
-  accent="review"
-  routePath={`/${$page.params.lang}/card-review`}
-  commandContext="Card Review"
-  description="Run deliberate spaced-repetition sessions with typography-forward cards, subtle progress, and fast review actions."
-  plannedExperience={[
-    'A focused setup screen for choosing what is due and how much to review.',
-    'A distraction-light review card with excellent readability for CJK and longer notes.',
-    'Fast rating controls for easy, medium, and hard without fumbling for the interface.'
-  ]}
->
-  <div slot="preview" class="review-preview stack">
-    <div class="review-preview__status cluster">
-      <p>Due today</p>
-      <span>18 cards</span>
-    </div>
+{#if data.loadError}
+  <section class="review-home stack" style="--stack-space: var(--space-5)">
+    <header class="review-home__header stack" style="--stack-space: var(--space-2)">
+      <p class="review-home__eyebrow">Setup</p>
+      <h1>Card Review</h1>
+      <p class="review-home__copy">{data.loadError}</p>
+    </header>
+  </section>
+{:else if home}
+  <section class="review-home stack" style="--stack-space: var(--space-5)">
+    <header class="review-home__header stack" style="--stack-space: var(--space-2)">
+      <p class="review-home__eyebrow">Setup</p>
+      <h1>Card Review</h1>
+      <p class="review-home__copy">Select the groups you want to review, then launch a due-card session from the current setup.</p>
+    </header>
 
-    <article class="review-card stack">
-      <p class="review-card__eyebrow">Current card</p>
-      <h2>补偿</h2>
-      <p>to make up for / to compensate</p>
-      <p class="review-card__example">Example: 我们以后再补偿这次错过的时间。</p>
-    </article>
+    <section class="review-stats cluster" aria-label="Card Review quick stats">
+      <div class="review-stat stack" style="--stack-space: var(--space-1)">
+        <span class="review-stat__label">Streak</span>
+        <span class="review-stat__value">
+          {#if home.stats.currentStreakDays > 0}
+            🔥 {home.stats.currentStreakDays}-day streak
+          {:else}
+            Start your streak
+          {/if}
+        </span>
+      </div>
 
-    <div class="review-actions cluster">
-      <span class="review-actions__pill">Easy</span>
-      <span class="review-actions__pill">Medium</span>
-      <span class="review-actions__pill">Hard</span>
-    </div>
-  </div>
-</MiniAppPlaceholder>
+      <div class="review-stat stack" style="--stack-space: var(--space-1)">
+        <span class="review-stat__label">In rotation</span>
+        <span class="review-stat__value">{formatCardLabel(home.stats.cardsInRotation)}</span>
+      </div>
+
+      <div class="review-stat stack" style="--stack-space: var(--space-1)">
+        <span class="review-stat__label">Due now</span>
+        <span class="review-stat__value">{formatCardLabel(home.stats.dueNowCount)}</span>
+      </div>
+
+      <div class="review-stat stack" style="--stack-space: var(--space-1)">
+        <span class="review-stat__label">Last reviewed</span>
+        <span class="review-stat__value">{formatRelativeDateLabel(home.stats.lastReviewedAtIso)}</span>
+      </div>
+    </section>
+
+    <form class="review-setup stack" style="--stack-space: var(--space-4)" method="GET" action={`/${currentLanguage}/card-review/session`}>
+      <section class="review-panel stack" style="--stack-space: var(--space-3)" aria-labelledby="review-groups-title">
+        <div class="review-panel__header cluster">
+          <div class="stack" style="--stack-space: var(--space-1)">
+            <h2 id="review-groups-title">Select groups to review</h2>
+            <p class="review-panel__copy">
+              {formatCardLabel(selectedRotationCount)} in rotation · {formatCardLabel(selectedDueCount, 'due card')} in the current selection
+            </p>
+          </div>
+
+          <button
+            type="button"
+            class="review-panel__link"
+            onclick={selectAllGroups}
+            disabled={allGroupsSelected}
+          >
+            Select all
+          </button>
+        </div>
+
+        {#if allGroups.length === 0}
+          <div class="review-state review-state--empty">
+            <h3>No review groups yet</h3>
+            <p>Add cards to one or more groups to start building Card Review sessions.</p>
+          </div>
+        {:else}
+          <div class="review-group-list stack" style="--stack-space: 0">
+            {#each allGroups as group}
+              <label class="review-group-row">
+                <span class="review-group-row__check">
+                  <input bind:group={selectedGroupIds} type="checkbox" name="group" value={group.groupId} />
+                </span>
+
+                <span class="review-group-row__copy stack" style="--stack-space: var(--space-1)">
+                  <span class="review-group-row__name">{group.groupName}</span>
+                  <span class="review-group-row__meta">{formatCardLabel(group.activeCardCount)} in rotation</span>
+                </span>
+
+                <span class="review-group-row__counts">{formatCardLabel(group.dueCardCount, 'due card')} today</span>
+              </label>
+            {/each}
+          </div>
+        {/if}
+      </section>
+
+      <section class="review-panel stack" style="--stack-space: var(--space-3)" aria-labelledby="review-count-title">
+        <div class="stack" style="--stack-space: var(--space-1)">
+          <h2 id="review-count-title">Card count</h2>
+          <p class="review-panel__copy">Choose the full due queue or trim this pass to a smaller focused session.</p>
+        </div>
+
+        <label class="review-option">
+          <input bind:group={countMode} type="radio" name="countMode" value="all_due" />
+
+          <span class="review-option__body stack" style="--stack-space: var(--space-1)">
+            <span class="review-option__title">All due cards</span>
+            <span class="review-option__meta">{formatCardLabel(selectedDueCount, 'due card')} in the selected groups</span>
+          </span>
+        </label>
+
+        <label class="review-option review-option--limit">
+          <input bind:group={countMode} type="radio" name="countMode" value="limit" />
+
+          <span class="review-option__body stack" style="--stack-space: var(--space-1)">
+            <span class="review-option__title">Limit to N cards</span>
+            <span class="review-option__meta">Use a smaller review pass without changing the selected groups.</span>
+          </span>
+
+          <input
+            bind:value={sessionLimit}
+            class="review-option__input"
+            type="number"
+            aria-label="Session size"
+            name="limit"
+            min="1"
+            max={Math.max(1, Math.min(selectedDueCount || 1, 100))}
+            disabled={countMode !== 'limit'}
+          />
+        </label>
+
+        <div class="review-setup__actions stack" style="--stack-space: var(--space-3)">
+          <button class="review-start-button" type="submit" disabled={startDisabled}>Start Session</button>
+
+          {#if setupHint}
+            <p class="review-setup__hint">{setupHint}</p>
+          {/if}
+
+          <p class="review-setup__supporting">
+            Reviewed today: {formatCardLabel(home.stats.reviewedTodayCount)}
+          </p>
+        </div>
+      </section>
+    </form>
+  </section>
+{/if}
 
 <style>
-  .review-preview,
-  .review-card {
-    --stack-space: var(--space-4);
+  .review-home {
+    padding: calc(var(--shell-header-height) + var(--space-5)) var(--space-4) calc(var(--space-7) + 4.5rem);
   }
 
-  .review-preview__status,
-  .review-actions {
-    align-items: center;
+  .review-home__eyebrow,
+  .review-stat__label,
+  .review-group-row__meta,
+  .review-panel__copy,
+  .review-option__meta,
+  .review-setup__hint,
+  .review-setup__supporting {
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+  }
+
+  .review-home__eyebrow,
+  .review-stat__label {
+    font-size: var(--font-size-caption);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .review-home__header h1,
+  .review-home__copy,
+  .review-stat__value,
+  .review-panel__header h2,
+  .review-state h3,
+  .review-state p,
+  .review-group-row__name,
+  .review-group-row__counts,
+  .review-option__title,
+  .review-setup__hint,
+  .review-setup__supporting {
+    margin: 0;
+  }
+
+  .review-home__copy {
+    max-inline-size: 44rem;
+  }
+
+  .review-stats {
+    gap: var(--space-3);
+  }
+
+  .review-stat,
+  .review-panel,
+  .review-state {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+  }
+
+  .review-stat {
+    flex: 1 1 11rem;
+    min-inline-size: min(100%, 11rem);
+    padding: var(--space-3) var(--space-4);
+    background: color-mix(in srgb, var(--color-info-bg) 30%, var(--color-surface));
+    border-color: var(--color-info-border);
+  }
+
+  .review-stat__value {
+    font-family: var(--font-ui);
+    font-size: var(--font-size-ui);
+    font-weight: 600;
+  }
+
+  .review-panel {
+    padding: var(--space-4);
+  }
+
+  .review-panel__header {
     justify-content: space-between;
     gap: var(--space-3);
   }
 
-  .review-preview__status,
-  .review-actions__pill,
-  .review-card {
+  .review-panel__link {
+    border: 0;
+    padding: 0;
+    background: transparent;
+    color: var(--color-primary);
+    cursor: pointer;
+  }
+
+  .review-panel__link:disabled {
+    color: var(--color-text-disabled);
+    cursor: default;
+  }
+
+  .review-state {
+    padding: var(--space-4);
+  }
+
+  .review-group-list {
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--radius-md);
+    overflow: clip;
+  }
+
+  .review-group-row {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: var(--space-3);
+    align-items: center;
+    min-block-size: 3.5rem;
+    padding: var(--space-3) var(--space-4);
+    cursor: pointer;
+  }
+
+  .review-group-row:nth-child(even) {
+    background: color-mix(in srgb, var(--color-surface-subtle) 55%, var(--color-surface));
+  }
+
+  .review-group-row__check input {
+    inline-size: 1rem;
+    block-size: 1rem;
+    accent-color: var(--color-primary);
+  }
+
+  .review-group-row__copy {
+    min-inline-size: 0;
+  }
+
+  .review-group-row__name {
+    font-family: var(--font-ui);
+    font-weight: 600;
+  }
+
+  .review-group-row__counts {
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+    text-align: end;
+  }
+
+  .review-option {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: var(--space-3);
+    align-items: center;
+    padding: var(--space-3) var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+  }
+
+  .review-option--limit {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+  }
+
+  .review-option input[type='radio'] {
+    margin: 0;
+    accent-color: var(--color-primary);
+  }
+
+  .review-option__body {
+    min-inline-size: 0;
+  }
+
+  .review-option__title {
+    font-family: var(--font-ui);
+    font-weight: 600;
+  }
+
+  .review-option__input,
+  .review-start-button {
+    min-block-size: 2.75rem;
+    border-radius: var(--radius-md);
     font-family: var(--font-ui);
   }
 
-  .review-preview__status {
-    color: var(--color-info-text);
-    font-size: var(--font-size-caption);
-    letter-spacing: var(--tracking-caps);
-    text-transform: uppercase;
-  }
-
-  .review-preview__status p {
-    margin: 0;
-  }
-
-  .review-card {
-    padding: var(--space-5);
-    border: 1px solid var(--color-info-border);
-    border-radius: var(--radius-lg);
-    background: color-mix(in srgb, var(--color-info-bg) 55%, var(--color-surface));
-    box-shadow: var(--shadow-sm);
-  }
-
-  .review-card__eyebrow,
-  .review-card p,
-  .review-card h2 {
-    margin: 0;
-  }
-
-  .review-card__eyebrow {
-    color: var(--color-text-secondary);
-    font-size: var(--font-size-caption);
-    letter-spacing: var(--tracking-caps);
-    text-transform: uppercase;
-  }
-
-  .review-card h2 {
-    font-size: clamp(2.25rem, 8vw, 3.25rem);
-    line-height: var(--leading-tight);
-  }
-
-  .review-card__example {
-    color: var(--color-text-secondary);
-  }
-
-  .review-actions__pill {
-    flex: 1;
-    min-block-size: 2.75rem;
-    padding: var(--space-3);
-    border: 1px solid var(--color-info-border);
-    border-radius: var(--radius-md);
-    background: var(--color-surface);
+  .review-option__input {
+    inline-size: 5.5rem;
+    padding-inline: var(--space-3);
+    border: 1px solid var(--color-border);
+    background: var(--color-surface-raised);
     color: var(--color-text-primary);
-    text-align: center;
-    font-size: var(--font-size-ui);
   }
 
-  @media (max-width: 40rem) {
-    .review-actions {
-      flex-direction: column;
+  .review-setup__actions {
+    align-items: stretch;
+  }
+
+  .review-start-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    inline-size: 100%;
+    padding-inline: var(--space-4);
+    border: 1px solid var(--color-primary);
+    background: var(--color-primary);
+    color: var(--color-text-inverse);
+    font-weight: 600;
+    text-decoration: none;
+  }
+
+  .review-start-button:disabled {
+    border-color: var(--color-border);
+    background: var(--color-surface-subtle);
+    color: var(--color-text-disabled);
+    cursor: not-allowed;
+  }
+  @media (max-width: 48rem) {
+    .review-group-row,
+    .review-option--limit {
+      grid-template-columns: auto minmax(0, 1fr);
+    }
+
+    .review-group-row__counts,
+    .review-option__input {
+      grid-column: 2;
+      justify-self: start;
+      text-align: start;
+    }
+
+    .review-panel__header {
+      align-items: flex-start;
     }
   }
 </style>

--- a/apps/web/src/routes/[lang]/card-review/session/+page.server.ts
+++ b/apps/web/src/routes/[lang]/card-review/session/+page.server.ts
@@ -1,0 +1,48 @@
+import { error, redirect } from '@sveltejs/kit';
+import { getDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import { CardReviewRequestError, loadCardReviewSessionData } from '$lib/server/card-review.js';
+import type { PageServerLoad } from './$types.js';
+
+export const load: PageServerLoad = async (event) => {
+  const { session } = await event.parent();
+  const languageCode = event.params.lang;
+
+  if (!languageCode) {
+    throw redirect(303, '/');
+  }
+
+  if (!session?.user?.id) {
+    return {
+      reviewSession: null,
+      loadError: 'You must be signed in to start a Card Review session.',
+    };
+  }
+
+  if (!env.DATABASE_URL) {
+    return {
+      reviewSession: null,
+      loadError: 'Card Review is not configured right now.',
+    };
+  }
+
+  const database = getDb(env.DATABASE_URL);
+
+  try {
+    return {
+      reviewSession: await loadCardReviewSessionData(session.user.id, languageCode, event.url, database),
+      loadError: null,
+    };
+  } catch (requestError) {
+    if (requestError instanceof CardReviewRequestError) {
+      throw error(requestError.status, requestError.message);
+    }
+
+    console.error('Failed to load Card Review session:', requestError);
+
+    return {
+      reviewSession: null,
+      loadError: 'The Card Review session could not be loaded right now.',
+    };
+  }
+};

--- a/apps/web/src/routes/[lang]/card-review/session/+page.svelte
+++ b/apps/web/src/routes/[lang]/card-review/session/+page.svelte
@@ -1,0 +1,332 @@
+<script lang="ts">
+  import { page } from '$app/stores';
+  import type { PageData } from './$types.js';
+
+  export let data: PageData;
+
+  type ReviewSessionData = NonNullable<PageData['reviewSession']>;
+
+  const shortDateFormatter = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+
+  $: reviewSession = data.reviewSession;
+  $: currentLanguage = $page.params.lang ?? '';
+  $: firstItem = reviewSession?.items[0] ?? null;
+  $: queuePreview = reviewSession?.items.slice(1, 5) ?? [];
+  $: homeHref = buildHomeHref();
+
+  function formatCardLabel(count: number, noun = 'card'): string {
+    return `${count} ${noun}${count === 1 ? '' : 's'}`;
+  }
+
+  function formatShortDate(value: string | null): string {
+    return value ? shortDateFormatter.format(new Date(value)) : 'Due now';
+  }
+
+  function buildHomeHref(): string {
+    if (!reviewSession) {
+      return `/${currentLanguage}/card-review`;
+    }
+
+    const params = new URLSearchParams();
+
+    for (const groupId of reviewSession.selection.groupIds) {
+      params.append('group', groupId);
+    }
+
+    if (reviewSession.selection.limit !== null) {
+      params.set('limit', String(reviewSession.selection.limit));
+    }
+
+    const query = params.toString();
+    return `/${currentLanguage}/card-review${query ? `?${query}` : ''}`;
+  }
+</script>
+
+<svelte:head>
+  <title>Card Review Session – StudyPuck</title>
+</svelte:head>
+
+{#if data.loadError}
+  <section class="review-session stack" style="--stack-space: var(--space-5)">
+    <header class="review-session__header stack" style="--stack-space: var(--space-2)">
+      <p class="review-session__eyebrow">Session</p>
+      <h1>Card Review</h1>
+      <p class="review-session__copy">{data.loadError}</p>
+    </header>
+  </section>
+{:else if reviewSession}
+  <section class="review-session stack" style="--stack-space: var(--space-5)">
+    <header class="review-session__header stack" style="--stack-space: var(--space-2)">
+      <p class="review-session__eyebrow">Session</p>
+      <div class="review-session__title cluster">
+        <h1>Card Review</h1>
+        <a class="review-session__back-link" href={homeHref}>Back to setup</a>
+      </div>
+      <p class="review-session__copy">
+        {#if reviewSession.totalCount > 0}
+          Session ready with {formatCardLabel(reviewSession.totalCount)} from {formatCardLabel(reviewSession.selection.groupIds.length, 'group')}.
+        {:else}
+          No due cards were loaded for this selection.
+        {/if}
+      </p>
+    </header>
+
+    <section class="review-session__summary cluster" aria-label="Session summary">
+      <div class="review-session__summary-item stack" style="--stack-space: var(--space-1)">
+        <span class="review-session__summary-label">Groups</span>
+        <span class="review-session__summary-value">{formatCardLabel(reviewSession.selection.groupIds.length, 'group')}</span>
+      </div>
+
+      <div class="review-session__summary-item stack" style="--stack-space: var(--space-1)">
+        <span class="review-session__summary-label">Mode</span>
+        <span class="review-session__summary-value">
+          {#if reviewSession.selection.limit === null}
+            All due cards
+          {:else}
+            Limit {reviewSession.selection.limit}
+          {/if}
+        </span>
+      </div>
+
+      <div class="review-session__summary-item stack" style="--stack-space: var(--space-1)">
+        <span class="review-session__summary-label">Loaded</span>
+        <span class="review-session__summary-value">{formatCardLabel(reviewSession.totalCount)}</span>
+      </div>
+    </section>
+
+    {#if reviewSession.totalCount === 0}
+      <section class="review-state review-state--empty stack" style="--stack-space: var(--space-2)">
+        <h2>Nothing due right now</h2>
+        <p>Return to the setup screen to adjust the selected groups or wait for the next due cards to arrive.</p>
+      </section>
+    {:else if firstItem}
+      <article class="review-card stack" style="--stack-space: var(--space-4)">
+        <div class="review-card__header cluster">
+          <div class="stack" style="--stack-space: var(--space-1)">
+            <p class="review-card__eyebrow">First queued card</p>
+            <h2>{firstItem.content}</h2>
+          </div>
+          <p class="review-card__due">Due {formatShortDate(firstItem.nextDueAtIso)}</p>
+        </div>
+
+        {#if firstItem.meaning}
+          <p class="review-card__meaning">{firstItem.meaning}</p>
+        {/if}
+
+        {#if firstItem.examples.length > 0}
+          <div class="stack" style="--stack-space: var(--space-2)">
+            <p class="review-card__section-label">Examples</p>
+            <ol class="review-card__examples stack" style="--stack-space: var(--space-2)">
+              {#each firstItem.examples as example}
+                <li>{example}</li>
+              {/each}
+            </ol>
+          </div>
+        {/if}
+
+        {#if firstItem.mnemonics.length > 0}
+          <div class="review-card__mnemonic stack" style="--stack-space: var(--space-2)">
+            <p class="review-card__section-label">Mnemonic</p>
+            <p>{firstItem.mnemonics[0]}</p>
+          </div>
+        {/if}
+
+        {#if firstItem.groups.length > 0}
+          <div class="review-card__groups cluster" aria-label="Card groups">
+            {#each firstItem.groups as group}
+              <span class="review-card__group-chip">{group.groupName}</span>
+            {/each}
+          </div>
+        {/if}
+      </article>
+
+      {#if queuePreview.length > 0}
+        <section class="review-queue stack" style="--stack-space: var(--space-3)" aria-labelledby="queue-preview-title">
+          <div class="stack" style="--stack-space: var(--space-1)">
+            <h2 id="queue-preview-title">Queue preview</h2>
+            <p class="review-queue__copy">The next few cards queued after the opener.</p>
+          </div>
+
+          <ol class="review-queue__list stack" style="--stack-space: var(--space-2)">
+            {#each queuePreview as item}
+              <li class="review-queue__item">
+                <div class="stack" style="--stack-space: var(--space-1)">
+                  <span class="review-queue__content">{item.content}</span>
+                  {#if item.meaning}
+                    <span class="review-queue__meaning">{item.meaning}</span>
+                  {/if}
+                </div>
+                <span class="review-queue__meta">{formatShortDate(item.nextDueAtIso)}</span>
+              </li>
+            {/each}
+          </ol>
+
+          {#if reviewSession.totalCount > queuePreview.length + 1}
+            <p class="review-queue__remaining">
+              +{reviewSession.totalCount - queuePreview.length - 1} more queued
+            </p>
+          {/if}
+        </section>
+      {/if}
+    {/if}
+  </section>
+{/if}
+
+<style>
+  .review-session {
+    padding: calc(var(--shell-header-height) + var(--space-5)) var(--space-4) calc(var(--space-7) + 4.5rem);
+  }
+
+  .review-session__eyebrow,
+  .review-session__summary-label,
+  .review-card__eyebrow,
+  .review-card__section-label,
+  .review-queue__copy,
+  .review-queue__meaning,
+  .review-queue__remaining,
+  .review-card__due {
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+  }
+
+  .review-session__eyebrow,
+  .review-session__summary-label,
+  .review-card__eyebrow,
+  .review-card__section-label {
+    font-size: var(--font-size-caption);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .review-session__title,
+  .review-card__header,
+  .review-queue__item {
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  .review-session__header h1,
+  .review-session__copy,
+  .review-session__summary-value,
+  .review-state h2,
+  .review-state p,
+  .review-card__header h2,
+  .review-card__meaning,
+  .review-card__mnemonic p,
+  .review-queue__content,
+  .review-queue__remaining {
+    margin: 0;
+  }
+
+  .review-session__back-link {
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+    text-decoration: none;
+  }
+
+  .review-session__summary {
+    gap: var(--space-3);
+  }
+
+  .review-session__summary-item,
+  .review-card,
+  .review-queue,
+  .review-state {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+  }
+
+  .review-session__summary-item {
+    flex: 1 1 10rem;
+    min-inline-size: min(100%, 10rem);
+    padding: var(--space-3) var(--space-4);
+  }
+
+  .review-session__summary-value,
+  .review-queue__content {
+    font-family: var(--font-ui);
+    font-weight: 600;
+  }
+
+  .review-card,
+  .review-queue,
+  .review-state {
+    padding: var(--space-4);
+  }
+
+  .review-card {
+    background: color-mix(in srgb, var(--color-info-bg) 24%, var(--color-surface));
+    border-color: var(--color-info-border);
+  }
+
+  .review-card__header h2 {
+    font-size: clamp(2rem, 8vw, 3rem);
+    line-height: var(--leading-tight);
+  }
+
+  .review-card__meaning {
+    font-size: var(--font-size-h4);
+  }
+
+  .review-card__examples {
+    padding-inline-start: 1.25rem;
+    margin: 0;
+  }
+
+  .review-card__mnemonic {
+    padding: var(--space-3);
+    border-radius: var(--radius-md);
+    background: var(--color-warning-bg);
+    border: 1px solid var(--color-warning-border);
+  }
+
+  .review-card__groups {
+    gap: var(--space-2);
+  }
+
+  .review-card__group-chip {
+    display: inline-flex;
+    align-items: center;
+    min-block-size: 1.875rem;
+    padding-inline: var(--space-3);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-raised);
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-caption);
+  }
+
+  .review-queue__list {
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  .review-queue__item {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    padding: var(--space-3) var(--space-4);
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-subtle);
+  }
+
+  @media (max-width: 48rem) {
+    .review-session__title,
+    .review-card__header {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .review-queue__item {
+      grid-template-columns: 1fr;
+      justify-items: start;
+    }
+  }
+</style>

--- a/apps/web/tests/e2e/card-review.spec.ts
+++ b/apps/web/tests/e2e/card-review.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from '@playwright/test';
+import {
+	resetDatabase,
+	seedCardReviewCard,
+	seedCardReviewDailyStat,
+	seedGroup,
+	seedUser
+} from './support/database';
+import { signInAs } from './support/session';
+
+test('configures a Card Review session from the home screen and loads the queued cards', async ({ page }) => {
+	await resetDatabase();
+
+	const user = await seedUser({
+		userId: 'auth0|e2e-card-review',
+		email: 'card-review@example.com',
+		name: 'Card Review User',
+		languages: [{ code: 'zh', label: 'Chinese' }]
+	});
+
+	const coreGroup = await seedGroup({
+		userId: user.userId,
+		languageId: 'zh',
+		groupId: 'group-core-review',
+		groupName: 'Core Review'
+	});
+
+	const futureGroup = await seedGroup({
+		userId: user.userId,
+		languageId: 'zh',
+		groupId: 'group-future-review',
+		groupName: 'Future Review'
+	});
+
+	await seedCardReviewCard({
+		userId: user.userId,
+		languageId: 'zh',
+		cardId: 'card-review-due-1',
+		cardContent: '补偿',
+		meaning: 'to compensate',
+		examples: ['我们以后再补偿这次错过的时间。'],
+		groupId: coreGroup.groupId,
+		dueAt: new Date('2026-05-09T12:00:00.000Z'),
+		lastReviewedAt: new Date('2026-05-07T12:00:00.000Z'),
+		reviewCount: 1,
+		intervalDays: 2
+	});
+
+	await seedCardReviewCard({
+		userId: user.userId,
+		languageId: 'zh',
+		cardId: 'card-review-due-2',
+		cardContent: '巩固',
+		meaning: 'to consolidate',
+		mnemonics: ['solid core'],
+		groupId: coreGroup.groupId,
+		dueAt: new Date('2026-05-08T12:00:00.000Z'),
+		lastReviewedAt: new Date('2026-05-06T12:00:00.000Z'),
+		reviewCount: 1,
+		intervalDays: 2
+	});
+
+	await seedCardReviewCard({
+		userId: user.userId,
+		languageId: 'zh',
+		cardId: 'card-review-future',
+		cardContent: '逐渐',
+		meaning: 'gradually',
+		groupId: futureGroup.groupId,
+		dueAt: new Date('2026-05-12T12:00:00.000Z'),
+		lastReviewedAt: new Date('2026-05-08T12:00:00.000Z'),
+		reviewCount: 2,
+		intervalDays: 4
+	});
+
+	await seedCardReviewDailyStat({
+		userId: user.userId,
+		languageId: 'zh',
+		date: new Date().toISOString().slice(0, 10),
+		cardsReviewed: 2
+	});
+
+	await seedCardReviewDailyStat({
+		userId: user.userId,
+		languageId: 'zh',
+		date: new Date(Date.now() - 86_400_000).toISOString().slice(0, 10),
+		cardsReviewed: 4
+	});
+
+	await signInAs(page, user);
+	await page.goto('/zh/card-review');
+
+	const contextView = page.getByLabel('Context view', { exact: true });
+	await expect(contextView.getByRole('heading', { name: 'Card Review' })).toBeVisible();
+	await expect(contextView.getByText('Core Review')).toBeVisible();
+	await expect(contextView.getByText('Future Review')).toBeVisible();
+	await expect(contextView.getByText('2 cards in rotation')).toBeVisible();
+	await expect(contextView.getByText('1 card in rotation')).toBeVisible();
+
+	const startButton = contextView.getByRole('button', { name: 'Start Session' });
+	await expect(startButton).toBeDisabled();
+
+	await contextView.getByRole('checkbox', { name: /Core Review/i }).check();
+	await expect(startButton).toBeEnabled();
+
+	await contextView.getByRole('radio', { name: /Limit to N cards/i }).check();
+	await contextView.getByRole('spinbutton', { name: 'Session size' }).fill('1');
+	await startButton.click();
+
+	await page.waitForURL(/\/zh\/card-review\/session\?.*group=group-core-review.*limit=1/);
+	await expect(contextView.getByText('Session ready with 1 card from 1 group.')).toBeVisible();
+	await expect(contextView.getByText('First queued card')).toBeVisible();
+	await expect(contextView.getByRole('heading', { name: '巩固' })).toBeVisible();
+	await expect(contextView.getByText('Core Review')).toBeVisible();
+});

--- a/apps/web/tests/e2e/support/database.ts
+++ b/apps/web/tests/e2e/support/database.ts
@@ -2,6 +2,8 @@ import {
 	addCardToGroup,
 	addStudyLanguage,
 	cardEntryDailyStats,
+	cardReviewDailyStats,
+	cardReviewSrs,
 	createDraftCardFromNote,
 	createGroup,
 	createInboxNote,
@@ -56,6 +58,35 @@ type SeedActiveCardOptions = {
 	cardType?: 'word' | 'pattern' | 'complex_prompt';
 	groupName?: string;
 	groupId?: string;
+	examples?: string[];
+	mnemonics?: string[];
+	llmInstructions?: string | null;
+	createdAt?: Date;
+	updatedAt?: Date;
+};
+
+type SeedCardReviewCardOptions = SeedActiveCardOptions & {
+	dueAt?: Date | null;
+	intervalDays?: number;
+	easeFactor?: number;
+	reviewCount?: number;
+	lastReviewedAt?: Date | null;
+	state?: 'active' | 'snoozed' | 'disabled';
+	snoozedUntil?: Date | null;
+};
+
+type SeedCardReviewDailyStatOptions = {
+	userId: string;
+	languageId: string;
+	date: string;
+	cardsReviewed?: number;
+	cardsRatedEasy?: number;
+	cardsRatedMedium?: number;
+	cardsRatedHard?: number;
+	cardsSnoozed?: number;
+	cardsDisabled?: number;
+	cardsPinnedToDrills?: number;
+	totalReviewTimeMinutes?: number;
 };
 
 type SeedGroupOptions = {
@@ -183,7 +214,8 @@ export async function seedActiveCard(options: SeedActiveCardOptions) {
 	const database = getDb(testDatabaseUrl);
 	const cardId = options.cardId ?? `card-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 	const groupId = options.groupId ?? `group-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-	const now = new Date();
+	const createdAt = options.createdAt ?? new Date();
+	const updatedAt = options.updatedAt ?? createdAt;
 
 	const [card] = await database
 		.insert(cards)
@@ -194,9 +226,12 @@ export async function seedActiveCard(options: SeedActiveCardOptions) {
 			content: options.cardContent,
 			meaning: options.meaning ?? null,
 			cardType: options.cardType ?? 'word',
+			examples: options.examples ?? [],
+			mnemonics: options.mnemonics ?? [],
+			llmInstructions: options.llmInstructions ?? null,
 			status: 'active',
-			createdAt: now,
-			updatedAt: now,
+			createdAt,
+			updatedAt,
 		})
 		.returning();
 
@@ -224,6 +259,17 @@ export async function seedActiveCard(options: SeedActiveCardOptions) {
 				languageId: options.languageId,
 				cardId: card.cardId,
 				groupId: group.groupId,
+			},
+			database as never
+		);
+	} else if (options.groupId) {
+		createdGroupId = options.groupId;
+		await addCardToGroup(
+			{
+				userId: options.userId,
+				languageId: options.languageId,
+				cardId: card.cardId,
+				groupId: options.groupId,
 			},
 			database as never
 		);
@@ -275,4 +321,47 @@ export async function getTodayCardEntryStats(userId: string, languageId: string)
 		.limit(1);
 
 	return stats ?? null;
+}
+
+export async function seedCardReviewCard(options: SeedCardReviewCardOptions) {
+	const database = getDb(testDatabaseUrl);
+	const { card, groupId } = await seedActiveCard(options);
+
+	await database.insert(cardReviewSrs).values({
+		userId: options.userId,
+		languageId: options.languageId,
+		cardId: card.cardId,
+		nextDue: options.dueAt ? Math.floor(options.dueAt.getTime() / 1_000) : null,
+		intervalDays: options.intervalDays ?? 1,
+		easeFactor: options.easeFactor ?? 2.5,
+		reviewCount: options.reviewCount ?? 0,
+		lastReviewed: options.lastReviewedAt ? Math.floor(options.lastReviewedAt.getTime() / 1_000) : null,
+		state: options.state ?? 'active',
+		snoozedUntil: options.snoozedUntil ?? null,
+	});
+
+	return { card, groupId };
+}
+
+export async function seedCardReviewDailyStat(options: SeedCardReviewDailyStatOptions) {
+	const database = getDb(testDatabaseUrl);
+
+	const [stat] = await database
+		.insert(cardReviewDailyStats)
+		.values({
+			userId: options.userId,
+			languageId: options.languageId,
+			date: options.date,
+			cardsReviewed: options.cardsReviewed ?? 0,
+			cardsRatedEasy: options.cardsRatedEasy ?? 0,
+			cardsRatedMedium: options.cardsRatedMedium ?? 0,
+			cardsRatedHard: options.cardsRatedHard ?? 0,
+			cardsSnoozed: options.cardsSnoozed ?? 0,
+			cardsDisabled: options.cardsDisabled ?? 0,
+			cardsPinnedToDrills: options.cardsPinnedToDrills ?? 0,
+			totalReviewTimeMinutes: options.totalReviewTimeMinutes ?? 0,
+		})
+		.returning();
+
+	return stat ?? null;
 }


### PR DESCRIPTION
## Summary
- replace the Card Review placeholder with a real setup screen backed by server data
- add a minimal /card-review/session handoff route that loads queued cards from the existing backend contract
- add Card Review browser coverage plus e2e seeding helpers for review SRS and daily stats

## Testing
- pnpm turbo test lint build --filter=web
- pnpm test:e2e:secure

Closes #188