### PR TITLE
Implement Card Review command bar flows

### DIFF
--- a/apps/web/src/lib/chat.ts
+++ b/apps/web/src/lib/chat.ts
@@ -19,6 +19,9 @@ export const CHAT_SUGGESTION_TYPES = [
   'create_group',
   'add_card_to_group',
   'remove_card_from_group',
+  'pin_review_card',
+  'snooze_review_card',
+  'next_review_card',
 ] as const;
 
 export const PROMPT_HISTORY_CAP = 10;
@@ -29,6 +32,11 @@ export const conversationHistoryTurnSchema = z.object({
 });
 
 const selectedChatCardIdsSchema = z.array(activeCardIdSchema).max(100).default([]);
+const cardReviewSelectionSchema = z.object({
+  groupIds: z.array(activeGroupIdSchema).max(100).default([]),
+  limit: z.number().int().min(1).max(100).nullable(),
+  countMode: z.enum(['all_due', 'limit']),
+});
 
 export const cardLibraryListSurfaceContextSchema = z.object({
   surface: z.literal('card_library_list'),
@@ -64,12 +72,30 @@ export const cardDetailDrawerSurfaceContextSchema = z.object({
   groupId: activeGroupIdSchema.optional(),
 });
 
+export const cardReviewSetupSurfaceContextSchema = z.object({
+  surface: z.literal('card_review_setup'),
+  selection: cardReviewSelectionSchema,
+});
+
+export const cardReviewSessionSurfaceContextSchema = z.object({
+  surface: z.literal('card_review_session'),
+  selection: cardReviewSelectionSchema.extend({
+    groupIds: z.array(activeGroupIdSchema).min(1).max(100),
+  }),
+  queueCardIds: z.array(activeCardIdSchema).min(1).max(100),
+  currentCardId: activeCardIdSchema,
+  initialTotalCount: z.number().int().min(1).max(100),
+  completedCount: z.number().int().min(0).max(100),
+});
+
 export const chatSurfaceContextSchema = z.discriminatedUnion('surface', [
   cardLibraryListSurfaceContextSchema,
   groupsListSurfaceContextSchema,
   groupDetailSurfaceContextSchema,
   addCardsToGroupDrawerSurfaceContextSchema,
   cardDetailDrawerSurfaceContextSchema,
+  cardReviewSetupSurfaceContextSchema,
+  cardReviewSessionSurfaceContextSchema,
 ]);
 
 export type ConversationHistoryTurn = z.infer<typeof conversationHistoryTurnSchema>;
@@ -133,6 +159,25 @@ export const removeCardFromGroupSuggestionSchema = z.object({
   }),
 });
 
+const cardReviewActionSuggestionPayloadSchema = z.object({
+  cardId: activeCardIdSchema,
+});
+
+export const pinReviewCardSuggestionSchema = z.object({
+  type: z.literal('pin_review_card'),
+  payload: cardReviewActionSuggestionPayloadSchema,
+});
+
+export const snoozeReviewCardSuggestionSchema = z.object({
+  type: z.literal('snooze_review_card'),
+  payload: cardReviewActionSuggestionPayloadSchema,
+});
+
+export const nextReviewCardSuggestionSchema = z.object({
+  type: z.literal('next_review_card'),
+  payload: cardReviewActionSuggestionPayloadSchema,
+});
+
 export const chatSuggestionSchema = z.discriminatedUnion('type', [
   appendExampleSentenceSuggestionSchema,
   appendMnemonicSuggestionSchema,
@@ -140,6 +185,9 @@ export const chatSuggestionSchema = z.discriminatedUnion('type', [
   createGroupSuggestionSchema,
   addCardToGroupSuggestionSchema,
   removeCardFromGroupSuggestionSchema,
+  pinReviewCardSuggestionSchema,
+  snoozeReviewCardSuggestionSchema,
+  nextReviewCardSuggestionSchema,
 ]);
 
 export type ChatRequest = z.infer<typeof chatRequestSchema>;

--- a/apps/web/src/lib/command-bar/card-review.test.ts
+++ b/apps/web/src/lib/command-bar/card-review.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveCardReviewCommandResponse } from './card-review.js';
+import { cardReviewSessionActions } from '$lib/stores/cardReviewSessionActions.js';
+
+describe('resolveCardReviewCommandResponse', () => {
+  it('returns null for non-Card Review commands', async () => {
+    await expect(resolveCardReviewCommandResponse({
+      input: '/help',
+      surfaceContext: null,
+    })).resolves.toBeNull();
+  });
+
+  it('requires an active Card Review session before executing review commands', async () => {
+    await expect(resolveCardReviewCommandResponse({
+      input: '/pin',
+      surfaceContext: {
+        surface: 'card_review_setup',
+        selection: {
+          groupIds: ['group-1'],
+          limit: null,
+          countMode: 'all_due',
+        },
+      },
+    })).resolves.toBe('Start a Card Review session before using that command.');
+  });
+
+  it('routes /next through the session action store when a session is active', async () => {
+    const nextSpy = vi.spyOn(cardReviewSessionActions, 'requestNext').mockResolvedValue('Moved to the next card.');
+
+    await expect(resolveCardReviewCommandResponse({
+      input: '/next',
+      surfaceContext: {
+        surface: 'card_review_session',
+        selection: {
+          groupIds: ['group-1'],
+          limit: null,
+          countMode: 'all_due',
+        },
+        queueCardIds: ['card-1', 'card-2'],
+        currentCardId: 'card-1',
+        initialTotalCount: 2,
+        completedCount: 0,
+      },
+    })).resolves.toBe('Moved to the next card.');
+
+    expect(nextSpy).toHaveBeenCalledWith('card-1');
+  });
+});

--- a/apps/web/src/lib/command-bar/card-review.ts
+++ b/apps/web/src/lib/command-bar/card-review.ts
@@ -1,0 +1,49 @@
+import type { ChatSurfaceContext } from '$lib/chat.js';
+import { cardReviewSessionActions } from '$lib/stores/cardReviewSessionActions.js';
+
+type ResolveCardReviewCommandResponseInput = {
+  input: string;
+  surfaceContext: ChatSurfaceContext | null;
+};
+
+function parseCardReviewCommand(input: string) {
+  const trimmedInput = input.trim();
+
+  if (!trimmedInput.startsWith('/')) {
+    return null;
+  }
+
+  const [typedCommand] = trimmedInput.split(/\s+/, 1);
+
+  if (typedCommand !== '/pin' && typedCommand !== '/snooze' && typedCommand !== '/next') {
+    return null;
+  }
+
+  return typedCommand;
+}
+
+export async function resolveCardReviewCommandResponse(
+  input: ResolveCardReviewCommandResponseInput,
+): Promise<string | null> {
+  const command = parseCardReviewCommand(input.input);
+
+  if (!command) {
+    return null;
+  }
+
+  if (input.surfaceContext?.surface !== 'card_review_session') {
+    return 'Start a Card Review session before using that command.';
+  }
+
+  const { currentCardId } = input.surfaceContext;
+
+  if (command === '/pin') {
+    return cardReviewSessionActions.requestPin(currentCardId);
+  }
+
+  if (command === '/snooze') {
+    return cardReviewSessionActions.requestSnooze(currentCardId);
+  }
+
+  return cardReviewSessionActions.requestNext(currentCardId);
+}

--- a/apps/web/src/lib/components/CommandBar.dom.test.ts
+++ b/apps/web/src/lib/components/CommandBar.dom.test.ts
@@ -6,6 +6,7 @@ import { fireEvent, render, screen, within } from '@testing-library/svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { commandBar } from '$lib/stores/commandBar.js';
 import { activeCardSuggestionActions } from '$lib/stores/activeCardSuggestionActions.js';
+import { cardReviewSessionActions } from '$lib/stores/cardReviewSessionActions.js';
 import { cardEntrySuggestionActions } from '$lib/stores/cardEntrySuggestionActions.js';
 
 type MockPageStoreValue = {
@@ -378,5 +379,112 @@ describe('CommandBar component behavior', () => {
     await fireEvent.click(screen.getAllByRole('button', { name: /Card card-1 -> Group group-2/ })[0]);
 
     expect(applySpy).toHaveBeenCalledWith('card-1', 'group-2');
+  });
+
+  it('executes Card Review action suggestions through the session action store', async () => {
+    pageStore.set({
+      params: { lang: 'zh' },
+      route: { id: '/[lang]/card-review/session' },
+      status: 200,
+      error: null,
+      data: {},
+      form: undefined,
+      state: {},
+      url: new URL('https://studypuck.test/zh/card-review/session'),
+    });
+
+    requestStructuredChatResponse.mockResolvedValue({
+      message: 'You can just pin this one.',
+      suggestions: [
+        {
+          type: 'pin_review_card',
+          payload: { cardId: 'card-1' },
+        },
+      ],
+    });
+
+    const pinSpy = vi.spyOn(cardReviewSessionActions, 'requestPin').mockResolvedValue('Pinned to Translation Drills.');
+    const { default: CommandBar } = await import('./CommandBar.svelte');
+    const snippet = createRawSnippet(() => ({
+      render: () => '<section>context content</section>',
+    }));
+
+    render(CommandBar, {
+      props: {
+        children: snippet,
+      },
+    });
+
+    commandBar.setPathname('/zh/card-review/session');
+    commandBar.setWorkspaceContext('zh', null);
+    commandBar.setSurfaceContext({
+      surface: 'card_review_session',
+      selection: {
+        groupIds: ['group-1'],
+        limit: null,
+        countMode: 'all_due',
+      },
+      queueCardIds: ['card-1', 'card-2'],
+      currentCardId: 'card-1',
+      initialTotalCount: 2,
+      completedCount: 0,
+    });
+
+    const textbox = screen.getByLabelText('Command bar');
+    await fireEvent.input(textbox, { target: { value: 'Pin this card for drills' } });
+    await fireEvent.keyDown(textbox, { key: 'Enter' });
+
+    expect(await screen.findAllByText('Pin card')).toHaveLength(2);
+    await fireEvent.click(screen.getAllByRole('button', { name: /Pin card/i })[0]);
+
+    expect(pinSpy).toHaveBeenCalledWith('card-1');
+  });
+
+  it('handles direct Card Review slash commands without calling the chat API', async () => {
+    pageStore.set({
+      params: { lang: 'zh' },
+      route: { id: '/[lang]/card-review/session' },
+      status: 200,
+      error: null,
+      data: {},
+      form: undefined,
+      state: {},
+      url: new URL('https://studypuck.test/zh/card-review/session'),
+    });
+
+    const nextSpy = vi.spyOn(cardReviewSessionActions, 'requestNext').mockResolvedValue('Moved to the next card.');
+    const { default: CommandBar } = await import('./CommandBar.svelte');
+    const snippet = createRawSnippet(() => ({
+      render: () => '<section>context content</section>',
+    }));
+
+    render(CommandBar, {
+      props: {
+        children: snippet,
+      },
+    });
+
+    commandBar.setPathname('/zh/card-review/session');
+    commandBar.setWorkspaceContext('zh', null);
+    commandBar.setSurfaceContext({
+      surface: 'card_review_session',
+      selection: {
+        groupIds: ['group-1'],
+        limit: null,
+        countMode: 'all_due',
+      },
+      queueCardIds: ['card-1', 'card-2'],
+      currentCardId: 'card-1',
+      initialTotalCount: 2,
+      completedCount: 0,
+    });
+
+    const textbox = screen.getByLabelText('Command bar');
+    await fireEvent.input(textbox, { target: { value: '/next' } });
+    await fireEvent.keyDown(textbox, { key: 'Enter' });
+
+    expect(await screen.findAllByText('Moved to the next card.')).toHaveLength(2);
+    expect(nextSpy).toHaveBeenCalledWith('card-1');
+    expect(requestStructuredChatResponse).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/components/CommandBar.svelte
+++ b/apps/web/src/lib/components/CommandBar.svelte
@@ -6,8 +6,10 @@
   import { createInboxNoteRequest } from '$lib/card-entry/client.js';
   import { requestStructuredChatResponse } from '$lib/chat/client.js';
   import type { ChatSuggestion } from '$lib/chat.js';
+  import { resolveCardReviewCommandResponse } from '$lib/command-bar/card-review.js';
   import { resolveCardEntryCommandResponse } from '$lib/command-bar/card-entry.js';
   import { activeCardSuggestionActions } from '$lib/stores/activeCardSuggestionActions.js';
+  import { cardReviewSessionActions } from '$lib/stores/cardReviewSessionActions.js';
   import { cardEntrySuggestionActions } from '$lib/stores/cardEntrySuggestionActions.js';
   import { cardEntryShellCounts } from '$lib/stores/cardEntryShell.js';
   import { cardEntryUi } from '$lib/stores/cardEntryUi.js';
@@ -196,6 +198,15 @@
         });
       }
 
+      const cardReviewCommandResponse = await resolveCardReviewCommandResponse({
+        input,
+        surfaceContext: submissionState.surfaceContextHint,
+      });
+
+      if (cardReviewCommandResponse !== null) {
+        return cardReviewCommandResponse;
+      }
+
       const promptHistory = commandBar.getPromptHistory(submissionState);
 
       // URL param takes priority; fall back to the store's active note, then omit.
@@ -322,6 +333,12 @@
         return 'Add card to group';
       case 'remove_card_from_group':
         return 'Remove from group';
+      case 'pin_review_card':
+        return 'Pin card';
+      case 'snooze_review_card':
+        return 'Snooze card';
+      case 'next_review_card':
+        return 'Next card';
       default:
         return 'Apply';
     }
@@ -339,6 +356,12 @@
         return `Card ${suggestion.payload.cardId} -> Group ${suggestion.payload.groupId}`;
       case 'remove_card_from_group':
         return `Card ${suggestion.payload.cardId} <- Group ${suggestion.payload.groupId}`;
+      case 'pin_review_card':
+        return `Pin ${suggestion.payload.cardId}`;
+      case 'snooze_review_card':
+        return `Snooze ${suggestion.payload.cardId}`;
+      case 'next_review_card':
+        return `Next after ${suggestion.payload.cardId}`;
       default:
         return '';
     }
@@ -461,6 +484,24 @@
         });
         await invalidateAll();
         commandBar.pushAssistantMessage('Removed the card from the suggested group.');
+        return;
+      }
+
+      if (suggestion.type === 'pin_review_card') {
+        const message = await cardReviewSessionActions.requestPin(suggestion.payload.cardId);
+        commandBar.pushAssistantMessage(message);
+        return;
+      }
+
+      if (suggestion.type === 'snooze_review_card') {
+        const message = await cardReviewSessionActions.requestSnooze(suggestion.payload.cardId);
+        commandBar.pushAssistantMessage(message);
+        return;
+      }
+
+      if (suggestion.type === 'next_review_card') {
+        const message = await cardReviewSessionActions.requestNext(suggestion.payload.cardId);
+        commandBar.pushAssistantMessage(message);
       }
     } catch (error) {
       commandBar.pushAssistantMessage(

--- a/apps/web/src/lib/server/ai-prompts/chat.test.ts
+++ b/apps/web/src/lib/server/ai-prompts/chat.test.ts
@@ -175,4 +175,61 @@ describe('buildStructuredChatPrompt', () => {
     expect(prompt.userPrompt).toContain('Allowed suggestion types: add_inbox_note.');
     expect(prompt.userPrompt).toContain('Never assume add_inbox_note creates anything automatically');
   });
+
+  it('includes Card Review action suggestion shapes and current-card guidance for active sessions', () => {
+    const canonicalContext: CanonicalChatContext = {
+      contextType: 'card_review_session',
+      languageId: 'zh',
+      allowedSuggestionTypes: ['add_inbox_note', 'pin_review_card', 'snooze_review_card', 'next_review_card'],
+      selection: {
+        groupIds: ['group-1'],
+        limit: 10,
+        countMode: 'limit',
+      },
+      initialTotalCount: 4,
+      completedCount: 1,
+      remainingCount: 3,
+      currentCardNumber: 2,
+      currentCard: {
+        cardId: 'card-1',
+        content: '谈论',
+        meaning: 'to discuss',
+        cardType: 'word',
+        groupNames: ['Conversation'],
+        examples: ['我们以后再谈论这个问题。'],
+        mnemonics: ['Think of a discussion turning in loops.'],
+        llmInstructions: null,
+        nextDueAtIso: '2026-05-10T12:00:00.000Z',
+        reviewCount: 2,
+      },
+      upcomingCards: [
+        {
+          cardId: 'card-2',
+          content: '聊天',
+          meaning: 'to chat',
+          cardType: 'word',
+          groupNames: ['Conversation'],
+          examples: [],
+          mnemonics: [],
+          llmInstructions: null,
+          nextDueAtIso: '2026-05-10T12:05:00.000Z',
+          reviewCount: 1,
+        },
+      ],
+    };
+
+    const prompt = buildStructuredChatPrompt({
+      canonicalContext,
+      userInput: 'I know this one already, move on.',
+      allowedSuggestionTypes: ['add_inbox_note', 'pin_review_card', 'snooze_review_card', 'next_review_card'],
+    });
+
+    expect(prompt.userPrompt).toContain('"contextType": "card_review_session"');
+    expect(prompt.userPrompt).toContain('"currentCardNumber": 2');
+    expect(prompt.userPrompt).toContain('{"type":"pin_review_card","payload":{"cardId":"string"}}');
+    expect(prompt.userPrompt).toContain('{"type":"snooze_review_card","payload":{"cardId":"string"}}');
+    expect(prompt.userPrompt).toContain('{"type":"next_review_card","payload":{"cardId":"string"}}');
+    expect(prompt.userPrompt).toContain('Use the exact current review cardId from the machine context');
+    expect(prompt.userPrompt).toContain('"cardId": "card-1"');
+  });
 });

--- a/apps/web/src/lib/server/ai-prompts/chat.ts
+++ b/apps/web/src/lib/server/ai-prompts/chat.ts
@@ -38,6 +38,18 @@ function buildResponseShapeInstruction(allowedSuggestionTypes: readonly ChatSugg
     suggestionExamples.push('{"type":"remove_card_from_group","payload":{"cardId":"string","groupId":"string"}}');
   }
 
+  if (allowedSuggestionTypes.includes('pin_review_card')) {
+    suggestionExamples.push('{"type":"pin_review_card","payload":{"cardId":"string"}}');
+  }
+
+  if (allowedSuggestionTypes.includes('snooze_review_card')) {
+    suggestionExamples.push('{"type":"snooze_review_card","payload":{"cardId":"string"}}');
+  }
+
+  if (allowedSuggestionTypes.includes('next_review_card')) {
+    suggestionExamples.push('{"type":"next_review_card","payload":{"cardId":"string"}}');
+  }
+
   return [
     'Return this JSON shape exactly:',
     '{"message":"string","suggestions":[{"type":"...","payload":{...}}]}',
@@ -61,6 +73,15 @@ function buildSuggestionGuidance(allowedSuggestionTypes: readonly ChatSuggestion
     allowedSuggestionTypes.includes('remove_card_from_group')
   ) {
     guidance.push('Use exact cardId and groupId values from the machine context. Never substitute names for IDs.');
+  }
+
+  if (
+    allowedSuggestionTypes.includes('pin_review_card') ||
+    allowedSuggestionTypes.includes('snooze_review_card') ||
+    allowedSuggestionTypes.includes('next_review_card')
+  ) {
+    guidance.push('Use the exact current review cardId from the machine context for Card Review suggestions.');
+    guidance.push('Only suggest Card Review actions that are valid for the current session card and queue state.');
   }
 
   if (allowedSuggestionTypes.includes('create_group')) {

--- a/apps/web/src/lib/server/chat-context.test.ts
+++ b/apps/web/src/lib/server/chat-context.test.ts
@@ -111,6 +111,8 @@ describe('resolveCanonicalChatContext', () => {
         }),
         loadCardLibraryGroupsData: vi.fn(),
         loadGroupDetailData: vi.fn(),
+        loadCardReviewHomeData: vi.fn(),
+        loadCardReviewSessionData: vi.fn(),
       },
     );
 
@@ -159,6 +161,8 @@ describe('resolveCanonicalChatContext', () => {
           totalCount: 1,
         }),
         loadGroupDetailData: vi.fn(),
+        loadCardReviewHomeData: vi.fn(),
+        loadCardReviewSessionData: vi.fn(),
       },
     );
 
@@ -229,6 +233,8 @@ describe('resolveCanonicalChatContext', () => {
             totalCount: 0,
           },
         }),
+        loadCardReviewHomeData: vi.fn(),
+        loadCardReviewSessionData: vi.fn(),
       },
     );
 
@@ -311,6 +317,8 @@ describe('resolveCanonicalChatContext', () => {
             totalCount: 2,
           },
         }),
+        loadCardReviewHomeData: vi.fn(),
+        loadCardReviewSessionData: vi.fn(),
       },
     );
 
@@ -392,6 +400,8 @@ describe('resolveCanonicalChatContext', () => {
             totalCount: 0,
           },
         }),
+        loadCardReviewHomeData: vi.fn(),
+        loadCardReviewSessionData: vi.fn(),
       },
     );
 
@@ -420,6 +430,168 @@ describe('resolveCanonicalChatContext', () => {
         groupId: 'group-1',
         groupName: 'Greetings',
       },
+    });
+  });
+
+  it('resolves card-review setup context from validated selection hints', async () => {
+    const context = await resolveCanonicalChatContext(
+      'user-1',
+      {
+        routeContext: resolveRouteContext('/es/card-review'),
+        languageId: 'es',
+        surfaceContext: {
+          surface: 'card_review_setup',
+          selection: {
+            groupIds: ['group-1'],
+            limit: 10,
+            countMode: 'limit',
+          },
+        },
+      },
+      {} as Parameters<typeof resolveCanonicalChatContext>[2],
+      {
+        loadActiveCardDetailData: vi.fn(),
+        loadCardLibraryData: vi.fn(),
+        loadCardLibraryGroupsData: vi.fn(),
+        loadGroupDetailData: vi.fn(),
+        loadCardReviewHomeData: vi.fn().mockResolvedValue({
+          stats: {
+            cardsInRotation: 12,
+            dueNowCount: 5,
+            reviewedTodayCount: 2,
+            currentStreakDays: 3,
+            lastReviewedAtIso: '2026-05-10T12:00:00.000Z',
+          },
+          groups: [
+            {
+              groupId: 'group-1',
+              groupName: 'Core',
+              activeCardCount: 8,
+              dueCardCount: 5,
+              nextDueAtIso: '2026-05-11T12:00:00.000Z',
+            },
+          ],
+          selection: {
+            groupIds: ['group-1'],
+            limit: 10,
+            countMode: 'limit',
+          },
+          sessionPreview: {
+            selectedGroupCount: 1,
+            selectedDueCount: 5,
+            nextDueAtIso: '2026-05-11T12:00:00.000Z',
+          },
+        }),
+        loadCardReviewSessionData: vi.fn(),
+      },
+    );
+
+    expect(context).toMatchObject({
+      contextType: 'card_review_setup',
+      languageId: 'es',
+      allowedSuggestionTypes: ['add_inbox_note'],
+      selection: {
+        groupIds: ['group-1'],
+        limit: 10,
+        countMode: 'limit',
+      },
+      selectedGroups: [{ groupId: 'group-1', groupName: 'Core' }],
+      sessionPreview: {
+        selectedGroupCount: 1,
+        selectedDueCount: 5,
+      },
+    });
+  });
+
+  it('resolves card-review session context with current card and upcoming queue snapshots', async () => {
+    const context = await resolveCanonicalChatContext(
+      'user-1',
+      {
+        routeContext: resolveRouteContext('/es/card-review/session'),
+        languageId: 'es',
+        surfaceContext: {
+          surface: 'card_review_session',
+          selection: {
+            groupIds: ['group-1'],
+            limit: 10,
+            countMode: 'limit',
+          },
+          queueCardIds: ['card-1', 'card-2'],
+          currentCardId: 'card-1',
+          initialTotalCount: 3,
+          completedCount: 1,
+        },
+      },
+      {} as Parameters<typeof resolveCanonicalChatContext>[2],
+      {
+        loadActiveCardDetailData: vi.fn(),
+        loadCardLibraryData: vi.fn(),
+        loadCardLibraryGroupsData: vi.fn(),
+        loadGroupDetailData: vi.fn(),
+        loadCardReviewHomeData: vi.fn(),
+        loadCardReviewSessionData: vi.fn().mockResolvedValue({
+          selection: {
+            groupIds: ['group-1'],
+            limit: 10,
+            countMode: 'limit',
+          },
+          totalCount: 3,
+          availableGroups: [],
+          items: [
+            {
+              cardId: 'card-1',
+              content: 'hablar',
+              meaning: 'to speak',
+              cardType: 'word',
+              examples: ['Quiero hablar contigo.'],
+              mnemonics: ['Think of habitual speaking.'],
+              llmInstructions: null,
+              updatedAtIso: null,
+              groups: [{ groupId: 'group-1', groupName: 'Core' }],
+              nextDueAtIso: '2026-05-10T12:00:00.000Z',
+              intervalDays: 2,
+              easeFactor: 2.5,
+              reviewCount: 3,
+              lastReviewedAtIso: null,
+              state: 'active',
+              snoozedUntilIso: null,
+            },
+            {
+              cardId: 'card-2',
+              content: 'conversar',
+              meaning: 'to converse',
+              cardType: 'word',
+              examples: [],
+              mnemonics: [],
+              llmInstructions: 'Prefer spoken-register examples.',
+              updatedAtIso: null,
+              groups: [{ groupId: 'group-1', groupName: 'Core' }],
+              nextDueAtIso: '2026-05-10T13:00:00.000Z',
+              intervalDays: 1,
+              easeFactor: 2.3,
+              reviewCount: 2,
+              lastReviewedAtIso: null,
+              state: 'active',
+              snoozedUntilIso: null,
+            },
+          ],
+        }),
+      },
+    );
+
+    expect(context).toMatchObject({
+      contextType: 'card_review_session',
+      languageId: 'es',
+      allowedSuggestionTypes: ['add_inbox_note', 'pin_review_card', 'snooze_review_card', 'next_review_card'],
+      initialTotalCount: 3,
+      completedCount: 1,
+      remainingCount: 2,
+      currentCardNumber: 2,
+      currentCard: {
+        cardId: 'card-1',
+        content: 'hablar',
+      },
+      upcomingCards: [{ cardId: 'card-2', content: 'conversar' }],
     });
   });
 });
@@ -457,6 +629,8 @@ describe('getAllowedSuggestionTypes', () => {
         }),
         loadCardLibraryGroupsData: vi.fn(),
         loadGroupDetailData: vi.fn(),
+        loadCardReviewHomeData: vi.fn(),
+        loadCardReviewSessionData: vi.fn(),
       },
     );
 
@@ -494,6 +668,8 @@ describe('getAllowedSuggestionTypes', () => {
         loadCardLibraryData: vi.fn(),
         loadCardLibraryGroupsData: vi.fn(),
         loadGroupDetailData: vi.fn(),
+        loadCardReviewHomeData: vi.fn(),
+        loadCardReviewSessionData: vi.fn(),
       },
     );
 
@@ -503,6 +679,72 @@ describe('getAllowedSuggestionTypes', () => {
       'add_inbox_note',
       'add_card_to_group',
       'remove_card_from_group',
+    ]);
+  });
+
+  it('returns review session suggestion types for card-review session context', async () => {
+    const context = await resolveCanonicalChatContext(
+      'user-1',
+      {
+        routeContext: resolveRouteContext('/es/card-review/session'),
+        languageId: 'es',
+        surfaceContext: {
+          surface: 'card_review_session',
+          selection: {
+            groupIds: ['group-1'],
+            limit: null,
+            countMode: 'all_due',
+          },
+          queueCardIds: ['card-1'],
+          currentCardId: 'card-1',
+          initialTotalCount: 1,
+          completedCount: 0,
+        },
+      },
+      {} as Parameters<typeof resolveCanonicalChatContext>[2],
+      {
+        loadActiveCardDetailData: vi.fn(),
+        loadCardLibraryData: vi.fn(),
+        loadCardLibraryGroupsData: vi.fn(),
+        loadGroupDetailData: vi.fn(),
+        loadCardReviewHomeData: vi.fn(),
+        loadCardReviewSessionData: vi.fn().mockResolvedValue({
+          selection: {
+            groupIds: ['group-1'],
+            limit: null,
+            countMode: 'all_due',
+          },
+          totalCount: 1,
+          availableGroups: [],
+          items: [
+            {
+              cardId: 'card-1',
+              content: 'hablar',
+              meaning: 'to speak',
+              cardType: 'word',
+              examples: [],
+              mnemonics: [],
+              llmInstructions: null,
+              updatedAtIso: null,
+              groups: [{ groupId: 'group-1', groupName: 'Core' }],
+              nextDueAtIso: null,
+              intervalDays: 1,
+              easeFactor: 2.5,
+              reviewCount: 0,
+              lastReviewedAtIso: null,
+              state: 'active',
+              snoozedUntilIso: null,
+            },
+          ],
+        }),
+      },
+    );
+
+    expect(getAllowedSuggestionTypes(context)).toEqual([
+      'add_inbox_note',
+      'pin_review_card',
+      'snooze_review_card',
+      'next_review_card',
     ]);
   });
 });
@@ -598,6 +840,50 @@ describe('areChatSuggestionsValidForContext', () => {
           type: 'remove_card_from_group',
           payload: { cardId: 'card-1', groupId: 'group-999' },
         },
+      ]),
+    ).toBe(false);
+  });
+
+  it('accepts Card Review action suggestions only for the current session card', () => {
+    const context = {
+      contextType: 'card_review_session',
+      languageId: 'es',
+      allowedSuggestionTypes: ['add_inbox_note', 'pin_review_card', 'snooze_review_card', 'next_review_card'],
+      selection: {
+        groupIds: ['group-1'],
+        limit: null,
+        countMode: 'all_due',
+      },
+      initialTotalCount: 2,
+      completedCount: 0,
+      remainingCount: 2,
+      currentCardNumber: 1,
+      currentCard: {
+        cardId: 'card-1',
+        content: 'hablar',
+        meaning: 'to speak',
+        cardType: 'word',
+        groupNames: ['Core'],
+        examples: [],
+        mnemonics: [],
+        llmInstructions: null,
+        nextDueAtIso: null,
+        reviewCount: 2,
+      },
+      upcomingCards: [],
+    } as Awaited<ReturnType<typeof resolveCanonicalChatContext>>;
+
+    expect(
+      areChatSuggestionsValidForContext(context, [
+        { type: 'pin_review_card', payload: { cardId: 'card-1' } },
+        { type: 'snooze_review_card', payload: { cardId: 'card-1' } },
+        { type: 'next_review_card', payload: { cardId: 'card-1' } },
+      ]),
+    ).toBe(true);
+
+    expect(
+      areChatSuggestionsValidForContext(context, [
+        { type: 'pin_review_card', payload: { cardId: 'card-2' } },
       ]),
     ).toBe(false);
   });

--- a/apps/web/src/lib/server/chat-context.ts
+++ b/apps/web/src/lib/server/chat-context.ts
@@ -10,13 +10,20 @@ import type { RouteContext } from '$lib/command-bar/shared.js';
 import { CardEntryRequestError } from '$lib/server/card-entry.js';
 import {
   loadActiveCardDetailData,
+  type CardLibraryCardListItemData,
+  type CardLibraryGroupData,
   loadCardLibraryData,
   loadCardLibraryGroupsData,
   loadGroupDetailData,
-  type CardLibraryCardListItemData,
   type CardLibraryGroupListItemData,
-  type CardLibraryGroupData,
 } from '$lib/server/cards.js';
+import {
+  loadCardReviewHomeData,
+  loadCardReviewSessionData,
+  type CardReviewGroupSummaryData,
+  type CardReviewSessionItemData,
+  type CardReviewSessionSelection,
+} from '$lib/server/card-review.js';
 
 type DatabaseClient = NonNullable<Parameters<typeof getNoteWithDraftCards>[3]>;
 
@@ -162,6 +169,60 @@ export type NonActionableContext = {
   allowedSuggestionTypes: readonly ['add_inbox_note'] | readonly [];
 };
 
+export type CardReviewGroupSnapshot = {
+  groupId: string;
+  groupName: string;
+  activeCardCount: number;
+  dueCardCount: number;
+  nextDueAtIso: string | null;
+};
+
+export type CardReviewCardSnapshot = {
+  cardId: string;
+  content: string;
+  meaning: string | null;
+  cardType: string | null;
+  groupNames: string[];
+  examples: string[];
+  mnemonics: string[];
+  llmInstructions: string | null;
+  nextDueAtIso: string | null;
+  reviewCount: number;
+};
+
+export type CardReviewSetupContext = {
+  contextType: 'card_review_setup';
+  languageId: string;
+  allowedSuggestionTypes: readonly ['add_inbox_note'];
+  selection: CardReviewSessionSelection;
+  stats: {
+    cardsInRotation: number;
+    dueNowCount: number;
+    reviewedTodayCount: number;
+    currentStreakDays: number;
+    lastReviewedAtIso: string | null;
+  };
+  selectedGroups: CardReviewGroupSnapshot[];
+  sessionPreview: {
+    selectedGroupCount: number;
+    selectedDueCount: number;
+    nextDueAtIso: string | null;
+  };
+};
+
+export type CardReviewSessionContext = {
+  contextType: 'card_review_session';
+  languageId: string;
+  allowedSuggestionTypes: readonly ['add_inbox_note', 'pin_review_card', 'snooze_review_card', 'next_review_card'];
+  selection: CardReviewSessionSelection;
+  initialTotalCount: number;
+  completedCount: number;
+  remainingCount: number;
+  currentCardNumber: number;
+  currentCard: CardReviewCardSnapshot;
+  upcomingCards: CardReviewCardSnapshot[];
+};
+
 export type CanonicalChatContext =
   | CardEntryNoteWorkspaceContext
   | CardLibraryListContext
@@ -169,6 +230,8 @@ export type CanonicalChatContext =
   | GroupDetailContext
   | AddCardsToGroupDrawerContext
   | CardDetailDrawerContext
+  | CardReviewSetupContext
+  | CardReviewSessionContext
   | NonActionableContext;
 
 // ── Context hint (derived from the client request) ───────────────────────────
@@ -187,6 +250,8 @@ type ResolverDeps = {
   loadCardLibraryData: typeof loadCardLibraryData;
   loadCardLibraryGroupsData: typeof loadCardLibraryGroupsData;
   loadGroupDetailData: typeof loadGroupDetailData;
+  loadCardReviewHomeData: typeof loadCardReviewHomeData;
+  loadCardReviewSessionData: typeof loadCardReviewSessionData;
 };
 
 const defaultResolverDeps: ResolverDeps = {
@@ -194,6 +259,8 @@ const defaultResolverDeps: ResolverDeps = {
   loadCardLibraryData,
   loadCardLibraryGroupsData,
   loadGroupDetailData,
+  loadCardReviewHomeData,
+  loadCardReviewSessionData,
 };
 
 // jsonb columns in the database schema are typed as `unknown` by Drizzle because
@@ -283,6 +350,31 @@ function buildGroupReference(item: Pick<CardLibraryGroupData, 'groupId' | 'group
   return {
     groupId: item.groupId,
     groupName: item.groupName,
+  };
+}
+
+function buildCardReviewGroupSnapshot(group: CardReviewGroupSummaryData): CardReviewGroupSnapshot {
+  return {
+    groupId: group.groupId,
+    groupName: group.groupName,
+    activeCardCount: group.activeCardCount,
+    dueCardCount: group.dueCardCount,
+    nextDueAtIso: group.nextDueAtIso,
+  };
+}
+
+function buildCardReviewCardSnapshot(item: CardReviewSessionItemData): CardReviewCardSnapshot {
+  return {
+    cardId: item.cardId,
+    content: item.content,
+    meaning: item.meaning,
+    cardType: item.cardType,
+    groupNames: item.groups.map((group) => group.groupName),
+    examples: item.examples,
+    mnemonics: item.mnemonics,
+    llmInstructions: item.llmInstructions,
+    nextDueAtIso: item.nextDueAtIso,
+    reviewCount: item.reviewCount,
   };
 }
 
@@ -541,6 +633,92 @@ async function resolveCardDetailDrawerContext(
   };
 }
 
+function buildCardReviewUrlFromSelection(pathname: string, selection: CardReviewSessionSelection) {
+  const url = new URL(pathname, 'https://studypuck.test');
+  url.searchParams.delete('group');
+
+  for (const groupId of selection.groupIds) {
+    url.searchParams.append('group', groupId);
+  }
+
+  if (selection.limit === null || selection.countMode === 'all_due') {
+    url.searchParams.delete('limit');
+  } else {
+    url.searchParams.set('limit', String(selection.limit));
+  }
+
+  return url;
+}
+
+async function resolveCardReviewSetupContext(
+  userId: string,
+  languageId: string,
+  surfaceContext: Extract<ChatSurfaceContext, { surface: 'card_review_setup' }>,
+  routeContext: RouteContext,
+  database: DatabaseClient,
+  deps: ResolverDeps,
+): Promise<CardReviewSetupContext> {
+  const home = await deps.loadCardReviewHomeData(
+    userId,
+    languageId,
+    buildCardReviewUrlFromSelection(routeContext.pathname, surfaceContext.selection),
+    database,
+  );
+
+  return {
+    contextType: 'card_review_setup',
+    languageId,
+    allowedSuggestionTypes: ['add_inbox_note'],
+    selection: home.selection,
+    stats: home.stats,
+    selectedGroups: home.groups
+      .filter((group) => home.selection.groupIds.includes(group.groupId))
+      .map((group) => buildCardReviewGroupSnapshot(group)),
+    sessionPreview: home.sessionPreview,
+  };
+}
+
+async function resolveCardReviewSessionContext(
+  userId: string,
+  languageId: string,
+  surfaceContext: Extract<ChatSurfaceContext, { surface: 'card_review_session' }>,
+  routeContext: RouteContext,
+  database: DatabaseClient,
+  deps: ResolverDeps,
+): Promise<CardReviewSessionContext | NonActionableContext> {
+  const session = await deps.loadCardReviewSessionData(
+    userId,
+    languageId,
+    buildCardReviewUrlFromSelection(routeContext.pathname, surfaceContext.selection),
+    database,
+  );
+  const queuedItems = session.items.filter((item) => surfaceContext.queueCardIds.includes(item.cardId));
+  const currentCard = queuedItems.find((item) => item.cardId === surfaceContext.currentCardId) ?? null;
+
+  if (!currentCard) {
+    return resolveNonActionableContext({
+      routeContext,
+      languageId,
+    });
+  }
+
+  return {
+    contextType: 'card_review_session',
+    languageId,
+    allowedSuggestionTypes: ['add_inbox_note', 'pin_review_card', 'snooze_review_card', 'next_review_card'],
+    selection: session.selection,
+    initialTotalCount: surfaceContext.initialTotalCount,
+    completedCount: surfaceContext.completedCount,
+    remainingCount: queuedItems.length,
+    currentCardNumber: surfaceContext.completedCount + 1,
+    currentCard: buildCardReviewCardSnapshot(currentCard),
+    upcomingCards: queuedItems
+      .filter((item) => item.cardId !== currentCard.cardId)
+      .slice(0, CARD_SNAPSHOT_LIMIT)
+      .map((item) => buildCardReviewCardSnapshot(item)),
+  };
+}
+
 // ── Resolver: non-actionable (cards, stats, settings, workspace) ─────────────
 
 function resolveNonActionableContext(
@@ -659,6 +837,32 @@ export async function resolveCanonicalChatContext(
         database,
         deps,
       );
+    case 'card_review_setup':
+      if (hint.routeContext.routeContextType !== 'card-review') {
+        return resolveNonActionableContext(hint);
+      }
+
+      return resolveCardReviewSetupContext(
+        userId,
+        languageId,
+        surfaceContext,
+        hint.routeContext,
+        database,
+        deps,
+      );
+    case 'card_review_session':
+      if (hint.routeContext.routeContextType !== 'card-review') {
+        return resolveNonActionableContext(hint);
+      }
+
+      return resolveCardReviewSessionContext(
+        userId,
+        languageId,
+        surfaceContext,
+        hint.routeContext,
+        database,
+        deps,
+      );
   }
 }
 
@@ -739,6 +943,13 @@ function isRemoveCardFromGroupSuggestionValid(
   }
 }
 
+function isCardReviewSuggestionValid(
+  context: CanonicalChatContext,
+  payload: Extract<ChatSuggestion, { type: 'pin_review_card' | 'snooze_review_card' | 'next_review_card' }>['payload'],
+) {
+  return context.contextType === 'card_review_session' && payload.cardId === context.currentCard.cardId;
+}
+
 export function areChatSuggestionsValidForContext(
   context: CanonicalChatContext,
   suggestions: readonly ChatSuggestion[],
@@ -773,6 +984,10 @@ export function areChatSuggestionsValidForContext(
         return isAddCardToGroupSuggestionValid(context, suggestion.payload);
       case 'remove_card_from_group':
         return isRemoveCardFromGroupSuggestionValid(context, suggestion.payload);
+      case 'pin_review_card':
+      case 'snooze_review_card':
+      case 'next_review_card':
+        return isCardReviewSuggestionValid(context, suggestion.payload);
     }
   });
 }

--- a/apps/web/src/lib/stores/cardReviewSessionActions.ts
+++ b/apps/web/src/lib/stores/cardReviewSessionActions.ts
@@ -1,0 +1,43 @@
+import { writable } from 'svelte/store';
+
+export type CardReviewSessionActionRequest = {
+  actionId: number;
+  action: 'pin' | 'snooze' | 'next';
+  cardId: string;
+  resolve: (message: string) => void;
+  reject: (error: Error) => void;
+};
+
+function createCardReviewSessionActionsStore() {
+  const { subscribe, set } = writable<CardReviewSessionActionRequest | null>(null);
+  let actionCounter = 0;
+
+  function dispatch(action: CardReviewSessionActionRequest['action'], cardId: string) {
+    actionCounter += 1;
+
+    return new Promise<string>((resolve, reject) => {
+      set({
+        actionId: actionCounter,
+        action,
+        cardId,
+        resolve,
+        reject,
+      });
+    });
+  }
+
+  return {
+    subscribe,
+    requestPin(cardId: string) {
+      return dispatch('pin', cardId);
+    },
+    requestSnooze(cardId: string) {
+      return dispatch('snooze', cardId);
+    },
+    requestNext(cardId: string) {
+      return dispatch('next', cardId);
+    },
+  };
+}
+
+export const cardReviewSessionActions = createCardReviewSessionActionsStore();

--- a/apps/web/src/lib/stores/commandBar.test.ts
+++ b/apps/web/src/lib/stores/commandBar.test.ts
@@ -195,6 +195,74 @@ describe('commandBar entity context and conversation reset', () => {
     });
   });
 
+  it('resets messages when Card Review moves from setup into an active session', () => {
+    commandBar.setWorkspaceContext('es', null);
+    commandBar.setSurfaceContext({
+      surface: 'card_review_setup',
+      selection: {
+        groupIds: ['group-1'],
+        limit: null,
+        countMode: 'all_due',
+      },
+    });
+    commandBar.pushAssistantMessage('Existing conversation');
+    commandBar.setSurfaceContext({
+      surface: 'card_review_session',
+      selection: {
+        groupIds: ['group-1'],
+        limit: null,
+        countMode: 'all_due',
+      },
+      queueCardIds: ['card-1', 'card-2'],
+      currentCardId: 'card-1',
+      initialTotalCount: 2,
+      completedCount: 0,
+    });
+
+    const state = getState();
+    expect(state.messages).toEqual([]);
+    expect(state.surfaceContextHint).toMatchObject({
+      surface: 'card_review_session',
+      currentCardId: 'card-1',
+    });
+  });
+
+  it('resets messages when the active Card Review session card changes', () => {
+    commandBar.setWorkspaceContext('es', null);
+    commandBar.setSurfaceContext({
+      surface: 'card_review_session',
+      selection: {
+        groupIds: ['group-1'],
+        limit: null,
+        countMode: 'all_due',
+      },
+      queueCardIds: ['card-1', 'card-2'],
+      currentCardId: 'card-1',
+      initialTotalCount: 2,
+      completedCount: 0,
+    });
+    commandBar.pushAssistantMessage('Existing conversation');
+    commandBar.setSurfaceContext({
+      surface: 'card_review_session',
+      selection: {
+        groupIds: ['group-1'],
+        limit: null,
+        countMode: 'all_due',
+      },
+      queueCardIds: ['card-2', 'card-1'],
+      currentCardId: 'card-2',
+      initialTotalCount: 2,
+      completedCount: 0,
+    });
+
+    const state = getState();
+    expect(state.messages).toEqual([]);
+    expect(state.surfaceContextHint).toMatchObject({
+      surface: 'card_review_session',
+      currentCardId: 'card-2',
+    });
+  });
+
   it('getPromptHistory returns only user and assistant turns bounded to PROMPT_HISTORY_CAP', () => {
     const mockState = {
       messages: [

--- a/apps/web/src/lib/stores/commandBar.ts
+++ b/apps/web/src/lib/stores/commandBar.ts
@@ -112,12 +112,15 @@ function getSurfaceContextScopeKey(surfaceContext: ChatSurfaceContext | null) {
   switch (surfaceContext.surface) {
     case 'card_library_list':
     case 'groups_list':
+    case 'card_review_setup':
       return surfaceContext.surface;
     case 'group_detail':
     case 'add_cards_to_group_drawer':
       return `${surfaceContext.surface}:${surfaceContext.groupId}`;
     case 'card_detail_drawer':
       return `${surfaceContext.surface}:${surfaceContext.sourceSurface}:${surfaceContext.groupId ?? 'none'}:${surfaceContext.cardId}`;
+    case 'card_review_session':
+      return `${surfaceContext.surface}:${surfaceContext.selection.groupIds.join(',')}:${surfaceContext.selection.limit ?? 'all'}:${surfaceContext.currentCardId}`;
   }
 }
 

--- a/apps/web/src/routes/[lang]/card-review/+page.svelte
+++ b/apps/web/src/routes/[lang]/card-review/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { page } from '$app/stores';
+  import { commandBar } from '$lib/stores/commandBar.js';
   import type { PageData } from './$types.js';
 
   export let data: PageData;
@@ -17,6 +18,7 @@
 
   $: home = data.home;
   $: currentLanguage = $page.params.lang ?? '';
+  $: commandBar.setWorkspaceContext(currentLanguage || null, null);
   $: allGroups = home?.groups ?? [];
   $: selectedGroups = allGroups.filter((group) => selectedGroupIds.includes(group.groupId));
   $: selectedDueCount = selectedGroups.reduce((count, group) => count + group.dueCardCount, 0);
@@ -42,6 +44,19 @@
     return new Date(group.nextDueAtIso) < new Date(soonest) ? group.nextDueAtIso : soonest;
   }, null);
   $: setupHint = getSetupHint();
+  $: commandBar.setSurfaceContext(
+    home
+      ? {
+          surface: 'card_review_setup',
+          selection: {
+            groupIds: selectedGroupIds,
+            limit: effectiveLimit,
+            countMode,
+          },
+        }
+      : null,
+  );
+  $: commandBar.setTargetHint(null, null);
 
   function formatRelativeDateLabel(value: string | null): string {
     if (!value) {

--- a/apps/web/src/routes/[lang]/card-review/session/+page.svelte
+++ b/apps/web/src/routes/[lang]/card-review/session/+page.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { page } from '$app/stores';
+  import { get } from 'svelte/store';
   import { tick } from 'svelte';
   import ActiveCardDrawer from '$lib/components/cards/ActiveCardDrawer.svelte';
+  import { commandBar } from '$lib/stores/commandBar.js';
+  import { cardReviewSessionActions, type CardReviewSessionActionRequest } from '$lib/stores/cardReviewSessionActions.js';
   import type { CardLibraryCardDetailData, CardLibraryGroupData } from '$lib/server/cards.js';
   import type { PageData } from './$types.js';
 
@@ -47,9 +50,11 @@
   let endSessionOpen = false;
   let endSessionDialog: HTMLElement | null = null;
   let previousReviewSession = data.reviewSession;
+  let lastHandledSessionActionId = get(cardReviewSessionActions)?.actionId ?? 0;
 
   $: reviewSession = data.reviewSession;
   $: currentLanguage = $page.params.lang ?? '';
+  $: commandBar.setWorkspaceContext(currentLanguage || null, null);
   $: currentItem = queueItems[0] ?? null;
   $: completedCount = initialTotalCount - queueItems.length;
   $: currentCardNumber = currentItem ? completedCount + 1 : initialTotalCount;
@@ -64,10 +69,28 @@
   $: drawerCard = drawerItem ? toDrawerCard(drawerItem) : null;
   $: queuePreview = queueItems.slice(1, 6);
   $: completionDurationLabel = formatDuration((completionAtMs ?? Date.now()) - startedAtMs);
+  $: commandBar.setSurfaceContext(
+    currentItem && reviewSession
+      ? {
+          surface: 'card_review_session',
+          selection: reviewSession.selection,
+          queueCardIds: queueItems.map((item) => item.cardId),
+          currentCardId: currentItem.cardId,
+          initialTotalCount,
+          completedCount,
+        }
+      : null,
+  );
+  $: commandBar.setTargetHint(currentItem?.cardId ?? null, null);
 
   $: if (reviewSession !== previousReviewSession) {
     resetSessionState(reviewSession);
     previousReviewSession = reviewSession;
+  }
+
+  $: if ($cardReviewSessionActions && $cardReviewSessionActions.actionId !== lastHandledSessionActionId) {
+    lastHandledSessionActionId = $cardReviewSessionActions.actionId;
+    void handleRequestedSessionAction($cardReviewSessionActions);
   }
 
   function resetSessionState(session: ReviewSessionData | null) {
@@ -206,6 +229,44 @@
     actionError = null;
   }
 
+  function advanceToNextCard(cardId: string) {
+    const currentIndex = queueItems.findIndex((item) => item.cardId === cardId);
+
+    if (currentIndex <= 0) {
+      if (queueItems.length <= 1) {
+        return 'There is no next card in this session.';
+      }
+
+      const [firstItem, ...remainingItems] = queueItems;
+
+      if (!firstItem) {
+        return 'There is no next card in this session.';
+      }
+
+      queueItems = [...remainingItems, firstItem];
+
+      if (drawerCardId === cardId) {
+        drawerCardId = queueItems[0]?.cardId ?? null;
+      }
+
+      actionError = null;
+      actionMessage = 'Moved to the next card.';
+      return actionMessage;
+    }
+
+    const [selectedItem] = queueItems.splice(currentIndex, 1);
+
+    if (!selectedItem) {
+      return 'There is no next card in this session.';
+    }
+
+    queueItems = [selectedItem, ...queueItems];
+    drawerCardId = selectedItem.cardId;
+    actionError = null;
+    actionMessage = 'Moved to the next card.';
+    return actionMessage;
+  }
+
   function handleDrawerUpdated(event: CustomEvent<{ card: CardLibraryCardDetailData; availableGroups: CardLibraryGroupData[] }>) {
     sessionAvailableGroups = event.detail.availableGroups;
     queueItems = queueItems.map((item) => item.cardId === event.detail.card.cardId
@@ -263,9 +324,9 @@
 
   async function applySessionAction(
     body: { action: 'rate'; cardId: string; rating: 'easy' | 'medium' | 'hard' } | { action: 'pin' | 'snooze' | 'disable'; cardId: string },
-  ) {
+  ): Promise<string> {
     if (!currentItem || actionPending) {
-      return;
+      throw new Error('The review action could not be completed right now.');
     }
 
     actionPending = true;
@@ -279,10 +340,31 @@
       removeCardFromQueue(result.cardId);
       actionMessage = result.message ?? 'Review action saved.';
       actionError = null;
+      return actionMessage;
     } catch (error) {
       actionError = error instanceof Error ? error.message : 'The review action could not be completed right now.';
+      throw error instanceof Error ? error : new Error(actionError);
     } finally {
       actionPending = false;
+    }
+  }
+
+  async function handleRequestedSessionAction(actionRequest: CardReviewSessionActionRequest) {
+    try {
+      if (actionRequest.action === 'next') {
+        actionRequest.resolve(advanceToNextCard(actionRequest.cardId));
+        return;
+      }
+
+      const message = await applySessionAction({
+        action: actionRequest.action,
+        cardId: actionRequest.cardId,
+      });
+      actionRequest.resolve(message);
+    } catch (error) {
+      const requestError = error instanceof Error ? error : new Error('The review action could not be completed right now.');
+      actionRequest.reject(requestError);
+      commandBar.pushAssistantMessage(requestError.message);
     }
   }
 


### PR DESCRIPTION
## Summary
- add canonical Card Review chat setup/session contexts and typed review suggestion support
- route /pin, /snooze, and /next through app-owned session actions from the command bar
- cover Card Review command-bar prompt, reset, and suggestion execution flows in tests

Closes #190