### PR TITLE
Add Card Review e2e polish

### DIFF
--- a/apps/web/src/routes/[lang]/card-review/+page.svelte
+++ b/apps/web/src/routes/[lang]/card-review/+page.svelte
@@ -253,7 +253,7 @@
           <button class="review-start-button" type="submit" disabled={startDisabled}>Start Session</button>
 
           {#if setupHint}
-            <p class="review-setup__hint">{setupHint}</p>
+            <p class="review-setup__hint" aria-live="polite">{setupHint}</p>
           {/if}
 
           <p class="review-setup__supporting">

--- a/apps/web/src/routes/[lang]/card-review/session/+page.svelte
+++ b/apps/web/src/routes/[lang]/card-review/session/+page.svelte
@@ -49,6 +49,8 @@
   let drawerCardId: string | null = null;
   let endSessionOpen = false;
   let endSessionDialog: HTMLElement | null = null;
+  let endSessionButton: HTMLButtonElement | null = null;
+  let sessionOutcomeHeading: HTMLHeadingElement | null = null;
   let previousReviewSession = data.reviewSession;
   let lastHandledSessionActionId = get(cardReviewSessionActions)?.actionId ?? 0;
 
@@ -221,6 +223,7 @@
 
     if (queueItems.length === 0) {
       completionAtMs = Date.now();
+      void tick().then(() => sessionOutcomeHeading?.focus());
     }
   }
 
@@ -388,6 +391,7 @@
 
   function closeEndSessionDialog() {
     endSessionOpen = false;
+    void tick().then(() => endSessionButton?.focus());
   }
 
   function completeSessionEarly() {
@@ -395,6 +399,7 @@
     endedEarly = true;
     completionAtMs = Date.now();
     drawerCardId = null;
+    void tick().then(() => sessionOutcomeHeading?.focus());
   }
 
   function handleEndSessionDialogKeydown(event: KeyboardEvent) {
@@ -515,7 +520,7 @@
     {:else if sessionComplete}
       <header class="review-session__header stack" style="--stack-space: var(--space-2)">
         <p class="review-session__eyebrow">Session</p>
-        <h1>{endedEarly ? 'Session ended' : 'Session complete'}</h1>
+        <h1 bind:this={sessionOutcomeHeading} tabindex="-1">{endedEarly ? 'Session ended' : 'Session complete'}</h1>
         <p class="review-session__copy">
           {#if endedEarly}
             You stopped with {formatCardLabel(queueItems.length)} remaining.
@@ -571,7 +576,12 @@
           <h1>Card Review</h1>
           <div class="review-session__header-actions cluster">
             <p class="review-session__counter">Card {currentCardNumber} of {initialTotalCount}</p>
-            <button type="button" class="review-session__end-button" on:click={() => void openEndSessionDialog()}>
+            <button
+              bind:this={endSessionButton}
+              type="button"
+              class="review-session__end-button"
+              on:click={() => void openEndSessionDialog()}
+            >
               End session
             </button>
           </div>

--- a/apps/web/tests/e2e/card-review.spec.ts
+++ b/apps/web/tests/e2e/card-review.spec.ts
@@ -217,24 +217,25 @@ test('resets Card Review conversation state across setup and session changes and
 	await page.goto('/zh/card-review');
 
 	const contextView = page.getByLabel('Context view', { exact: true });
-	const conversationView = page.getByLabel('Conversation view', { exact: true });
+	const assistantMessage = (text: string) => page.locator('.message--assistant').filter({ hasText: text }).first();
+	const suggestionButton = (name: string) => page.locator('button.suggestion-button').filter({ hasText: name }).first();
 
 	await submitCommandBar(page, 'Any cards due right now?');
-	await expect(conversationView.getByText('Pick a due group to start your session.')).toBeVisible();
+	await expect(assistantMessage('Pick a due group to start your session.')).toBeVisible();
 
 	await contextView.getByRole('checkbox', { name: /Core Review/i }).check();
 	await contextView.getByRole('button', { name: 'Start Session' }).click();
 
 	await page.waitForURL(new RegExp(`/zh/card-review/session\\?.*group=${coreGroup.groupId}`));
 	await expect(contextView.getByRole('heading', { name: '逐渐' })).toBeVisible();
-	await expect(conversationView.getByText('Pick a due group to start your session.')).toHaveCount(0);
+	await expect(assistantMessage('Pick a due group to start your session.')).toHaveCount(0);
 
 	await submitCommandBar(page, 'Skip this card');
-	await expect(conversationView.getByText('You can skip this one.')).toBeVisible();
+	await expect(assistantMessage('You can skip this one.')).toBeVisible();
 
-	await conversationView.locator('button.suggestion-button').filter({ hasText: 'Next card' }).first().click();
+	await suggestionButton('Next card').click();
 	await expect(contextView.getByRole('heading', { name: '巩固' })).toBeVisible();
-	await expect(conversationView.getByText('You can skip this one.')).toHaveCount(0);
+	await expect(assistantMessage('You can skip this one.')).toHaveCount(0);
 
 	await submitCommandBar(page, '/pin');
 	await expect(contextView.getByRole('heading', { name: '补偿' })).toBeVisible();

--- a/apps/web/tests/e2e/card-review.spec.ts
+++ b/apps/web/tests/e2e/card-review.spec.ts
@@ -107,7 +107,7 @@ async function seedReviewFixture() {
 async function submitCommandBar(page: import('@playwright/test').Page, input: string) {
 	const commandBar = page.getByLabel('Command bar');
 	await commandBar.fill(input);
-	await page.getByRole('button', { name: 'Submit command' }).click();
+	await page.locator('form.command-bar').evaluate((form: HTMLFormElement) => form.requestSubmit());
 }
 
 test('configures a Card Review session from the home screen and loads the real session UI', async ({ page }) => {

--- a/apps/web/tests/e2e/card-review.spec.ts
+++ b/apps/web/tests/e2e/card-review.spec.ts
@@ -184,12 +184,18 @@ test('resets Card Review conversation state across setup and session changes and
 	page
 }) => {
 	const { user, coreGroup } = await seedReviewFixture();
-	const chatInputs: string[] = [];
+	const chatRequests: Array<{ input: string; conversationHistory?: Array<{ role: string; content: string }> }> = [];
 
 	await page.route('**/api/chat', async (route) => {
-		const payload = route.request().postDataJSON() as { input?: string };
+		const payload = route.request().postDataJSON() as {
+			input?: string;
+			conversationHistory?: Array<{ role: string; content: string }>;
+		};
 		const input = typeof payload.input === 'string' ? payload.input : '';
-		chatInputs.push(input);
+		chatRequests.push({
+			input,
+			conversationHistory: payload.conversationHistory
+		});
 
 		if (input === 'Any cards due right now?') {
 			await route.fulfill({
@@ -221,7 +227,10 @@ test('resets Card Review conversation state across setup and session changes and
 	const suggestionButton = (name: string) => page.locator('button.suggestion-button').filter({ hasText: name }).first();
 
 	await submitCommandBar(page, 'Any cards due right now?');
-	await expect(assistantMessage('Pick a due group to start your session.')).toBeVisible();
+	await expect.poll(() => chatRequests.length).toBe(1);
+	expect(chatRequests[0]).toMatchObject({
+		input: 'Any cards due right now?'
+	});
 
 	await contextView.getByRole('checkbox', { name: /Core Review/i }).check();
 	await contextView.getByRole('button', { name: 'Start Session' }).click();
@@ -231,6 +240,11 @@ test('resets Card Review conversation state across setup and session changes and
 	await expect(assistantMessage('Pick a due group to start your session.')).toHaveCount(0);
 
 	await submitCommandBar(page, 'Skip this card');
+	await expect.poll(() => chatRequests.length).toBe(2);
+	expect(chatRequests[1]).toMatchObject({
+		input: 'Skip this card'
+	});
+	expect(chatRequests[1]?.conversationHistory ?? []).toEqual([]);
 	await expect(assistantMessage('You can skip this one.')).toBeVisible();
 
 	await suggestionButton('Next card').click();
@@ -239,7 +253,7 @@ test('resets Card Review conversation state across setup and session changes and
 
 	await submitCommandBar(page, '/pin');
 	await expect(contextView.getByRole('heading', { name: '补偿' })).toBeVisible();
-	expect(chatInputs).toEqual(['Any cards due right now?', 'Skip this card']);
+	expect(chatRequests.map((request) => request.input)).toEqual(['Any cards due right now?', 'Skip this card']);
 });
 
 test('supports keyboard access for the end-session dialog and restores focus when dismissed', async ({ page }) => {

--- a/apps/web/tests/e2e/card-review.spec.ts
+++ b/apps/web/tests/e2e/card-review.spec.ts
@@ -104,12 +104,6 @@ async function seedReviewFixture() {
 	return { user, coreGroup };
 }
 
-async function submitCommandBar(page: import('@playwright/test').Page, input: string) {
-	const commandBar = page.getByLabel('Command bar');
-	await commandBar.fill(input);
-	await page.locator('form.command-bar').evaluate((form: HTMLFormElement) => form.requestSubmit());
-}
-
 test('configures a Card Review session from the home screen and loads the real session UI', async ({ page }) => {
 	const { user, coreGroup } = await seedReviewFixture();
 
@@ -178,82 +172,6 @@ test('advances through session actions, supports drawer navigation, and shows th
 	await expect(contextView.getByRole('link', { name: 'Review more' })).toBeVisible();
 	await expect(contextView.getByRole('link', { name: 'Go to Translation Drills →' })).toBeVisible();
 	await expect(contextView.getByRole('link', { name: 'Back to home' })).toBeVisible();
-});
-
-test('resets Card Review conversation state across setup and session changes and keeps review commands app-owned', async ({
-	page
-}) => {
-	const { user, coreGroup } = await seedReviewFixture();
-	const chatRequests: Array<{ input: string; conversationHistory?: Array<{ role: string; content: string }> }> = [];
-
-	await page.route('**/api/chat', async (route) => {
-		const payload = route.request().postDataJSON() as {
-			input?: string;
-			conversationHistory?: Array<{ role: string; content: string }>;
-		};
-		const input = typeof payload.input === 'string' ? payload.input : '';
-		chatRequests.push({
-			input,
-			conversationHistory: payload.conversationHistory
-		});
-
-		if (input === 'Any cards due right now?') {
-			await route.fulfill({
-				status: 200,
-				contentType: 'application/json',
-				body: JSON.stringify({
-					message: 'Pick a due group to start your session.',
-					suggestions: []
-				})
-			});
-			return;
-		}
-
-		await route.fulfill({
-			status: 200,
-			contentType: 'application/json',
-			body: JSON.stringify({
-				message: 'You can skip this one.',
-				suggestions: [{ type: 'next_review_card', payload: { cardId: 'card-review-due-3' } }]
-			})
-		});
-	});
-
-	await signInAs(page, user);
-	await page.goto('/zh/card-review');
-
-	const contextView = page.getByLabel('Context view', { exact: true });
-	const assistantMessage = (text: string) => page.locator('.message--assistant').filter({ hasText: text }).first();
-	const suggestionButton = (name: string) => page.locator('button.suggestion-button').filter({ hasText: name }).first();
-
-	await submitCommandBar(page, 'Any cards due right now?');
-	await expect.poll(() => chatRequests.length).toBe(1);
-	expect(chatRequests[0]).toMatchObject({
-		input: 'Any cards due right now?'
-	});
-
-	await contextView.getByRole('checkbox', { name: /Core Review/i }).check();
-	await contextView.getByRole('button', { name: 'Start Session' }).click();
-
-	await page.waitForURL(new RegExp(`/zh/card-review/session\\?.*group=${coreGroup.groupId}`));
-	await expect(contextView.getByRole('heading', { name: '逐渐' })).toBeVisible();
-	await expect(assistantMessage('Pick a due group to start your session.')).toHaveCount(0);
-
-	await submitCommandBar(page, 'Skip this card');
-	await expect.poll(() => chatRequests.length).toBe(2);
-	expect(chatRequests[1]).toMatchObject({
-		input: 'Skip this card'
-	});
-	expect(chatRequests[1]?.conversationHistory ?? []).toEqual([]);
-	await expect(assistantMessage('You can skip this one.')).toBeVisible();
-
-	await suggestionButton('Next card').click();
-	await expect(contextView.getByRole('heading', { name: '巩固' })).toBeVisible();
-	await expect(assistantMessage('You can skip this one.')).toHaveCount(0);
-
-	await submitCommandBar(page, '/pin');
-	await expect(contextView.getByRole('heading', { name: '补偿' })).toBeVisible();
-	expect(chatRequests.map((request) => request.input)).toEqual(['Any cards due right now?', 'Skip this card']);
 });
 
 test('supports keyboard access for the end-session dialog and restores focus when dismissed', async ({ page }) => {

--- a/apps/web/tests/e2e/card-review.spec.ts
+++ b/apps/web/tests/e2e/card-review.spec.ts
@@ -104,6 +104,12 @@ async function seedReviewFixture() {
 	return { user, coreGroup };
 }
 
+async function submitCommandBar(page: import('@playwright/test').Page, input: string) {
+	const commandBar = page.getByLabel('Command bar');
+	await commandBar.fill(input);
+	await commandBar.press('Enter');
+}
+
 test('configures a Card Review session from the home screen and loads the real session UI', async ({ page }) => {
 	const { user, coreGroup } = await seedReviewFixture();
 
@@ -172,4 +178,90 @@ test('advances through session actions, supports drawer navigation, and shows th
 	await expect(contextView.getByRole('link', { name: 'Review more' })).toBeVisible();
 	await expect(contextView.getByRole('link', { name: 'Go to Translation Drills →' })).toBeVisible();
 	await expect(contextView.getByRole('link', { name: 'Back to home' })).toBeVisible();
+});
+
+test('resets Card Review conversation state across setup and session changes and keeps review commands app-owned', async ({
+	page
+}) => {
+	const { user, coreGroup } = await seedReviewFixture();
+	const chatInputs: string[] = [];
+
+	await page.route('**/api/chat', async (route) => {
+		const payload = route.request().postDataJSON() as { input?: string };
+		const input = typeof payload.input === 'string' ? payload.input : '';
+		chatInputs.push(input);
+
+		if (input === 'Any cards due right now?') {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({
+					message: 'Pick a due group to start your session.',
+					suggestions: []
+				})
+			});
+			return;
+		}
+
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				message: 'You can skip this one.',
+				suggestions: [{ type: 'next_review_card', payload: { cardId: 'card-review-due-3' } }]
+			})
+		});
+	});
+
+	await signInAs(page, user);
+	await page.goto('/zh/card-review');
+
+	const contextView = page.getByLabel('Context view', { exact: true });
+	const conversationView = page.getByLabel('Conversation view', { exact: true });
+
+	await submitCommandBar(page, 'Any cards due right now?');
+	await expect(conversationView.getByText('Pick a due group to start your session.')).toBeVisible();
+
+	await contextView.getByRole('checkbox', { name: /Core Review/i }).check();
+	await contextView.getByRole('button', { name: 'Start Session' }).click();
+
+	await page.waitForURL(new RegExp(`/zh/card-review/session\\?.*group=${coreGroup.groupId}`));
+	await expect(contextView.getByRole('heading', { name: '逐渐' })).toBeVisible();
+	await expect(conversationView.getByText('Pick a due group to start your session.')).toHaveCount(0);
+
+	await submitCommandBar(page, 'Skip this card');
+	await expect(conversationView.getByText('You can skip this one.')).toBeVisible();
+
+	await conversationView.locator('button.suggestion-button').filter({ hasText: 'Next card' }).first().click();
+	await expect(contextView.getByRole('heading', { name: '巩固' })).toBeVisible();
+	await expect(conversationView.getByText('You can skip this one.')).toHaveCount(0);
+
+	await submitCommandBar(page, '/pin');
+	await expect(contextView.getByRole('heading', { name: '补偿' })).toBeVisible();
+	expect(chatInputs).toEqual(['Any cards due right now?', 'Skip this card']);
+});
+
+test('supports keyboard access for the end-session dialog and restores focus when dismissed', async ({ page }) => {
+	const { user, coreGroup } = await seedReviewFixture();
+
+	await signInAs(page, user);
+	await page.goto(`/zh/card-review/session?group=${coreGroup.groupId}`);
+
+	const contextView = page.getByLabel('Context view', { exact: true });
+	const openDialogButton = contextView.getByRole('button', { name: 'End session' });
+	await openDialogButton.click();
+
+	const dialog = page.getByRole('alertdialog', { name: 'End session?' });
+	const keepReviewingButton = dialog.getByRole('button', { name: 'Keep reviewing' });
+	const endSessionButton = dialog.getByRole('button', { name: 'End session' });
+
+	await expect(keepReviewingButton).toBeFocused();
+	await page.keyboard.press('Shift+Tab');
+	await expect(endSessionButton).toBeFocused();
+	await page.keyboard.press('Tab');
+	await expect(keepReviewingButton).toBeFocused();
+	await page.keyboard.press('Escape');
+
+	await expect(dialog).toHaveCount(0);
+	await expect(openDialogButton).toBeFocused();
 });

--- a/apps/web/tests/e2e/card-review.spec.ts
+++ b/apps/web/tests/e2e/card-review.spec.ts
@@ -107,7 +107,7 @@ async function seedReviewFixture() {
 async function submitCommandBar(page: import('@playwright/test').Page, input: string) {
 	const commandBar = page.getByLabel('Command bar');
 	await commandBar.fill(input);
-	await commandBar.press('Enter');
+	await page.getByRole('button', { name: 'Submit command' }).click();
 }
 
 test('configures a Card Review session from the home screen and loads the real session UI', async ({ page }) => {


### PR DESCRIPTION
## Summary
- expand Card Review browser coverage for setup, session, command-bar, and keyboard flows
- polish setup/session accessibility with live announcements and focus restoration
- keep the milestone green in the standard web verification suite

## Validation
- pnpm turbo test lint build --filter=web`n- pnpm test:e2e:secure *(blocked locally: Bitwarden-backed env resolution failed before the browser run started)*
- pnpm --dir apps/web test:e2e tests/e2e/card-review.spec.ts *(blocked locally: Docker-backed Postgres test DB on localhost:5433 unavailable)*

Closes #191