### PR TITLE
Implement Card Review session actions and drawer integration

### DIFF
--- a/apps/web/src/lib/components/cards/ActiveCardDrawer.svelte
+++ b/apps/web/src/lib/components/cards/ActiveCardDrawer.svelte
@@ -49,6 +49,7 @@
   export let hasPrevious = false;
   export let hasNext = false;
   export let disabled = false;
+  export let allowDelete = true;
 
   let draft = structuredClone(card);
   let previousCard = card;
@@ -361,7 +362,7 @@
   }
 
   async function confirmDelete() {
-    if (disabled || removePending) {
+    if (disabled || removePending || !allowDelete) {
       return;
     }
 
@@ -760,20 +761,22 @@
     </details>
   </div>
 
-  <footer class="active-card-drawer__footer">
-    <button
-      type="button"
-      class="active-card-drawer__delete"
-      disabled={disabled || removePending}
-      on:click={() => {
-        deleteConfirmOpen = true;
-      }}
-    >
-      {removePending ? 'Deleting…' : 'Delete card'}
-    </button>
-  </footer>
+  {#if allowDelete}
+    <footer class="active-card-drawer__footer">
+      <button
+        type="button"
+        class="active-card-drawer__delete"
+        disabled={disabled || removePending}
+        on:click={() => {
+          deleteConfirmOpen = true;
+        }}
+      >
+        {removePending ? 'Deleting…' : 'Delete card'}
+      </button>
+    </footer>
+  {/if}
 
-  {#if deleteConfirmOpen}
+  {#if allowDelete && deleteConfirmOpen}
     <div class="active-card-drawer__confirm-backdrop">
       <div class="active-card-drawer__confirm stack" style="--stack-space: var(--space-3)" role="alertdialog" aria-modal="true">
         <h2>Delete "{draft.content}"?</h2>

--- a/apps/web/src/lib/components/cards/ActiveCardDrawer.test.ts
+++ b/apps/web/src/lib/components/cards/ActiveCardDrawer.test.ts
@@ -119,6 +119,21 @@ describe('ActiveCardDrawer', () => {
     });
   });
 
+  it('hides delete controls when delete is not allowed', () => {
+    render(ActiveCardDrawer, {
+      props: {
+        lang: 'zh',
+        card: createCard(),
+        availableGroups: [],
+        selectedIndex: 0,
+        totalCount: 1,
+        allowDelete: false,
+      },
+    });
+
+    expect(screen.queryByRole('button', { name: 'Delete card' })).toBeNull();
+  });
+
   it('applies append-mnemonic suggestions through the active-card PATCH endpoint', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/apps/web/src/lib/server/card-review.test.ts
+++ b/apps/web/src/lib/server/card-review.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  applyCardReviewSessionAction,
   CardReviewRequestError,
+  type CardReviewActionDeps,
   type CardReviewLoaderDeps,
   loadCardReviewHomeData,
   loadCardReviewSessionData,
@@ -62,6 +64,10 @@ describe('Card Review server helpers', () => {
         snoozedUntil: null,
       },
     ]),
+    getGroups: vi.fn(async () => [
+      { groupId: 'group-extended', groupName: 'Extended' },
+      { groupId: 'group-core', groupName: 'Core' },
+    ]),
   };
   const deps = baseDeps as unknown as CardReviewLoaderDeps;
 
@@ -107,6 +113,10 @@ describe('Card Review server helpers', () => {
       cardId: 'card-1',
       nextDueAtIso: '2026-05-09T12:00:00.000Z',
     });
+    expect(result.availableGroups).toEqual([
+      { groupId: 'group-core', groupName: 'Core' },
+      { groupId: 'group-extended', groupName: 'Extended' },
+    ]);
   });
 
   it('rejects invalid session input before hitting the data layer', async () => {
@@ -132,6 +142,142 @@ describe('Card Review server helpers', () => {
 
     await expect(loadCardReviewHomeData('user-1', 'ja', url, database, deps)).rejects.toMatchObject({
       status: 404,
+    } satisfies Partial<CardReviewRequestError>);
+  });
+});
+
+describe('applyCardReviewSessionAction', () => {
+  const database = {} as never;
+  const now = new Date('2026-05-10T12:00:00.000Z');
+  const baseResult = {
+    eventId: 'event-1',
+    cardId: 'card-1',
+    rating: null,
+    occurredAt: now,
+    state: 'active' as const,
+    snoozedUntil: null,
+    nextDueAt: new Date('2026-05-12T12:00:00.000Z'),
+    intervalDays: 2,
+    easeFactor: 2.5,
+    reviewCount: 4,
+  };
+
+  const actionDeps = {
+    getActiveUserLanguages: vi.fn(async () => [{
+      userId: 'user-1',
+      languageId: 'zh',
+      languageName: 'Chinese',
+      isActive: true,
+      cefrLevel: null,
+      settings: null,
+      createdAt: null,
+    }]),
+    recordCardReviewRating: vi.fn(async () => ({
+      ...baseResult,
+      eventType: 'rated' as const,
+      rating: 'easy' as const,
+    })),
+    recordCardReviewPinToDrills: vi.fn(async () => ({
+      ...baseResult,
+      eventType: 'pinned_to_drills' as const,
+    })),
+    snoozeCardForReview: vi.fn(async () => ({
+      ...baseResult,
+      eventType: 'snoozed' as const,
+      state: 'snoozed' as const,
+      snoozedUntil: new Date('2026-05-11T12:00:00.000Z'),
+    })),
+    disableCardForReview: vi.fn(async () => ({
+      ...baseResult,
+      eventType: 'disabled' as const,
+      state: 'disabled' as const,
+    })),
+    now: vi.fn(() => now),
+  };
+  const deps = actionDeps as unknown as CardReviewActionDeps;
+
+  it('records a rating action and returns a UI-friendly response', async () => {
+    const result = await applyCardReviewSessionAction(
+      'user-1',
+      'zh',
+      {
+        action: 'rate',
+        cardId: 'card-1',
+        rating: 'easy',
+      },
+      database,
+      deps,
+    );
+
+    expect(actionDeps.recordCardReviewRating).toHaveBeenCalledWith(
+      'user-1',
+      'zh',
+      'card-1',
+      'easy',
+      { reviewedAt: now },
+      database,
+    );
+    expect(result).toMatchObject({
+      action: 'rate',
+      cardId: 'card-1',
+      rating: 'easy',
+      occurredAtIso: '2026-05-10T12:00:00.000Z',
+      message: 'Easy recorded.',
+    });
+  });
+
+  it('uses the default 24-hour snooze duration for snooze actions', async () => {
+    await applyCardReviewSessionAction(
+      'user-1',
+      'zh',
+      {
+        action: 'snooze',
+        cardId: 'card-1',
+      },
+      database,
+      deps,
+    );
+
+    expect(actionDeps.snoozeCardForReview).toHaveBeenCalledWith(
+      'user-1',
+      'zh',
+      'card-1',
+      new Date('2026-05-11T12:00:00.000Z'),
+      { occurredAt: now },
+      database,
+    );
+  });
+
+  it('rejects invalid review action payloads', async () => {
+    await expect(applyCardReviewSessionAction(
+      'user-1',
+      'zh',
+      {
+        action: 'rate',
+        cardId: 'card-1',
+      },
+      database,
+      deps,
+    )).rejects.toMatchObject({
+      status: 400,
+    } satisfies Partial<CardReviewRequestError>);
+  });
+
+  it('converts missing-card mutation errors into request errors', async () => {
+    actionDeps.disableCardForReview.mockRejectedValueOnce(new Error('That card is not available for review.'));
+
+    await expect(applyCardReviewSessionAction(
+      'user-1',
+      'zh',
+      {
+        action: 'disable',
+        cardId: 'card-1',
+      },
+      database,
+      deps,
+    )).rejects.toMatchObject({
+      status: 404,
+      message: 'That card is not available for review.',
     } satisfies Partial<CardReviewRequestError>);
   });
 });

--- a/apps/web/src/lib/server/card-review.ts
+++ b/apps/web/src/lib/server/card-review.ts
@@ -1,15 +1,21 @@
 import {
+  disableCardForReview,
   getActiveUserLanguages,
   getCardReviewHomeStats,
   getDb,
+  getGroups,
   listCardReviewGroupSummaries,
   listCardReviewSessionCards,
+  recordCardReviewPinToDrills,
+  recordCardReviewRating,
+  snoozeCardForReview,
   type CardReviewGroupSummary,
   type CardReviewHomeStats,
   type CardReviewQueueItem,
+  type CardReviewRating,
 } from '@studypuck/database';
 import { z } from 'zod';
-import { activeGroupIdSchema } from '$lib/schemas/cards.js';
+import { activeCardIdSchema, activeGroupIdSchema } from '$lib/schemas/cards.js';
 
 type DatabaseClient = ReturnType<typeof getDb>;
 
@@ -18,6 +24,15 @@ export type CardReviewLoaderDeps = {
   getCardReviewHomeStats: typeof getCardReviewHomeStats;
   listCardReviewGroupSummaries: typeof listCardReviewGroupSummaries;
   listCardReviewSessionCards: typeof listCardReviewSessionCards;
+  getGroups: typeof getGroups;
+};
+
+export type CardReviewActionDeps = Pick<CardReviewLoaderDeps, 'getActiveUserLanguages'> & {
+  recordCardReviewRating: typeof recordCardReviewRating;
+  recordCardReviewPinToDrills: typeof recordCardReviewPinToDrills;
+  snoozeCardForReview: typeof snoozeCardForReview;
+  disableCardForReview: typeof disableCardForReview;
+  now: () => Date;
 };
 
 const defaultLoaderDeps: CardReviewLoaderDeps = {
@@ -25,9 +40,41 @@ const defaultLoaderDeps: CardReviewLoaderDeps = {
   getCardReviewHomeStats,
   listCardReviewGroupSummaries,
   listCardReviewSessionCards,
+  getGroups,
+};
+
+const defaultActionDeps: CardReviewActionDeps = {
+  getActiveUserLanguages,
+  recordCardReviewRating,
+  recordCardReviewPinToDrills,
+  snoozeCardForReview,
+  disableCardForReview,
+  now: () => new Date(),
 };
 
 const cardReviewSessionLimitSchema = z.coerce.number().int().min(1, 'Session size must be at least 1 card.').max(100, 'Session size must be 100 cards or fewer.');
+const cardReviewRatingSchema = z.enum(['easy', 'medium', 'hard']);
+const cardReviewSessionActionSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('rate'),
+    cardId: activeCardIdSchema,
+    rating: cardReviewRatingSchema,
+  }),
+  z.object({
+    action: z.literal('pin'),
+    cardId: activeCardIdSchema,
+  }),
+  z.object({
+    action: z.literal('snooze'),
+    cardId: activeCardIdSchema,
+  }),
+  z.object({
+    action: z.literal('disable'),
+    cardId: activeCardIdSchema,
+  }),
+]);
+
+const CARD_REVIEW_DEFAULT_SNOOZE_DURATION_MS = 24 * 60 * 60 * 1_000;
 
 export class CardReviewRequestError extends Error {
   status: number;
@@ -93,6 +140,23 @@ export type CardReviewSessionData = {
   selection: CardReviewSessionSelection;
   totalCount: number;
   items: CardReviewSessionItemData[];
+  availableGroups: Array<{ groupId: string; groupName: string }>;
+};
+
+export type CardReviewSessionActionInput = z.infer<typeof cardReviewSessionActionSchema>;
+
+export type CardReviewSessionActionResult = {
+  action: CardReviewSessionActionInput['action'];
+  cardId: string;
+  rating: CardReviewRating | null;
+  occurredAtIso: string;
+  state: 'active' | 'snoozed' | 'disabled';
+  snoozedUntilIso: string | null;
+  nextDueAtIso: string | null;
+  intervalDays: number;
+  easeFactor: number;
+  reviewCount: number;
+  message: string;
 };
 
 async function assertUserHasLanguage(
@@ -197,6 +261,42 @@ function findNextDue(groups: CardReviewGroupSummary[]): string | null {
   return toIsoString(nextDueAt);
 }
 
+function mapAvailableGroup(group: { groupId: string; groupName: string }) {
+  return {
+    groupId: group.groupId,
+    groupName: group.groupName,
+  };
+}
+
+function buildSessionActionMessage(action: CardReviewSessionActionInput['action'], rating: CardReviewRating | null): string {
+  if (action === 'rate') {
+    const label = rating === 'easy' ? 'Easy' : rating === 'medium' ? 'Medium' : 'Hard';
+    return `${label} recorded.`;
+  }
+
+  if (action === 'pin') {
+    return 'Card pinned to Translation Drills.';
+  }
+
+  if (action === 'snooze') {
+    return 'Card snoozed.';
+  }
+
+  return 'Card disabled.';
+}
+
+function normalizeMutationError(error: unknown): never {
+  if (error instanceof CardReviewRequestError) {
+    throw error;
+  }
+
+  if (error instanceof Error && error.message === 'That card is not available for review.') {
+    throw new CardReviewRequestError(404, error.message);
+  }
+
+  throw error;
+}
+
 export async function loadCardReviewHomeData(
   userId: string,
   languageId: string,
@@ -243,14 +343,93 @@ export async function loadCardReviewSessionData(
     throw new CardReviewRequestError(400, 'Select at least one group before starting a review session.');
   }
 
-  const items = await deps.listCardReviewSessionCards(userId, languageId, {
-    groupIds: selection.groupIds,
-    limit: selection.limit,
-  }, database as never);
+  const [items, availableGroups] = await Promise.all([
+    deps.listCardReviewSessionCards(userId, languageId, {
+      groupIds: selection.groupIds,
+      limit: selection.limit,
+    }, database as never),
+    deps.getGroups(userId, languageId, database as never),
+  ]);
 
   return {
     selection,
     totalCount: items.length,
     items: items.map((item) => mapSessionItem(item)),
+    availableGroups: [...availableGroups]
+      .map((group) => mapAvailableGroup(group))
+      .sort((left, right) => left.groupName.localeCompare(right.groupName)),
   };
+}
+
+export async function applyCardReviewSessionAction(
+  userId: string,
+  languageId: string,
+  input: unknown,
+  database: DatabaseClient,
+  deps: CardReviewActionDeps = defaultActionDeps,
+): Promise<CardReviewSessionActionResult> {
+  await assertUserHasLanguage(userId, languageId, database, deps);
+
+  const parsedInput = cardReviewSessionActionSchema.safeParse(input);
+
+  if (!parsedInput.success) {
+    throw new CardReviewRequestError(
+      400,
+      parsedInput.error.issues[0]?.message ?? 'A valid Card Review action is required.',
+    );
+  }
+
+  const occurredAt = deps.now();
+
+  try {
+    const result = parsedInput.data.action === 'rate'
+      ? await deps.recordCardReviewRating(
+        userId,
+        languageId,
+        parsedInput.data.cardId,
+        parsedInput.data.rating,
+        { reviewedAt: occurredAt },
+        database as never,
+      )
+      : parsedInput.data.action === 'pin'
+        ? await deps.recordCardReviewPinToDrills(
+          userId,
+          languageId,
+          parsedInput.data.cardId,
+          { occurredAt },
+          database as never,
+        )
+        : parsedInput.data.action === 'snooze'
+          ? await deps.snoozeCardForReview(
+            userId,
+            languageId,
+            parsedInput.data.cardId,
+            new Date(occurredAt.getTime() + CARD_REVIEW_DEFAULT_SNOOZE_DURATION_MS),
+            { occurredAt },
+            database as never,
+          )
+          : await deps.disableCardForReview(
+            userId,
+            languageId,
+            parsedInput.data.cardId,
+            { occurredAt },
+            database as never,
+          );
+
+    return {
+      action: parsedInput.data.action,
+      cardId: result.cardId,
+      rating: result.rating,
+      occurredAtIso: result.occurredAt.toISOString(),
+      state: result.state,
+      snoozedUntilIso: toIsoString(result.snoozedUntil),
+      nextDueAtIso: toIsoString(result.nextDueAt),
+      intervalDays: result.intervalDays ?? 1,
+      easeFactor: result.easeFactor ?? 2.5,
+      reviewCount: result.reviewCount ?? 0,
+      message: buildSessionActionMessage(parsedInput.data.action, result.rating),
+    };
+  } catch (error) {
+    normalizeMutationError(error);
+  }
 }

--- a/apps/web/src/routes/[lang]/card-review/session/+page.svelte
+++ b/apps/web/src/routes/[lang]/card-review/session/+page.svelte
@@ -1,28 +1,97 @@
 <script lang="ts">
   import { page } from '$app/stores';
+  import { tick } from 'svelte';
+  import ActiveCardDrawer from '$lib/components/cards/ActiveCardDrawer.svelte';
+  import type { CardLibraryCardDetailData, CardLibraryGroupData } from '$lib/server/cards.js';
   import type { PageData } from './$types.js';
 
   export let data: PageData;
 
   type ReviewSessionData = NonNullable<PageData['reviewSession']>;
+  type SessionItem = ReviewSessionData['items'][number];
+  type SessionActionResult = {
+    action: 'rate' | 'pin' | 'snooze' | 'disable';
+    cardId: string;
+    rating: 'easy' | 'medium' | 'hard' | null;
+    message: string;
+  };
+  type SessionActionResponse = Partial<SessionActionResult> & {
+    message?: string;
+  };
 
   const shortDateFormatter = new Intl.DateTimeFormat('en-US', {
     month: 'short',
     day: 'numeric',
   });
 
+  let queueItems: SessionItem[] = [];
+  let initialTotalCount = 0;
+  let sessionAvailableGroups: CardLibraryGroupData[] = [];
+  let ratingCounts = {
+    easy: 0,
+    medium: 0,
+    hard: 0,
+  };
+  let secondaryActionCounts = {
+    pin: 0,
+    snooze: 0,
+    disable: 0,
+  };
+  let startedAtMs = Date.now();
+  let completionAtMs: number | null = null;
+  let endedEarly = false;
+  let actionPending = false;
+  let actionError: string | null = null;
+  let actionMessage = '';
+  let drawerCardId: string | null = null;
+  let endSessionOpen = false;
+  let endSessionDialog: HTMLElement | null = null;
+  let previousReviewSession = data.reviewSession;
+
   $: reviewSession = data.reviewSession;
   $: currentLanguage = $page.params.lang ?? '';
-  $: firstItem = reviewSession?.items[0] ?? null;
-  $: queuePreview = reviewSession?.items.slice(1, 5) ?? [];
+  $: currentItem = queueItems[0] ?? null;
+  $: completedCount = initialTotalCount - queueItems.length;
+  $: currentCardNumber = currentItem ? completedCount + 1 : initialTotalCount;
+  $: reviewedCount = ratingCounts.easy + ratingCounts.medium + ratingCounts.hard;
+  $: hasPinnedCards = secondaryActionCounts.pin > 0;
+  $: sessionComplete = Boolean(reviewSession) && initialTotalCount > 0 && (queueItems.length === 0 || endedEarly);
   $: homeHref = buildHomeHref();
+  $: translationDrillsHref = `/${currentLanguage}/translation-drills`;
+  $: rootHomeHref = currentLanguage ? `/${currentLanguage}` : '/';
+  $: drawerIndex = drawerCardId ? queueItems.findIndex((item) => item.cardId === drawerCardId) : -1;
+  $: drawerItem = drawerIndex >= 0 ? queueItems[drawerIndex] : null;
+  $: drawerCard = drawerItem ? toDrawerCard(drawerItem) : null;
+  $: queuePreview = queueItems.slice(1, 6);
+  $: completionDurationLabel = formatDuration((completionAtMs ?? Date.now()) - startedAtMs);
 
-  function formatCardLabel(count: number, noun = 'card'): string {
-    return `${count} ${noun}${count === 1 ? '' : 's'}`;
+  $: if (reviewSession !== previousReviewSession) {
+    resetSessionState(reviewSession);
+    previousReviewSession = reviewSession;
   }
 
-  function formatShortDate(value: string | null): string {
-    return value ? shortDateFormatter.format(new Date(value)) : 'Due now';
+  function resetSessionState(session: ReviewSessionData | null) {
+    queueItems = session ? structuredClone(session.items) : [];
+    initialTotalCount = session?.totalCount ?? 0;
+    sessionAvailableGroups = session ? structuredClone(session.availableGroups) : [];
+    ratingCounts = {
+      easy: 0,
+      medium: 0,
+      hard: 0,
+    };
+    secondaryActionCounts = {
+      pin: 0,
+      snooze: 0,
+      disable: 0,
+    };
+    startedAtMs = Date.now();
+    completionAtMs = null;
+    endedEarly = false;
+    actionPending = false;
+    actionError = null;
+    actionMessage = '';
+    drawerCardId = null;
+    endSessionOpen = false;
   }
 
   function buildHomeHref(): string {
@@ -43,7 +112,295 @@
     const query = params.toString();
     return `/${currentLanguage}/card-review${query ? `?${query}` : ''}`;
   }
+
+  function formatCardLabel(count: number, noun = 'card'): string {
+    return `${count} ${noun}${count === 1 ? '' : 's'}`;
+  }
+
+  function formatShortDate(value: string | null): string {
+    return value ? shortDateFormatter.format(new Date(value)) : 'Due now';
+  }
+
+  function formatDuration(durationMs: number): string {
+    const totalSeconds = Math.max(0, Math.round(durationMs / 1_000));
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+
+    if (minutes === 0) {
+      return `${seconds}s`;
+    }
+
+    return `${minutes}m ${seconds}s`;
+  }
+
+  function toDrawerCard(item: SessionItem): CardLibraryCardDetailData {
+    return {
+      cardId: item.cardId,
+      content: item.content,
+      meaning: item.meaning,
+      cardType: item.cardType,
+      examples: item.examples,
+      mnemonics: item.mnemonics,
+      llmInstructions: item.llmInstructions,
+      updatedAtIso: item.updatedAtIso,
+      groups: item.groups,
+    };
+  }
+
+  function updateCounts(action: 'rate' | 'pin' | 'snooze' | 'disable', rating: 'easy' | 'medium' | 'hard' | null) {
+    if (action === 'rate' && rating) {
+      ratingCounts = {
+        ...ratingCounts,
+        [rating]: ratingCounts[rating] + 1,
+      };
+      return;
+    }
+
+    if (action === 'pin') {
+      secondaryActionCounts = {
+        ...secondaryActionCounts,
+        pin: secondaryActionCounts.pin + 1,
+      };
+      return;
+    }
+
+    if (action === 'snooze') {
+      secondaryActionCounts = {
+        ...secondaryActionCounts,
+        snooze: secondaryActionCounts.snooze + 1,
+      };
+      return;
+    }
+
+    secondaryActionCounts = {
+      ...secondaryActionCounts,
+      disable: secondaryActionCounts.disable + 1,
+    };
+  }
+
+  function updateDrawerAfterRemoval(cardId: string) {
+    if (!drawerCardId) {
+      return;
+    }
+
+    if (drawerCardId !== cardId) {
+      return;
+    }
+
+    const nextQueue = queueItems.filter((item) => item.cardId !== cardId);
+    const nextIndex = Math.min(drawerIndex, nextQueue.length - 1);
+    drawerCardId = nextIndex >= 0 ? nextQueue[nextIndex]?.cardId ?? null : null;
+  }
+
+  function removeCardFromQueue(cardId: string) {
+    updateDrawerAfterRemoval(cardId);
+    queueItems = queueItems.filter((item) => item.cardId !== cardId);
+
+    if (queueItems.length === 0) {
+      completionAtMs = Date.now();
+    }
+  }
+
+  function openDrawer(cardId: string) {
+    drawerCardId = cardId;
+    actionError = null;
+  }
+
+  function handleDrawerUpdated(event: CustomEvent<{ card: CardLibraryCardDetailData; availableGroups: CardLibraryGroupData[] }>) {
+    sessionAvailableGroups = event.detail.availableGroups;
+    queueItems = queueItems.map((item) => item.cardId === event.detail.card.cardId
+      ? {
+        ...item,
+        content: event.detail.card.content,
+        meaning: event.detail.card.meaning,
+        cardType: event.detail.card.cardType,
+        examples: event.detail.card.examples,
+        mnemonics: event.detail.card.mnemonics,
+        llmInstructions: event.detail.card.llmInstructions,
+        updatedAtIso: event.detail.card.updatedAtIso,
+        groups: event.detail.card.groups,
+      }
+      : item);
+  }
+
+  function handleDrawerDeleted(event: CustomEvent<{ cardId: string }>) {
+    removeCardFromQueue(event.detail.cardId);
+    actionMessage = 'Card deleted.';
+    actionError = null;
+  }
+
+  function navigateDrawer(direction: 'previous' | 'next') {
+    if (!drawerCardId || drawerIndex < 0) {
+      return;
+    }
+
+    const nextIndex = direction === 'previous' ? drawerIndex - 1 : drawerIndex + 1;
+    drawerCardId = queueItems[nextIndex]?.cardId ?? drawerCardId;
+  }
+
+  async function postAction(body: Record<string, unknown>): Promise<SessionActionResult> {
+    const response = await fetch(`/${currentLanguage}/card-review/session/actions`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const payload = (await response.json().catch(() => null)) as SessionActionResponse | null;
+
+    if (!response.ok || !payload?.cardId || !payload.action || typeof payload.message !== 'string') {
+      throw new Error(payload?.message ?? 'The review action could not be completed right now.');
+    }
+
+    return {
+      action: payload.action,
+      cardId: payload.cardId,
+      rating: payload.rating ?? null,
+      message: payload.message,
+    };
+  }
+
+  async function applySessionAction(
+    body: { action: 'rate'; cardId: string; rating: 'easy' | 'medium' | 'hard' } | { action: 'pin' | 'snooze' | 'disable'; cardId: string },
+  ) {
+    if (!currentItem || actionPending) {
+      return;
+    }
+
+    actionPending = true;
+    actionError = null;
+    actionMessage = '';
+    endSessionOpen = false;
+
+    try {
+      const result = await postAction(body);
+      updateCounts(result.action, result.rating ?? null);
+      removeCardFromQueue(result.cardId);
+      actionMessage = result.message ?? 'Review action saved.';
+      actionError = null;
+    } catch (error) {
+      actionError = error instanceof Error ? error.message : 'The review action could not be completed right now.';
+    } finally {
+      actionPending = false;
+    }
+  }
+
+  function getFocusableElements(container: HTMLElement | null) {
+    return container
+      ? Array.from(
+        container.querySelectorAll<HTMLElement>('button:not([disabled]), [href], input:not([disabled]), textarea:not([disabled])'),
+      )
+      : [];
+  }
+
+  async function openEndSessionDialog() {
+    if (!currentItem || actionPending) {
+      return;
+    }
+
+    endSessionOpen = true;
+    await tick();
+    getFocusableElements(endSessionDialog)[0]?.focus();
+  }
+
+  function closeEndSessionDialog() {
+    endSessionOpen = false;
+  }
+
+  function completeSessionEarly() {
+    endSessionOpen = false;
+    endedEarly = true;
+    completionAtMs = Date.now();
+    drawerCardId = null;
+  }
+
+  function handleEndSessionDialogKeydown(event: KeyboardEvent) {
+    if (event.key !== 'Tab' || !endSessionOpen) {
+      return;
+    }
+
+    const focusableElements = getFocusableElements(endSessionDialog);
+
+    if (focusableElements.length === 0) {
+      return;
+    }
+
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    if (event.shiftKey && document.activeElement === firstElement) {
+      event.preventDefault();
+      lastElement?.focus();
+      return;
+    }
+
+    if (!event.shiftKey && document.activeElement === lastElement) {
+      event.preventDefault();
+      firstElement?.focus();
+    }
+  }
+
+  function isTypingTarget(target: EventTarget | null) {
+    return target instanceof HTMLElement && Boolean(target.closest('input, textarea, select, [contenteditable="true"]'));
+  }
+
+  function handleWindowKeydown(event: KeyboardEvent) {
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      if (endSessionOpen) {
+        event.preventDefault();
+        closeEndSessionDialog();
+      }
+
+      return;
+    }
+
+    if (!currentItem || actionPending || sessionComplete || drawerCardId || isTypingTarget(event.target)) {
+      return;
+    }
+
+    if (event.key === '1') {
+      event.preventDefault();
+      void applySessionAction({ action: 'rate', cardId: currentItem.cardId, rating: 'easy' });
+      return;
+    }
+
+    if (event.key === '2') {
+      event.preventDefault();
+      void applySessionAction({ action: 'rate', cardId: currentItem.cardId, rating: 'medium' });
+      return;
+    }
+
+    if (event.key === '3') {
+      event.preventDefault();
+      void applySessionAction({ action: 'rate', cardId: currentItem.cardId, rating: 'hard' });
+      return;
+    }
+
+    if (event.key === 'p' || event.key === 'P') {
+      event.preventDefault();
+      void applySessionAction({ action: 'pin', cardId: currentItem.cardId });
+      return;
+    }
+
+    if (event.key === 's' || event.key === 'S') {
+      event.preventDefault();
+      void applySessionAction({ action: 'snooze', cardId: currentItem.cardId });
+      return;
+    }
+
+    if (event.key === 'd' || event.key === 'D') {
+      event.preventDefault();
+      void applySessionAction({ action: 'disable', cardId: currentItem.cardId });
+    }
+  }
 </script>
+
+<svelte:window on:keydown={handleWindowKeydown} />
 
 <svelte:head>
   <title>Card Review Session – StudyPuck</title>
@@ -59,97 +416,239 @@
   </section>
 {:else if reviewSession}
   <section class="review-session stack" style="--stack-space: var(--space-5)">
-    <header class="review-session__header stack" style="--stack-space: var(--space-2)">
-      <p class="review-session__eyebrow">Session</p>
-      <div class="review-session__title cluster">
-        <h1>Card Review</h1>
-        <a class="review-session__back-link" href={homeHref}>Back to setup</a>
-      </div>
-      <p class="review-session__copy">
-        {#if reviewSession.totalCount > 0}
-          Session ready with {formatCardLabel(reviewSession.totalCount)} from {formatCardLabel(reviewSession.selection.groupIds.length, 'group')}.
-        {:else}
-          No due cards were loaded for this selection.
-        {/if}
-      </p>
-    </header>
+    {#if initialTotalCount === 0}
+      <header class="review-session__header stack" style="--stack-space: var(--space-2)">
+        <p class="review-session__eyebrow">Session</p>
+        <div class="review-session__title cluster">
+          <h1>Card Review</h1>
+          <a class="review-session__back-link" href={homeHref}>Back to setup</a>
+        </div>
+        <p class="review-session__copy">No due cards were loaded for this selection.</p>
+      </header>
 
-    <section class="review-session__summary cluster" aria-label="Session summary">
-      <div class="review-session__summary-item stack" style="--stack-space: var(--space-1)">
-        <span class="review-session__summary-label">Groups</span>
-        <span class="review-session__summary-value">{formatCardLabel(reviewSession.selection.groupIds.length, 'group')}</span>
-      </div>
-
-      <div class="review-session__summary-item stack" style="--stack-space: var(--space-1)">
-        <span class="review-session__summary-label">Mode</span>
-        <span class="review-session__summary-value">
-          {#if reviewSession.selection.limit === null}
-            All due cards
-          {:else}
-            Limit {reviewSession.selection.limit}
-          {/if}
-        </span>
-      </div>
-
-      <div class="review-session__summary-item stack" style="--stack-space: var(--space-1)">
-        <span class="review-session__summary-label">Loaded</span>
-        <span class="review-session__summary-value">{formatCardLabel(reviewSession.totalCount)}</span>
-      </div>
-    </section>
-
-    {#if reviewSession.totalCount === 0}
       <section class="review-state review-state--empty stack" style="--stack-space: var(--space-2)">
         <h2>Nothing due right now</h2>
-        <p>Return to the setup screen to adjust the selected groups or wait for the next due cards to arrive.</p>
+        <p>Return to setup and adjust the selected groups, or come back when more cards are due.</p>
       </section>
-    {:else if firstItem}
+    {:else if sessionComplete}
+      <header class="review-session__header stack" style="--stack-space: var(--space-2)">
+        <p class="review-session__eyebrow">Session</p>
+        <h1>{endedEarly ? 'Session ended' : 'Session complete'}</h1>
+        <p class="review-session__copy">
+          {#if endedEarly}
+            You stopped with {formatCardLabel(queueItems.length)} remaining.
+          {:else}
+            You made it through every card in this review queue.
+          {/if}
+        </p>
+      </header>
+
+      <section class="review-complete stack" style="--stack-space: var(--space-4)">
+        <div class="review-complete__stats cluster" aria-label="Session summary">
+          <div class="review-complete__stat stack" style="--stack-space: var(--space-1)">
+            <span class="review-complete__label">Cards reviewed</span>
+            <span class="review-complete__value">{reviewedCount}</span>
+          </div>
+          <div class="review-complete__stat stack" style="--stack-space: var(--space-1)">
+            <span class="review-complete__label">Time taken</span>
+            <span class="review-complete__value">{completionDurationLabel}</span>
+          </div>
+          <div class="review-complete__stat stack" style="--stack-space: var(--space-1)">
+            <span class="review-complete__label">Actions</span>
+            <span class="review-complete__value">{completedCount}</span>
+          </div>
+        </div>
+
+        <div class="review-complete__breakdown cluster" aria-label="Rating breakdown">
+          <span class="review-complete__pill review-complete__pill--easy">Easy {ratingCounts.easy}</span>
+          <span class="review-complete__pill review-complete__pill--medium">Medium {ratingCounts.medium}</span>
+          <span class="review-complete__pill review-complete__pill--hard">Hard {ratingCounts.hard}</span>
+        </div>
+
+        {#if secondaryActionCounts.pin > 0 || secondaryActionCounts.snooze > 0 || secondaryActionCounts.disable > 0}
+          <p class="review-complete__meta">
+            Pinned {secondaryActionCounts.pin} • Snoozed {secondaryActionCounts.snooze} • Disabled {secondaryActionCounts.disable}
+          </p>
+        {/if}
+
+        <div class="review-complete__actions stack" style="--stack-space: var(--space-3)">
+          <a class="review-action-button review-action-button--outline" href={homeHref}>Review more</a>
+          <a
+            class={`review-action-button ${hasPinnedCards ? 'review-action-button--primary' : 'review-action-button--outline'}`}
+            href={translationDrillsHref}
+          >
+            Go to Translation Drills →
+          </a>
+          <a class="review-complete__home-link" href={rootHomeHref}>Back to home</a>
+        </div>
+      </section>
+    {:else if currentItem}
+      <header class="review-session__header stack" style="--stack-space: var(--space-2)">
+        <p class="review-session__eyebrow">Session</p>
+        <div class="review-session__title cluster">
+          <h1>Card Review</h1>
+          <div class="review-session__header-actions cluster">
+            <p class="review-session__counter">Card {currentCardNumber} of {initialTotalCount}</p>
+            <button type="button" class="review-session__end-button" on:click={() => void openEndSessionDialog()}>
+              End session
+            </button>
+          </div>
+        </div>
+        <p class="review-session__copy">
+          Reviewing {formatCardLabel(reviewSession.selection.groupIds.length, 'group')}.
+          {#if reviewSession.selection.limit === null}
+            All due cards are included.
+          {:else}
+            Session limit: {reviewSession.selection.limit}.
+          {/if}
+        </p>
+      </header>
+
+      <section class="review-session__summary cluster" aria-label="Session progress">
+        <div class="review-session__summary-item stack" style="--stack-space: var(--space-1)">
+          <span class="review-session__summary-label">Completed</span>
+          <span class="review-session__summary-value">{completedCount}</span>
+        </div>
+        <div class="review-session__summary-item stack" style="--stack-space: var(--space-1)">
+          <span class="review-session__summary-label">Remaining</span>
+          <span class="review-session__summary-value">{queueItems.length}</span>
+        </div>
+        <div class="review-session__summary-item stack" style="--stack-space: var(--space-1)">
+          <span class="review-session__summary-label">Reviewed</span>
+          <span class="review-session__summary-value">{reviewedCount}</span>
+        </div>
+      </section>
+
+      {#if actionError || actionMessage}
+        <p class={`review-session__status ${actionError ? 'review-session__status--error' : ''}`} aria-live="polite">
+          {actionError ?? actionMessage}
+        </p>
+      {/if}
+
       <article class="review-card stack" style="--stack-space: var(--space-4)">
         <div class="review-card__header cluster">
           <div class="stack" style="--stack-space: var(--space-1)">
-            <p class="review-card__eyebrow">First queued card</p>
-            <h2>{firstItem.content}</h2>
+            <p class="review-card__eyebrow">Current card</p>
+            <h2>{currentItem.content}</h2>
+            <p class="review-card__due">Due {formatShortDate(currentItem.nextDueAtIso)}</p>
           </div>
-          <p class="review-card__due">Due {formatShortDate(firstItem.nextDueAtIso)}</p>
+          <button type="button" class="review-card__details-button" on:click={() => openDrawer(currentItem.cardId)}>
+            Card details
+          </button>
         </div>
 
-        {#if firstItem.meaning}
-          <p class="review-card__meaning">{firstItem.meaning}</p>
+        {#if currentItem.meaning}
+          <p class="review-card__meaning">{currentItem.meaning}</p>
         {/if}
 
-        {#if firstItem.examples.length > 0}
+        {#if currentItem.groups.length > 0}
+          <div class="review-card__groups cluster" aria-label="Card groups">
+            {#each currentItem.groups as group}
+              <span class="review-card__group-chip">{group.groupName}</span>
+            {/each}
+          </div>
+        {/if}
+
+        {#if currentItem.examples.length > 0}
           <div class="stack" style="--stack-space: var(--space-2)">
             <p class="review-card__section-label">Examples</p>
             <ol class="review-card__examples stack" style="--stack-space: var(--space-2)">
-              {#each firstItem.examples as example}
+              {#each currentItem.examples as example}
                 <li>{example}</li>
               {/each}
             </ol>
           </div>
         {/if}
 
-        {#if firstItem.mnemonics.length > 0}
-          <div class="review-card__mnemonic stack" style="--stack-space: var(--space-2)">
+        {#if currentItem.mnemonics.length > 0}
+          <div class="review-card__callout review-card__callout--warning stack" style="--stack-space: var(--space-2)">
             <p class="review-card__section-label">Mnemonic</p>
-            <p>{firstItem.mnemonics[0]}</p>
+            {#each currentItem.mnemonics as mnemonic}
+              <p>{mnemonic}</p>
+            {/each}
           </div>
         {/if}
 
-        {#if firstItem.groups.length > 0}
-          <div class="review-card__groups cluster" aria-label="Card groups">
-            {#each firstItem.groups as group}
-              <span class="review-card__group-chip">{group.groupName}</span>
-            {/each}
+        {#if currentItem.llmInstructions}
+          <div class="review-card__callout stack" style="--stack-space: var(--space-2)">
+            <p class="review-card__section-label">LLM instructions</p>
+            <p>{currentItem.llmInstructions}</p>
           </div>
         {/if}
       </article>
 
-      {#if queuePreview.length > 0}
-        <section class="review-queue stack" style="--stack-space: var(--space-3)" aria-labelledby="queue-preview-title">
-          <div class="stack" style="--stack-space: var(--space-1)">
-            <h2 id="queue-preview-title">Queue preview</h2>
-            <p class="review-queue__copy">The next few cards queued after the opener.</p>
-          </div>
+      <section class="review-actions stack" style="--stack-space: var(--space-3)" aria-label="Review actions">
+        <div class="review-actions__ratings cluster">
+          <button
+            type="button"
+            class="review-action-button review-action-button--easy"
+            disabled={actionPending}
+            on:click={() => void applySessionAction({ action: 'rate', cardId: currentItem.cardId, rating: 'easy' })}
+          >
+            <span>Easy</span>
+            <small>1</small>
+          </button>
+          <button
+            type="button"
+            class="review-action-button review-action-button--medium"
+            disabled={actionPending}
+            on:click={() => void applySessionAction({ action: 'rate', cardId: currentItem.cardId, rating: 'medium' })}
+          >
+            <span>Medium</span>
+            <small>2</small>
+          </button>
+          <button
+            type="button"
+            class="review-action-button review-action-button--hard"
+            disabled={actionPending}
+            on:click={() => void applySessionAction({ action: 'rate', cardId: currentItem.cardId, rating: 'hard' })}
+          >
+            <span>Hard</span>
+            <small>3</small>
+          </button>
+        </div>
 
+        <div class="review-actions__secondary cluster">
+          <button
+            type="button"
+            class="review-action-button review-action-button--outline"
+            disabled={actionPending}
+            on:click={() => void applySessionAction({ action: 'pin', cardId: currentItem.cardId })}
+          >
+            📌 Pin to Drills
+          </button>
+          <button
+            type="button"
+            class="review-action-button review-action-button--outline"
+            disabled={actionPending}
+            on:click={() => void applySessionAction({ action: 'snooze', cardId: currentItem.cardId })}
+          >
+            💤 Snooze
+          </button>
+          <button
+            type="button"
+            class="review-action-button review-action-button--outline review-action-button--danger"
+            disabled={actionPending}
+            on:click={() => void applySessionAction({ action: 'disable', cardId: currentItem.cardId })}
+          >
+            🚫 Disable
+          </button>
+        </div>
+      </section>
+
+      <section class="review-queue stack" style="--stack-space: var(--space-3)" aria-labelledby="queue-preview-title">
+        <div class="stack" style="--stack-space: var(--space-1)">
+          <h2 id="queue-preview-title">Up next</h2>
+          <p class="review-queue__copy">
+            {#if queuePreview.length > 0}
+              Preview the next few cards without leaving the session flow.
+            {:else}
+              Rate this card to finish the current queue.
+            {/if}
+          </p>
+        </div>
+
+        {#if queuePreview.length > 0}
           <ol class="review-queue__list stack" style="--stack-space: var(--space-2)">
             {#each queuePreview as item}
               <li class="review-queue__item">
@@ -159,20 +658,77 @@
                     <span class="review-queue__meaning">{item.meaning}</span>
                   {/if}
                 </div>
-                <span class="review-queue__meta">{formatShortDate(item.nextDueAtIso)}</span>
+                <div class="review-queue__meta stack" style="--stack-space: var(--space-2)">
+                  <span>{formatShortDate(item.nextDueAtIso)}</span>
+                  <button type="button" class="review-queue__details" on:click={() => openDrawer(item.cardId)}>
+                    Details
+                  </button>
+                </div>
               </li>
             {/each}
           </ol>
 
-          {#if reviewSession.totalCount > queuePreview.length + 1}
+          {#if queueItems.length > queuePreview.length + 1}
             <p class="review-queue__remaining">
-              +{reviewSession.totalCount - queuePreview.length - 1} more queued
+              +{queueItems.length - queuePreview.length - 1} more queued
             </p>
           {/if}
-        </section>
-      {/if}
+        {/if}
+      </section>
     {/if}
   </section>
+
+  {#if drawerCard}
+    <ActiveCardDrawer
+      lang={currentLanguage}
+      card={drawerCard}
+      availableGroups={sessionAvailableGroups}
+      selectedIndex={drawerIndex}
+      totalCount={queueItems.length}
+      hasPrevious={drawerIndex > 0}
+      hasNext={drawerIndex >= 0 && drawerIndex < queueItems.length - 1}
+      allowDelete={false}
+      on:close={() => {
+        drawerCardId = null;
+      }}
+      on:updated={handleDrawerUpdated}
+      on:deleted={handleDrawerDeleted}
+      on:previous={() => navigateDrawer('previous')}
+      on:next={() => navigateDrawer('next')}
+    />
+  {/if}
+
+  {#if endSessionOpen}
+    <button
+      type="button"
+      class="review-dialog__backdrop"
+      aria-label="Dismiss end session dialog"
+      on:click={closeEndSessionDialog}
+    ></button>
+
+    <div
+      bind:this={endSessionDialog}
+      class="review-dialog stack"
+      style="--stack-space: var(--space-3)"
+      role="alertdialog"
+      tabindex="-1"
+      aria-modal="true"
+      aria-labelledby="end-session-title"
+      aria-describedby="end-session-description"
+      on:keydown={handleEndSessionDialogKeydown}
+    >
+      <h2 id="end-session-title">End session?</h2>
+      <p id="end-session-description">{formatCardLabel(queueItems.length)} remain in this queue.</p>
+      <div class="review-dialog__actions cluster">
+        <button type="button" class="review-action-button review-action-button--outline" on:click={closeEndSessionDialog}>
+          Keep reviewing
+        </button>
+        <button type="button" class="review-action-button review-action-button--danger-fill" on:click={completeSessionEarly}>
+          End session
+        </button>
+      </div>
+    </div>
+  {/if}
 {/if}
 
 <style>
@@ -184,10 +740,14 @@
   .review-session__summary-label,
   .review-card__eyebrow,
   .review-card__section-label,
+  .review-card__due,
   .review-queue__copy,
   .review-queue__meaning,
   .review-queue__remaining,
-  .review-card__due {
+  .review-complete__label,
+  .review-complete__meta,
+  .review-session__counter,
+  .review-session__status {
     color: var(--color-text-secondary);
     font-family: var(--font-ui);
     font-size: var(--font-size-small);
@@ -196,17 +756,24 @@
   .review-session__eyebrow,
   .review-session__summary-label,
   .review-card__eyebrow,
-  .review-card__section-label {
+  .review-card__section-label,
+  .review-complete__label {
     font-size: var(--font-size-caption);
     letter-spacing: var(--tracking-caps);
     text-transform: uppercase;
   }
 
   .review-session__title,
+  .review-session__header-actions,
   .review-card__header,
-  .review-queue__item {
-    justify-content: space-between;
+  .review-session__summary,
+  .review-actions__ratings,
+  .review-actions__secondary,
+  .review-complete__stats,
+  .review-complete__breakdown,
+  .review-dialog__actions {
     gap: var(--space-3);
+    justify-content: space-between;
   }
 
   .review-session__header h1,
@@ -216,38 +783,63 @@
   .review-state p,
   .review-card__header h2,
   .review-card__meaning,
-  .review-card__mnemonic p,
+  .review-card__callout p,
   .review-queue__content,
-  .review-queue__remaining {
+  .review-complete__value,
+  .review-complete__meta,
+  .review-session__counter,
+  .review-session__status,
+  .review-dialog h2,
+  .review-dialog p {
     margin: 0;
   }
 
-  .review-session__back-link {
+  .review-session__back-link,
+  .review-complete__home-link {
+    color: var(--color-text-primary);
     font-family: var(--font-ui);
     font-size: var(--font-size-small);
     text-decoration: none;
   }
 
-  .review-session__summary {
-    gap: var(--space-3);
+  .review-session__header-actions {
+    align-items: center;
+  }
+
+  .review-session__counter {
+    min-inline-size: max-content;
+  }
+
+  .review-session__end-button {
+    border: 0;
+    background: transparent;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    font-family: var(--font-ui);
+    font-size: var(--font-size-small);
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
   }
 
   .review-session__summary-item,
   .review-card,
   .review-queue,
-  .review-state {
+  .review-state,
+  .review-complete {
     border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
     background: var(--color-surface);
   }
 
-  .review-session__summary-item {
+  .review-session__summary-item,
+  .review-complete__stat {
     flex: 1 1 10rem;
     min-inline-size: min(100%, 10rem);
     padding: var(--space-3) var(--space-4);
   }
 
   .review-session__summary-value,
+  .review-complete__value,
   .review-queue__content {
     font-family: var(--font-ui);
     font-weight: 600;
@@ -255,7 +847,8 @@
 
   .review-card,
   .review-queue,
-  .review-state {
+  .review-state,
+  .review-complete {
     padding: var(--space-4);
   }
 
@@ -264,52 +857,152 @@
     border-color: var(--color-info-border);
   }
 
+  .review-card__header {
+    align-items: flex-start;
+  }
+
   .review-card__header h2 {
     font-size: clamp(2rem, 8vw, 3rem);
     line-height: var(--leading-tight);
+    font-family: "Noto Sans CJK SC", "PingFang SC", "Hiragino Sans", "Malgun Gothic", system-ui;
   }
 
   .review-card__meaning {
     font-size: var(--font-size-h4);
   }
 
-  .review-card__examples {
-    padding-inline-start: 1.25rem;
-    margin: 0;
-  }
-
-  .review-card__mnemonic {
-    padding: var(--space-3);
+  .review-card__details-button,
+  .review-queue__details,
+  .review-action-button {
+    min-block-size: 2.75rem;
     border-radius: var(--radius-md);
-    background: var(--color-warning-bg);
-    border: 1px solid var(--color-warning-border);
+    font-family: var(--font-ui);
   }
 
-  .review-card__groups {
+  .review-card__details-button,
+  .review-queue__details {
+    padding: 0.55rem 0.9rem;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text-primary);
+    cursor: pointer;
+  }
+
+  .review-card__groups,
+  .review-complete__breakdown {
+    flex-wrap: wrap;
     gap: var(--space-2);
   }
 
-  .review-card__group-chip {
+  .review-card__group-chip,
+  .review-complete__pill {
     display: inline-flex;
     align-items: center;
     min-block-size: 1.875rem;
     padding-inline: var(--space-3);
-    border-radius: var(--radius-md);
-    background: var(--color-surface-raised);
-    color: var(--color-text-secondary);
+    border-radius: var(--radius-pill, 999px);
     font-family: var(--font-ui);
     font-size: var(--font-size-caption);
   }
 
-  .review-queue__list {
-    padding: 0;
+  .review-card__group-chip {
+    background: var(--color-surface-raised);
+    color: var(--color-text-secondary);
+  }
+
+  .review-card__examples {
     margin: 0;
+    padding-inline-start: 1.25rem;
+  }
+
+  .review-card__callout {
+    padding: var(--space-3);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-border-subtle);
+    background: var(--color-surface-subtle);
+  }
+
+  .review-card__callout--warning {
+    background: var(--color-warning-bg);
+    border-color: var(--color-warning-border);
+  }
+
+  .review-action-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    padding: 0.75rem 1rem;
+    border: 1px solid transparent;
+    cursor: pointer;
+    font-weight: 600;
+    text-decoration: none;
+  }
+
+  .review-action-button small {
+    color: inherit;
+    font-size: var(--font-size-caption);
+    opacity: 0.8;
+  }
+
+  .review-action-button--easy {
+    background: var(--color-success-bg);
+    border-color: var(--color-success-border);
+    color: var(--color-success-text);
+  }
+
+  .review-action-button--medium {
+    background: var(--color-info-bg);
+    border-color: var(--color-info-border);
+    color: var(--color-info-text);
+  }
+
+  .review-action-button--hard {
+    background: var(--color-warning-bg);
+    border-color: var(--color-warning-border);
+    color: var(--color-warning-text);
+  }
+
+  .review-action-button--outline {
+    background: var(--color-surface);
+    border-color: var(--color-border);
+    color: var(--color-text-primary);
+  }
+
+  .review-action-button--primary {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: var(--color-primary-contrast);
+  }
+
+  .review-action-button--danger,
+  .review-session__status--error {
+    color: var(--color-danger-text);
+  }
+
+  .review-action-button--danger-fill {
+    background: var(--color-danger-bg);
+    border-color: var(--color-danger-border);
+    color: var(--color-danger-text);
+  }
+
+  .review-action-button:disabled,
+  .review-card__details-button:disabled,
+  .review-queue__details:disabled {
+    cursor: wait;
+    opacity: 0.65;
+  }
+
+  .review-queue__list {
+    margin: 0;
+    padding: 0;
     list-style: none;
   }
 
   .review-queue__item {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
+    gap: var(--space-3);
     align-items: center;
     padding: var(--space-3) var(--space-4);
     border: 1px solid var(--color-border-subtle);
@@ -317,16 +1010,73 @@
     background: var(--color-surface-subtle);
   }
 
+  .review-queue__meta {
+    align-items: flex-end;
+  }
+
+  .review-complete__pill--easy {
+    background: var(--color-success-bg);
+    color: var(--color-success-text);
+  }
+
+  .review-complete__pill--medium {
+    background: var(--color-info-bg);
+    color: var(--color-info-text);
+  }
+
+  .review-complete__pill--hard {
+    background: var(--color-warning-bg);
+    color: var(--color-warning-text);
+  }
+
+  .review-complete__actions {
+    align-items: stretch;
+  }
+
+  .review-complete__home-link {
+    align-self: center;
+  }
+
+  .review-dialog__backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 54;
+    border: 0;
+    background: color-mix(in srgb, var(--neutral-900) 22%, transparent);
+  }
+
+  .review-dialog {
+    position: fixed;
+    inset-block-start: 50%;
+    inset-inline-start: 50%;
+    z-index: 55;
+    inline-size: min(28rem, calc(100vw - 2rem));
+    padding: var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface-raised);
+    box-shadow: var(--shadow-lg);
+    transform: translate(-50%, -50%);
+  }
+
   @media (max-width: 48rem) {
     .review-session__title,
-    .review-card__header {
+    .review-session__header-actions,
+    .review-card__header,
+    .review-actions__ratings,
+    .review-actions__secondary,
+    .review-complete__stats,
+    .review-dialog__actions {
       flex-direction: column;
-      align-items: flex-start;
+      align-items: stretch;
     }
 
     .review-queue__item {
       grid-template-columns: 1fr;
-      justify-items: start;
+    }
+
+    .review-queue__meta {
+      align-items: flex-start;
     }
   }
 </style>

--- a/apps/web/src/routes/[lang]/card-review/session/actions/+server.ts
+++ b/apps/web/src/routes/[lang]/card-review/session/actions/+server.ts
@@ -1,0 +1,42 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { withTransactionDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import { applyCardReviewSessionAction, CardReviewRequestError } from '$lib/server/card-review.js';
+
+export const POST: RequestHandler = async (event) => {
+  const session = await event.locals.auth();
+  const userId = session?.user?.id;
+  const languageId = event.params.lang;
+
+  if (!userId || !languageId) {
+    return json({ message: 'You must be signed in to review cards.' }, { status: 401 });
+  }
+
+  if (!env.DATABASE_URL) {
+    return json({ message: 'Card Review is not configured right now.' }, { status: 500 });
+  }
+
+  let body: unknown;
+
+  try {
+    body = await event.request.json();
+  } catch {
+    return json({ message: 'The Card Review action payload must be valid JSON.' }, { status: 400 });
+  }
+
+  try {
+    const result = await withTransactionDb(
+      env.DATABASE_URL,
+      (database) => applyCardReviewSessionAction(userId, languageId, body, database as never),
+    );
+
+    return json(result);
+  } catch (requestError) {
+    if (requestError instanceof CardReviewRequestError) {
+      return json({ message: requestError.message }, { status: requestError.status });
+    }
+
+    console.error('Failed to apply Card Review action:', requestError);
+    return json({ message: 'The review action could not be completed right now.' }, { status: 500 });
+  }
+};

--- a/apps/web/tests/e2e/card-review.spec.ts
+++ b/apps/web/tests/e2e/card-review.spec.ts
@@ -8,7 +8,7 @@ import {
 } from './support/database';
 import { signInAs } from './support/session';
 
-test('configures a Card Review session from the home screen and loads the queued cards', async ({ page }) => {
+async function seedReviewFixture() {
 	await resetDatabase();
 
 	const user = await seedUser({
@@ -63,9 +63,23 @@ test('configures a Card Review session from the home screen and loads the queued
 	await seedCardReviewCard({
 		userId: user.userId,
 		languageId: 'zh',
-		cardId: 'card-review-future',
+		cardId: 'card-review-due-3',
 		cardContent: '逐渐',
 		meaning: 'gradually',
+		llmInstructions: 'Prefer examples about steady progress.',
+		groupId: coreGroup.groupId,
+		dueAt: new Date('2026-05-07T12:00:00.000Z'),
+		lastReviewedAt: new Date('2026-05-05T12:00:00.000Z'),
+		reviewCount: 2,
+		intervalDays: 3
+	});
+
+	await seedCardReviewCard({
+		userId: user.userId,
+		languageId: 'zh',
+		cardId: 'card-review-future',
+		cardContent: '预习',
+		meaning: 'to preview a lesson',
 		groupId: futureGroup.groupId,
 		dueAt: new Date('2026-05-12T12:00:00.000Z'),
 		lastReviewedAt: new Date('2026-05-08T12:00:00.000Z'),
@@ -87,6 +101,12 @@ test('configures a Card Review session from the home screen and loads the queued
 		cardsReviewed: 4
 	});
 
+	return { user, coreGroup };
+}
+
+test('configures a Card Review session from the home screen and loads the real session UI', async ({ page }) => {
+	const { user, coreGroup } = await seedReviewFixture();
+
 	await signInAs(page, user);
 	await page.goto('/zh/card-review');
 
@@ -94,8 +114,6 @@ test('configures a Card Review session from the home screen and loads the queued
 	await expect(contextView.getByRole('heading', { name: 'Card Review' })).toBeVisible();
 	await expect(contextView.getByText('Core Review')).toBeVisible();
 	await expect(contextView.getByText('Future Review')).toBeVisible();
-	await expect(contextView.getByText('2 cards in rotation')).toBeVisible();
-	await expect(contextView.getByText('1 card in rotation')).toBeVisible();
 
 	const startButton = contextView.getByRole('button', { name: 'Start Session' });
 	await expect(startButton).toBeDisabled();
@@ -104,12 +122,54 @@ test('configures a Card Review session from the home screen and loads the queued
 	await expect(startButton).toBeEnabled();
 
 	await contextView.getByRole('radio', { name: /Limit to N cards/i }).check();
-	await contextView.getByRole('spinbutton', { name: 'Session size' }).fill('1');
+	await contextView.getByRole('spinbutton', { name: 'Session size' }).fill('2');
 	await startButton.click();
 
-	await page.waitForURL(/\/zh\/card-review\/session\?.*group=group-core-review.*limit=1/);
-	await expect(contextView.getByText('Session ready with 1 card from 1 group.')).toBeVisible();
-	await expect(contextView.getByText('First queued card')).toBeVisible();
+	await page.waitForURL(new RegExp(`/zh/card-review/session\\?.*group=${coreGroup.groupId}.*limit=2`));
+	await expect(contextView.getByText('Card 1 of 2')).toBeVisible();
+	await expect(contextView.getByRole('heading', { name: '逐渐' })).toBeVisible();
+	await expect(contextView.getByRole('button', { name: 'Easy 1' })).toBeVisible();
+	await expect(contextView.getByRole('button', { name: 'Pin to Drills' })).toBeVisible();
+	await expect(contextView.getByRole('heading', { name: 'Up next' })).toBeVisible();
+	await expect(contextView.getByText('巩固')).toBeVisible();
+});
+
+test('advances through session actions, supports drawer navigation, and shows the completion CTAs', async ({ page }) => {
+	const { user, coreGroup } = await seedReviewFixture();
+
+	await signInAs(page, user);
+	await page.goto(`/zh/card-review/session?group=${coreGroup.groupId}`);
+
+	const contextView = page.getByLabel('Context view', { exact: true });
+	await expect(contextView.getByText('Card 1 of 3')).toBeVisible();
+	await expect(contextView.getByRole('heading', { name: '逐渐' })).toBeVisible();
+
+	await contextView.getByRole('button', { name: 'Card details' }).click();
+	const drawer = page.getByRole('dialog');
+	await expect(drawer.locator('textarea').first()).toHaveValue('逐渐');
+	await drawer.getByRole('button', { name: 'Next card' }).click();
+	await expect(drawer.locator('textarea').first()).toHaveValue('巩固');
+	await drawer.getByRole('button', { name: 'Previous card' }).click();
+	await expect(drawer.locator('textarea').first()).toHaveValue('逐渐');
+	await drawer.getByRole('button', { name: 'Close drawer' }).click();
+
+	await contextView.getByRole('button', { name: 'Easy 1' }).click();
+	await expect(contextView.getByText('Easy recorded.')).toBeVisible();
+	await expect(contextView.getByText('Card 2 of 3')).toBeVisible();
 	await expect(contextView.getByRole('heading', { name: '巩固' })).toBeVisible();
-	await expect(contextView.getByText('Core Review')).toBeVisible();
+
+	await page.keyboard.press('P');
+	await expect(contextView.getByText('Card pinned to Translation Drills.')).toBeVisible();
+	await expect(contextView.getByText('Card 3 of 3')).toBeVisible();
+	await expect(contextView.getByRole('heading', { name: '补偿' })).toBeVisible();
+
+	await page.keyboard.press('3');
+	await expect(contextView.getByRole('heading', { name: 'Session complete' })).toBeVisible();
+	await expect(contextView.getByText('Cards reviewed')).toBeVisible();
+	await expect(contextView.getByText(/^2$/)).toBeVisible();
+	await expect(contextView.getByText('Easy 1')).toBeVisible();
+	await expect(contextView.getByText('Hard 1')).toBeVisible();
+	await expect(contextView.getByRole('link', { name: 'Review more' })).toBeVisible();
+	await expect(contextView.getByRole('link', { name: 'Go to Translation Drills →' })).toBeVisible();
+	await expect(contextView.getByRole('link', { name: 'Back to home' })).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- implement the real Card Review session flow with ratings, pin/snooze/disable actions, keyboard shortcuts, end-session handling, and completion UI
- add an app-owned Card Review session action route plus richer server helpers for session loading and action validation
- reuse ActiveCardDrawer in session mode and extend unit/e2e coverage for the full review flow

Closes #189