### PR TITLE
Build Translation Drills foundations

### DIFF
--- a/apps/web/src/lib/server/translation-drills.test.ts
+++ b/apps/web/src/lib/server/translation-drills.test.ts
@@ -1,0 +1,423 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  applyTranslationDrillAction,
+  loadTranslationDrillHomeData,
+  TranslationDrillRequestError,
+  type TranslationDrillActionDeps,
+  type TranslationDrillLoaderDeps,
+} from './translation-drills.js';
+
+describe('Translation Drills server helpers', () => {
+  const database = {} as never;
+
+  const baseDeps = {
+    getActiveUserLanguages: vi.fn(async () => [{
+      userId: 'user-1',
+      languageId: 'zh',
+      languageName: 'Chinese',
+      isActive: true,
+      cefrLevel: 'B1',
+      settings: null,
+      createdAt: null,
+    }]),
+    getGroups: vi.fn(async () => [
+      { groupId: 'group-extended', groupName: 'Extended' },
+      { groupId: 'group-core', groupName: 'Core' },
+    ]),
+    listTranslationDrillDrawPileGroups: vi.fn(async () => [
+      {
+        groupId: 'group-core',
+        groupName: 'Core',
+        drawPileName: null,
+        pileSizeLimit: 4,
+        remainingCardCount: 2,
+        activeCards: [{
+          cardId: 'card-1',
+          content: '补偿',
+          meaning: 'to compensate',
+          cardType: 'word',
+          examples: [],
+          mnemonics: [],
+          llmInstructions: null,
+          updatedAt: new Date('2026-05-01T12:00:00.000Z'),
+          sourceGroup: { groupId: 'group-core', groupName: 'Core' },
+          addedFrom: 'draw_pile:group-core',
+          addedAt: new Date('2026-05-08T12:00:00.000Z'),
+          lastUsedAt: null,
+          usageCount: 0,
+          state: 'active' as const,
+          stateUntil: null,
+          cefrOverride: null,
+          metadata: null,
+          nextDueAt: null,
+          intervalDays: null,
+          performanceScore: null,
+        }],
+        snoozedCards: [],
+      },
+    ]),
+    listTranslationDrillContextCards: vi.fn(async () => [
+      {
+        cardId: 'card-1',
+        content: '补偿',
+        meaning: 'to compensate',
+        cardType: 'word',
+        examples: [],
+        mnemonics: [],
+        llmInstructions: null,
+        updatedAt: new Date('2026-05-01T12:00:00.000Z'),
+        sourceGroup: { groupId: 'group-core', groupName: 'Core' },
+        addedFrom: 'draw_pile:group-core',
+        addedAt: new Date('2026-05-08T12:00:00.000Z'),
+        lastUsedAt: null,
+        usageCount: 0,
+        state: 'active' as const,
+        stateUntil: null,
+        cefrOverride: null,
+        metadata: null,
+        nextDueAt: null,
+        intervalDays: null,
+        performanceScore: null,
+      },
+      {
+        cardId: 'card-2',
+        content: '把握',
+        meaning: 'to grasp',
+        cardType: 'word',
+        examples: [],
+        mnemonics: [],
+        llmInstructions: 'Prefer aspect pairs',
+        updatedAt: new Date('2026-05-02T12:00:00.000Z'),
+        sourceGroup: null,
+        addedFrom: 'pinned_from_review',
+        addedAt: new Date('2026-05-09T12:00:00.000Z'),
+        lastUsedAt: new Date('2026-05-09T12:05:00.000Z'),
+        usageCount: 2,
+        state: 'active' as const,
+        stateUntil: null,
+        cefrOverride: 'B2',
+        metadata: null,
+        nextDueAt: new Date('2026-05-13T12:00:00.000Z'),
+        intervalDays: 3,
+        performanceScore: 0.8,
+      },
+    ]),
+    listTranslationDrillChallengeCards: vi.fn(async () => [
+      {
+        cardId: 'card-2',
+        content: '把握',
+        meaning: 'to grasp',
+        cardType: 'word',
+        examples: [],
+        mnemonics: [],
+        llmInstructions: 'Prefer aspect pairs',
+        updatedAt: new Date('2026-05-02T12:00:00.000Z'),
+        sourceGroup: null,
+        addedFrom: 'pinned_from_review',
+        addedAt: new Date('2026-05-09T12:00:00.000Z'),
+        lastUsedAt: new Date('2026-05-09T12:05:00.000Z'),
+        usageCount: 2,
+        state: 'active' as const,
+        stateUntil: null,
+        cefrOverride: 'B2',
+        metadata: null,
+        nextDueAt: new Date('2026-05-13T12:00:00.000Z'),
+        intervalDays: 3,
+        performanceScore: 0.8,
+      },
+      {
+        cardId: 'card-1',
+        content: '补偿',
+        meaning: 'to compensate',
+        cardType: 'word',
+        examples: [],
+        mnemonics: [],
+        llmInstructions: null,
+        updatedAt: new Date('2026-05-01T12:00:00.000Z'),
+        sourceGroup: { groupId: 'group-core', groupName: 'Core' },
+        addedFrom: 'draw_pile:group-core',
+        addedAt: new Date('2026-05-08T12:00:00.000Z'),
+        lastUsedAt: null,
+        usageCount: 0,
+        state: 'active' as const,
+        stateUntil: null,
+        cefrOverride: null,
+        metadata: null,
+        nextDueAt: null,
+        intervalDays: null,
+        performanceScore: null,
+      },
+    ]),
+  };
+  const deps = baseDeps as unknown as TranslationDrillLoaderDeps;
+
+  it('loads Translation Drills home data with grouped context and challenge inputs', async () => {
+    const result = await loadTranslationDrillHomeData('user-1', 'zh', database, deps);
+
+    expect(result.summary).toEqual({
+      configuredGroupCount: 1,
+      activeCardCount: 2,
+      snoozedCardCount: 0,
+      dismissedCardCount: 0,
+      disabledCardCount: 0,
+      remainingDrawCount: 2,
+      hasConfiguredDrawPiles: true,
+      hasVisibleContext: true,
+    });
+    expect(result.ungroupedContextCards).toEqual([
+      expect.objectContaining({
+        cardId: 'card-2',
+        addedFrom: 'pinned_from_review',
+      }),
+    ]);
+    expect(result.challenge.generationInput).toEqual({
+      activeCardCount: 2,
+      cefrLevel: 'B1',
+      cards: [
+        expect.objectContaining({ cardId: 'card-2' }),
+        expect.objectContaining({ cardId: 'card-1' }),
+      ],
+      suggestedSourceCardIds: ['card-2', 'card-1'],
+    });
+  });
+
+  it('returns 404 when the requested language is not active for the user', async () => {
+    baseDeps.getActiveUserLanguages.mockResolvedValueOnce([]);
+
+    await expect(loadTranslationDrillHomeData('user-1', 'ja', database, deps)).rejects.toMatchObject({
+      status: 404,
+    } satisfies Partial<TranslationDrillRequestError>);
+  });
+});
+
+describe('applyTranslationDrillAction', () => {
+  const database = {} as never;
+  const now = new Date('2026-05-10T12:00:00.000Z');
+
+  const actionDeps = {
+    getActiveUserLanguages: vi.fn(async () => [{
+      userId: 'user-1',
+      languageId: 'zh',
+      languageName: 'Chinese',
+      isActive: true,
+      cefrLevel: 'B1',
+      settings: null,
+      createdAt: null,
+    }]),
+    listTranslationDrillChallengeCards: vi.fn(async () => [
+      {
+        cardId: 'card-1',
+        content: '补偿',
+        meaning: 'to compensate',
+        cardType: 'word',
+        examples: [],
+        mnemonics: [],
+        llmInstructions: null,
+        updatedAt: new Date('2026-05-01T12:00:00.000Z'),
+        sourceGroup: { groupId: 'group-core', groupName: 'Core' },
+        addedFrom: 'draw_pile:group-core',
+        addedAt: new Date('2026-05-08T12:00:00.000Z'),
+        lastUsedAt: null,
+        usageCount: 0,
+        state: 'active' as const,
+        stateUntil: null,
+        cefrOverride: null,
+        metadata: null,
+        nextDueAt: null,
+        intervalDays: null,
+        performanceScore: null,
+      },
+    ]),
+    drawTranslationDrillCard: vi.fn(async () => ({
+      cardId: 'card-drawn',
+      content: '经历',
+      meaning: 'experience',
+      cardType: 'word',
+      examples: [],
+      mnemonics: [],
+      llmInstructions: null,
+      updatedAt: new Date('2026-05-03T12:00:00.000Z'),
+      sourceGroup: { groupId: 'group-core', groupName: 'Core' },
+      addedFrom: 'draw_pile:group-core',
+      addedAt: now,
+      lastUsedAt: null,
+      usageCount: 0,
+      state: 'active' as const,
+      stateUntil: null,
+      cefrOverride: null,
+      metadata: null,
+      nextDueAt: null,
+      intervalDays: null,
+      performanceScore: null,
+    })),
+    snoozeTranslationDrillCard: vi.fn(async () => ({
+      cardId: 'card-1',
+      state: 'snoozed' as const,
+      stateUntil: new Date('2026-05-11T12:00:00.000Z'),
+      nextDueAt: null,
+      intervalDays: null,
+      usageCount: 0,
+      performanceScore: null,
+    })),
+    disableTranslationDrillCard: vi.fn(async () => ({
+      cardId: 'card-1',
+      state: 'disabled' as const,
+      stateUntil: null,
+      nextDueAt: null,
+      intervalDays: null,
+      usageCount: 0,
+      performanceScore: null,
+    })),
+    dismissTranslationDrillCard: vi.fn(async () => ({
+      cardId: 'card-1',
+      state: 'dismissed' as const,
+      stateUntil: new Date('2026-05-15T12:00:00.000Z'),
+      nextDueAt: new Date('2026-05-15T12:00:00.000Z'),
+      intervalDays: 5,
+      usageCount: 1,
+      performanceScore: null,
+    })),
+    getTranslationDrillDismissSchedule: vi.fn(async () => ({
+      cardId: 'card-1',
+      recommendedDays: 5,
+      optionDays: [1, 5, 15, 30],
+    })),
+    now: vi.fn(() => now),
+  };
+  const deps = actionDeps as unknown as TranslationDrillActionDeps;
+
+  it('draws cards and returns UI-friendly card data', async () => {
+    const result = await applyTranslationDrillAction(
+      'user-1',
+      'zh',
+      {
+        action: 'draw',
+        groupId: 'group-core',
+      },
+      database,
+      deps,
+    );
+
+    expect(actionDeps.drawTranslationDrillCard).toHaveBeenCalledWith(
+      'user-1',
+      'zh',
+      'group-core',
+      { occurredAt: now },
+      database,
+    );
+    expect(result).toMatchObject({
+      action: 'draw',
+      card: {
+        cardId: 'card-drawn',
+      },
+    });
+  });
+
+  it('uses the default 24-hour snooze duration for snooze actions', async () => {
+    await applyTranslationDrillAction(
+      'user-1',
+      'zh',
+      {
+        action: 'snooze',
+        cardId: 'card-1',
+      },
+      database,
+      deps,
+    );
+
+    expect(actionDeps.snoozeTranslationDrillCard).toHaveBeenCalledWith(
+      'user-1',
+      'zh',
+      'card-1',
+      new Date('2026-05-11T12:00:00.000Z'),
+      { occurredAt: now },
+      database,
+    );
+  });
+
+  it('uses the recommended dismiss schedule when no explicit interval is provided', async () => {
+    const result = await applyTranslationDrillAction(
+      'user-1',
+      'zh',
+      {
+        action: 'dismiss',
+        cardId: 'card-1',
+      },
+      database,
+      deps,
+    );
+
+    expect(actionDeps.dismissTranslationDrillCard).toHaveBeenCalledWith(
+      'user-1',
+      'zh',
+      'card-1',
+      new Date('2026-05-15T12:00:00.000Z'),
+      { occurredAt: now },
+      database,
+    );
+    expect(result).toMatchObject({
+      action: 'dismiss',
+      intervalDays: 5,
+    });
+  });
+
+  it('validates challenge source cards against the active context', async () => {
+    const result = await applyTranslationDrillAction(
+      'user-1',
+      'zh',
+      {
+        action: 'challenge-start',
+        challenge: {
+          prompt: 'Translate: "We should make up for the time we lost."',
+          sourceCardIds: ['card-1'],
+        },
+      },
+      database,
+      deps,
+    );
+
+    expect(result).toMatchObject({
+      action: 'challenge-start',
+      conversationReset: true,
+      challenge: {
+        prompt: 'Translate: "We should make up for the time we lost."',
+        sourceCardIds: ['card-1'],
+      },
+    });
+  });
+
+  it('rejects invalid Translation Drills action payloads', async () => {
+    await expect(applyTranslationDrillAction(
+      'user-1',
+      'zh',
+      {
+        action: 'dismiss',
+        cardId: 'card-1',
+        returnInDays: 0,
+      },
+      database,
+      deps,
+    )).rejects.toMatchObject({
+      status: 400,
+    } satisfies Partial<TranslationDrillRequestError>);
+  });
+
+  it('rejects challenge cards that are not active in context', async () => {
+    await expect(applyTranslationDrillAction(
+      'user-1',
+      'zh',
+      {
+        action: 'challenge-start',
+        challenge: {
+          prompt: 'Translate this.',
+          sourceCardIds: ['card-2'],
+        },
+      },
+      database,
+      deps,
+    )).rejects.toMatchObject({
+      status: 400,
+      message: 'Challenge source cards must come from the active Translation Drills context.',
+    } satisfies Partial<TranslationDrillRequestError>);
+  });
+});

--- a/apps/web/src/lib/server/translation-drills.ts
+++ b/apps/web/src/lib/server/translation-drills.ts
@@ -1,0 +1,508 @@
+import {
+  disableTranslationDrillCard,
+  dismissTranslationDrillCard,
+  drawTranslationDrillCard,
+  getActiveUserLanguages,
+  getDb,
+  getGroups,
+  getTranslationDrillDismissSchedule,
+  listTranslationDrillChallengeCards,
+  listTranslationDrillContextCards,
+  listTranslationDrillDrawPileGroups,
+  snoozeTranslationDrillCard,
+  type TranslationDrillContextCard,
+  type TranslationDrillDrawPileGroup,
+} from '@studypuck/database';
+import { z } from 'zod';
+import { activeCardIdSchema, activeGroupIdSchema } from '$lib/schemas/cards.js';
+
+type DatabaseClient = ReturnType<typeof getDb>;
+
+export type TranslationDrillLoaderDeps = {
+  getActiveUserLanguages: typeof getActiveUserLanguages;
+  getGroups: typeof getGroups;
+  listTranslationDrillDrawPileGroups: typeof listTranslationDrillDrawPileGroups;
+  listTranslationDrillContextCards: typeof listTranslationDrillContextCards;
+  listTranslationDrillChallengeCards: typeof listTranslationDrillChallengeCards;
+};
+
+export type TranslationDrillActionDeps = Pick<TranslationDrillLoaderDeps, 'getActiveUserLanguages' | 'listTranslationDrillChallengeCards'> & {
+  drawTranslationDrillCard: typeof drawTranslationDrillCard;
+  snoozeTranslationDrillCard: typeof snoozeTranslationDrillCard;
+  disableTranslationDrillCard: typeof disableTranslationDrillCard;
+  dismissTranslationDrillCard: typeof dismissTranslationDrillCard;
+  getTranslationDrillDismissSchedule: typeof getTranslationDrillDismissSchedule;
+  now: () => Date;
+};
+
+const defaultLoaderDeps: TranslationDrillLoaderDeps = {
+  getActiveUserLanguages,
+  getGroups,
+  listTranslationDrillDrawPileGroups,
+  listTranslationDrillContextCards,
+  listTranslationDrillChallengeCards,
+};
+
+const defaultActionDeps: TranslationDrillActionDeps = {
+  getActiveUserLanguages,
+  listTranslationDrillChallengeCards,
+  drawTranslationDrillCard,
+  snoozeTranslationDrillCard,
+  disableTranslationDrillCard,
+  dismissTranslationDrillCard,
+  getTranslationDrillDismissSchedule,
+  now: () => new Date(),
+};
+
+const translationDrillDismissDaysSchema = z.coerce.number().int().min(1, 'Dismiss timing must be at least 1 day.').max(365, 'Dismiss timing must be 365 days or fewer.');
+const translationDrillChallengePayloadSchema = z.object({
+  challengeId: z.string().trim().min(1).max(120).optional(),
+  prompt: z.string().trim().min(1, 'Challenge prompt is required.').max(400),
+  sourceCardIds: z.array(activeCardIdSchema).min(1, 'Select at least one active context card for the challenge.').max(10),
+});
+const translationDrillActionSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('draw'),
+    groupId: activeGroupIdSchema,
+  }),
+  z.object({
+    action: z.literal('snooze'),
+    cardId: activeCardIdSchema,
+  }),
+  z.object({
+    action: z.literal('disable'),
+    cardId: activeCardIdSchema,
+  }),
+  z.object({
+    action: z.literal('dismiss'),
+    cardId: activeCardIdSchema,
+    returnInDays: translationDrillDismissDaysSchema.optional(),
+  }),
+  z.object({
+    action: z.literal('challenge-start'),
+    challenge: translationDrillChallengePayloadSchema,
+  }),
+  z.object({
+    action: z.literal('challenge-clear'),
+  }),
+]);
+
+const TRANSLATION_DRILL_DEFAULT_SNOOZE_DURATION_MS = 24 * 60 * 60 * 1_000;
+
+export class TranslationDrillRequestError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'TranslationDrillRequestError';
+    this.status = status;
+  }
+}
+
+export type TranslationDrillContextCardData = {
+  cardId: string;
+  content: string;
+  meaning: string | null;
+  cardType: string | null;
+  examples: string[];
+  mnemonics: string[];
+  llmInstructions: string | null;
+  updatedAtIso: string | null;
+  sourceGroup: { groupId: string; groupName: string } | null;
+  addedFrom: string | null;
+  addedAtIso: string | null;
+  lastUsedAtIso: string | null;
+  usageCount: number;
+  state: 'active' | 'snoozed' | 'dismissed' | 'disabled';
+  stateUntilIso: string | null;
+  cefrOverride: string | null;
+  nextDueAtIso: string | null;
+  intervalDays: number | null;
+  performanceScore: number | null;
+};
+
+export type TranslationDrillDrawPileGroupData = {
+  groupId: string;
+  groupName: string;
+  drawPileName: string | null;
+  pileSizeLimit: number;
+  remainingCardCount: number;
+  activeCards: TranslationDrillContextCardData[];
+  snoozedCards: TranslationDrillContextCardData[];
+};
+
+export type TranslationDrillHomeData = {
+  summary: {
+    configuredGroupCount: number;
+    activeCardCount: number;
+    snoozedCardCount: number;
+    dismissedCardCount: number;
+    disabledCardCount: number;
+    remainingDrawCount: number;
+    hasConfiguredDrawPiles: boolean;
+    hasVisibleContext: boolean;
+  };
+  availableGroups: Array<{ groupId: string; groupName: string }>;
+  configuredGroups: TranslationDrillDrawPileGroupData[];
+  ungroupedContextCards: TranslationDrillContextCardData[];
+  challenge: {
+    activeChallenge: null;
+    generationInput: {
+      activeCardCount: number;
+      cefrLevel: string | null;
+      cards: TranslationDrillContextCardData[];
+      suggestedSourceCardIds: string[];
+    };
+  };
+};
+
+export type TranslationDrillActionInput = z.infer<typeof translationDrillActionSchema>;
+
+export type TranslationDrillActionResult =
+  | {
+      action: 'draw';
+      card: TranslationDrillContextCardData;
+      message: string;
+    }
+  | {
+      action: 'snooze' | 'disable' | 'dismiss';
+      cardId: string;
+      state: 'active' | 'snoozed' | 'dismissed' | 'disabled';
+      stateUntilIso: string | null;
+      nextDueAtIso: string | null;
+      intervalDays: number | null;
+      usageCount: number;
+      performanceScore: number | null;
+      message: string;
+    }
+  | {
+      action: 'challenge-start';
+      challenge: {
+        challengeId: string;
+        prompt: string;
+        sourceCardIds: string[];
+        startedAtIso: string;
+      };
+      conversationReset: true;
+      message: string;
+    }
+  | {
+      action: 'challenge-clear';
+      challenge: null;
+      conversationReset: true;
+      message: string;
+    };
+
+type ActiveLanguageRecord = Awaited<ReturnType<typeof getActiveUserLanguages>>[number];
+
+async function assertUserHasLanguage(
+  userId: string,
+  languageId: string,
+  database: DatabaseClient,
+  deps: Pick<TranslationDrillLoaderDeps, 'getActiveUserLanguages'> = defaultLoaderDeps,
+): Promise<ActiveLanguageRecord> {
+  const activeLanguages = await deps.getActiveUserLanguages(userId, database as never);
+  const language = activeLanguages.find((entry) => entry.languageId === languageId);
+
+  if (!language) {
+    throw new TranslationDrillRequestError(404, 'That language is not available for this user.');
+  }
+
+  return language;
+}
+
+function toIsoString(date: Date | null): string | null {
+  return date ? date.toISOString() : null;
+}
+
+function mapContextCard(card: TranslationDrillContextCard): TranslationDrillContextCardData {
+  return {
+    cardId: card.cardId,
+    content: card.content,
+    meaning: card.meaning,
+    cardType: card.cardType,
+    examples: card.examples,
+    mnemonics: card.mnemonics,
+    llmInstructions: card.llmInstructions,
+    updatedAtIso: toIsoString(card.updatedAt),
+    sourceGroup: card.sourceGroup,
+    addedFrom: card.addedFrom,
+    addedAtIso: toIsoString(card.addedAt),
+    lastUsedAtIso: toIsoString(card.lastUsedAt),
+    usageCount: card.usageCount,
+    state: card.state,
+    stateUntilIso: toIsoString(card.stateUntil),
+    cefrOverride: card.cefrOverride,
+    nextDueAtIso: toIsoString(card.nextDueAt),
+    intervalDays: card.intervalDays,
+    performanceScore: card.performanceScore,
+  };
+}
+
+function mapDrawPileGroup(group: TranslationDrillDrawPileGroup): TranslationDrillDrawPileGroupData {
+  return {
+    groupId: group.groupId,
+    groupName: group.groupName,
+    drawPileName: group.drawPileName,
+    pileSizeLimit: group.pileSizeLimit,
+    remainingCardCount: group.remainingCardCount,
+    activeCards: group.activeCards.map((card) => mapContextCard(card)),
+    snoozedCards: group.snoozedCards.map((card) => mapContextCard(card)),
+  };
+}
+
+function buildActionMessage(action: TranslationDrillActionInput['action']): string {
+  switch (action) {
+    case 'draw':
+      return 'Card drawn into Translation Drills.';
+    case 'snooze':
+      return 'Card snoozed.';
+    case 'disable':
+      return 'Card disabled.';
+    case 'dismiss':
+      return 'Card dismissed from the active context.';
+    case 'challenge-start':
+      return 'New challenge ready.';
+    case 'challenge-clear':
+      return 'Challenge cleared.';
+  }
+}
+
+function normalizeMutationError(error: unknown): never {
+  if (error instanceof TranslationDrillRequestError) {
+    throw error;
+  }
+
+  if (error instanceof Error) {
+    if (
+      error.message === 'That card is not in the Translation Drills context.' ||
+      error.message === 'That card is not active in Translation Drills.' ||
+      error.message === 'That card cannot be dismissed from Translation Drills right now.' ||
+      error.message === 'That group is not configured as a Translation Drills draw pile.' ||
+      error.message === 'There are no cards available to draw from that pile right now.'
+    ) {
+      throw new TranslationDrillRequestError(404, error.message);
+    }
+
+    if (
+      error.message === 'That draw pile is already at its active limit.' ||
+      error.message === 'That card is not available for Translation Drills.'
+    ) {
+      throw new TranslationDrillRequestError(400, error.message);
+    }
+  }
+
+  throw error;
+}
+
+async function validateChallengeSourceCards(
+  userId: string,
+  languageId: string,
+  sourceCardIds: string[],
+  database: DatabaseClient,
+  deps: Pick<TranslationDrillActionDeps, 'listTranslationDrillChallengeCards'> = defaultActionDeps,
+): Promise<void> {
+  const activeCards = await deps.listTranslationDrillChallengeCards(userId, languageId, database as never);
+  const activeCardIds = new Set(activeCards.map((card) => card.cardId));
+
+  for (const cardId of sourceCardIds) {
+    if (!activeCardIds.has(cardId)) {
+      throw new TranslationDrillRequestError(400, 'Challenge source cards must come from the active Translation Drills context.');
+    }
+  }
+}
+
+export async function loadTranslationDrillHomeData(
+  userId: string,
+  languageId: string,
+  database: DatabaseClient,
+  deps: TranslationDrillLoaderDeps = defaultLoaderDeps,
+): Promise<TranslationDrillHomeData> {
+  const language = await assertUserHasLanguage(userId, languageId, database, deps);
+
+  const [availableGroups, configuredGroups, contextCards, challengeCards] = await Promise.all([
+    deps.getGroups(userId, languageId, database as never),
+    deps.listTranslationDrillDrawPileGroups(userId, languageId, {}, database as never),
+    deps.listTranslationDrillContextCards(userId, languageId, database as never),
+    deps.listTranslationDrillChallengeCards(userId, languageId, database as never),
+  ]);
+
+  const configuredGroupIds = new Set(configuredGroups.map((group) => group.groupId));
+  const ungroupedContextCards = contextCards
+    .filter((card) => card.state === 'active' || card.state === 'snoozed')
+    .filter((card) => !card.sourceGroup || !configuredGroupIds.has(card.sourceGroup.groupId));
+
+  return {
+    summary: {
+      configuredGroupCount: configuredGroups.length,
+      activeCardCount: contextCards.filter((card) => card.state === 'active').length,
+      snoozedCardCount: contextCards.filter((card) => card.state === 'snoozed').length,
+      dismissedCardCount: contextCards.filter((card) => card.state === 'dismissed').length,
+      disabledCardCount: contextCards.filter((card) => card.state === 'disabled').length,
+      remainingDrawCount: configuredGroups.reduce((total, group) => total + group.remainingCardCount, 0),
+      hasConfiguredDrawPiles: configuredGroups.length > 0,
+      hasVisibleContext: contextCards.some((card) => card.state === 'active' || card.state === 'snoozed'),
+    },
+    availableGroups: [...availableGroups]
+      .map((group) => ({ groupId: group.groupId, groupName: group.groupName }))
+      .sort((left, right) => left.groupName.localeCompare(right.groupName)),
+    configuredGroups: configuredGroups.map((group) => mapDrawPileGroup(group)),
+    ungroupedContextCards: ungroupedContextCards.map((card) => mapContextCard(card)),
+    challenge: {
+      activeChallenge: null,
+      generationInput: {
+        activeCardCount: challengeCards.length,
+        cefrLevel: language.cefrLevel ?? null,
+        cards: challengeCards.map((card) => mapContextCard(card)),
+        suggestedSourceCardIds: challengeCards.slice(0, 2).map((card) => card.cardId),
+      },
+    },
+  };
+}
+
+export async function applyTranslationDrillAction(
+  userId: string,
+  languageId: string,
+  input: unknown,
+  database: DatabaseClient,
+  deps: TranslationDrillActionDeps = defaultActionDeps,
+): Promise<TranslationDrillActionResult> {
+  await assertUserHasLanguage(userId, languageId, database, deps);
+
+  const parsed = translationDrillActionSchema.safeParse(input);
+
+  if (!parsed.success) {
+    throw new TranslationDrillRequestError(400, parsed.error.issues[0]?.message ?? 'Translation Drills action is invalid.');
+  }
+
+  const payload = parsed.data;
+
+  try {
+    switch (payload.action) {
+      case 'draw': {
+        const drawnCard = await deps.drawTranslationDrillCard(
+          userId,
+          languageId,
+          payload.groupId,
+          { occurredAt: deps.now() },
+          database as never,
+        );
+
+        return {
+          action: 'draw',
+          card: mapContextCard(drawnCard),
+          message: buildActionMessage('draw'),
+        };
+      }
+
+      case 'snooze': {
+        const occurredAt = deps.now();
+        const result = await deps.snoozeTranslationDrillCard(
+          userId,
+          languageId,
+          payload.cardId,
+          new Date(occurredAt.getTime() + TRANSLATION_DRILL_DEFAULT_SNOOZE_DURATION_MS),
+          { occurredAt },
+          database as never,
+        );
+
+        return {
+          action: 'snooze',
+          cardId: result.cardId,
+          state: result.state,
+          stateUntilIso: toIsoString(result.stateUntil),
+          nextDueAtIso: toIsoString(result.nextDueAt),
+          intervalDays: result.intervalDays,
+          usageCount: result.usageCount,
+          performanceScore: result.performanceScore,
+          message: buildActionMessage('snooze'),
+        };
+      }
+
+      case 'disable': {
+        const result = await deps.disableTranslationDrillCard(
+          userId,
+          languageId,
+          payload.cardId,
+          database as never,
+        );
+
+        return {
+          action: 'disable',
+          cardId: result.cardId,
+          state: result.state,
+          stateUntilIso: toIsoString(result.stateUntil),
+          nextDueAtIso: toIsoString(result.nextDueAt),
+          intervalDays: result.intervalDays,
+          usageCount: result.usageCount,
+          performanceScore: result.performanceScore,
+          message: buildActionMessage('disable'),
+        };
+      }
+
+      case 'dismiss': {
+        const schedule = await deps.getTranslationDrillDismissSchedule(
+          userId,
+          languageId,
+          payload.cardId,
+          database as never,
+        );
+        const occurredAt = deps.now();
+        const returnInDays = payload.returnInDays ?? schedule.recommendedDays;
+        const result = await deps.dismissTranslationDrillCard(
+          userId,
+          languageId,
+          payload.cardId,
+          new Date(occurredAt.getTime() + (returnInDays * 86_400_000)),
+          { occurredAt },
+          database as never,
+        );
+
+        return {
+          action: 'dismiss',
+          cardId: result.cardId,
+          state: result.state,
+          stateUntilIso: toIsoString(result.stateUntil),
+          nextDueAtIso: toIsoString(result.nextDueAt),
+          intervalDays: result.intervalDays,
+          usageCount: result.usageCount,
+          performanceScore: result.performanceScore,
+          message: buildActionMessage('dismiss'),
+        };
+      }
+
+      case 'challenge-start': {
+        const challengeId = payload.challenge.challengeId?.trim() || `translation-drill-${globalThis.crypto?.randomUUID?.() ?? Date.now().toString(36)}`;
+        await validateChallengeSourceCards(
+          userId,
+          languageId,
+          payload.challenge.sourceCardIds,
+          database,
+          deps,
+        );
+
+        return {
+          action: 'challenge-start',
+          challenge: {
+            challengeId,
+            prompt: payload.challenge.prompt,
+            sourceCardIds: payload.challenge.sourceCardIds,
+            startedAtIso: deps.now().toISOString(),
+          },
+          conversationReset: true,
+          message: buildActionMessage('challenge-start'),
+        };
+      }
+
+      case 'challenge-clear':
+        return {
+          action: 'challenge-clear',
+          challenge: null,
+          conversationReset: true,
+          message: buildActionMessage('challenge-clear'),
+        };
+    }
+  } catch (error) {
+    normalizeMutationError(error);
+  }
+}

--- a/apps/web/src/routes/[lang]/translation-drills/+page.server.ts
+++ b/apps/web/src/routes/[lang]/translation-drills/+page.server.ts
@@ -1,0 +1,48 @@
+import { error, redirect } from '@sveltejs/kit';
+import { getDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import { loadTranslationDrillHomeData, TranslationDrillRequestError } from '$lib/server/translation-drills.js';
+import type { PageServerLoad } from './$types.js';
+
+export const load: PageServerLoad = async (event) => {
+  const { session } = await event.parent();
+  const languageCode = event.params.lang;
+
+  if (!languageCode) {
+    throw redirect(303, '/');
+  }
+
+  if (!session?.user?.id) {
+    return {
+      home: null,
+      loadError: 'You must be signed in to view Translation Drills.',
+    };
+  }
+
+  if (!env.DATABASE_URL) {
+    return {
+      home: null,
+      loadError: 'Translation Drills is not configured right now.',
+    };
+  }
+
+  const database = getDb(env.DATABASE_URL);
+
+  try {
+    return {
+      home: await loadTranslationDrillHomeData(session.user.id, languageCode, database),
+      loadError: null,
+    };
+  } catch (requestError) {
+    if (requestError instanceof TranslationDrillRequestError) {
+      throw error(requestError.status, requestError.message);
+    }
+
+    console.error('Failed to load Translation Drills home:', requestError);
+
+    return {
+      home: null,
+      loadError: 'The Translation Drills home could not be loaded right now.',
+    };
+  }
+};

--- a/apps/web/src/routes/[lang]/translation-drills/actions/+server.ts
+++ b/apps/web/src/routes/[lang]/translation-drills/actions/+server.ts
@@ -1,0 +1,42 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { withTransactionDb } from '@studypuck/database';
+import { env } from '$env/dynamic/private';
+import { applyTranslationDrillAction, TranslationDrillRequestError } from '$lib/server/translation-drills.js';
+
+export const POST: RequestHandler = async (event) => {
+  const session = await event.locals.auth();
+  const userId = session?.user?.id;
+  const languageId = event.params.lang;
+
+  if (!userId || !languageId) {
+    return json({ message: 'You must be signed in to use Translation Drills.' }, { status: 401 });
+  }
+
+  if (!env.DATABASE_URL) {
+    return json({ message: 'Translation Drills is not configured right now.' }, { status: 500 });
+  }
+
+  let body: unknown;
+
+  try {
+    body = await event.request.json();
+  } catch {
+    return json({ message: 'The Translation Drills action payload must be valid JSON.' }, { status: 400 });
+  }
+
+  try {
+    const result = await withTransactionDb(
+      env.DATABASE_URL,
+      (database) => applyTranslationDrillAction(userId, languageId, body, database as never),
+    );
+
+    return json(result);
+  } catch (requestError) {
+    if (requestError instanceof TranslationDrillRequestError) {
+      return json({ message: requestError.message }, { status: requestError.status });
+    }
+
+    console.error('Failed to apply Translation Drills action:', requestError);
+    return json({ message: 'The Translation Drills action could not be completed right now.' }, { status: 500 });
+  }
+};

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -45,10 +45,11 @@
     "./relations": "./src/relations.ts",
     "./validation": "./src/validation.ts",
     "./types": "./src/types.ts",
-    "./users": "./src/users.ts",
+     "./users": "./src/users.ts",
 		"./cards": "./src/cards.ts",
 		"./card-entry": "./src/card-entry.ts",
 		"./card-review": "./src/card-review.ts",
+		"./translation-drills": "./src/translation-drills.ts",
 		"./test-utils": "./src/test-utils.ts"
 	}
 }

--- a/packages/database/src/card-review.ts
+++ b/packages/database/src/card-review.ts
@@ -2,6 +2,7 @@ import { and, asc, desc, eq, inArray, sql } from 'drizzle-orm';
 import type { PgDatabase } from 'drizzle-orm/pg-core';
 import { db, type TransactionCapableDatabaseConnection } from './index.js';
 import { cards, cardGroups, groups, cardReviewDailyStats, cardReviewEvents, cardReviewSrs } from './schema.js';
+import { pinCardToTranslationDrillsContext } from './translation-drills.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyDb = PgDatabase<any, any, any>;
@@ -890,6 +891,7 @@ export async function recordCardReviewPinToDrills(
     await upsertDailyStats(userId, languageId, occurredAt, {
       cardsPinnedToDrills: 1,
     }, tx);
+    await pinCardToTranslationDrillsContext(userId, languageId, cardId, { occurredAt }, tx);
 
     return {
       eventId,

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -142,6 +142,7 @@ export * from './users.js';
 export * from './cards.js';
 export * from './card-entry.js';
 export * from './card-review.js';
+export * from './translation-drills.js';
 
 // Re-export relations and types
 // Note: validation schemas are NOT re-exported here to avoid pulling drizzle-zod

--- a/packages/database/src/tests/card-review.test.ts
+++ b/packages/database/src/tests/card-review.test.ts
@@ -2,7 +2,17 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import postgres from 'postgres';
 import { eq } from 'drizzle-orm';
 import { setupTestDatabase, cleanupTestDatabase, resetTestTables, type TestDb } from '../test-utils.js';
-import { cardGroups, cards, cardReviewDailyStats, cardReviewEvents, cardReviewSrs, groups, studyLanguages, users } from '../schema.js';
+import {
+  cardGroups,
+  cards,
+  cardReviewDailyStats,
+  cardReviewEvents,
+  cardReviewSrs,
+  groups,
+  studyLanguages,
+  translationDrillContext,
+  users,
+} from '../schema.js';
 import {
   disableCardForReview,
   getCardReviewHomeStats,
@@ -374,6 +384,10 @@ describe('Card Review database operations', () => {
       .select()
       .from(cardReviewDailyStats)
       .where(eq(cardReviewDailyStats.date, '2026-05-10'));
+    const [translationContext] = await db
+      .select()
+      .from(translationDrillContext)
+      .where(eq(translationDrillContext.cardId, 'card-actions'));
 
     expect(storedSrs.state).toBe('disabled');
     expect(storedEvents.map((event) => event.eventType).sort()).toEqual(['disabled', 'pinned_to_drills', 'snoozed']);
@@ -381,6 +395,10 @@ describe('Card Review database operations', () => {
       cardsSnoozed: 1,
       cardsDisabled: 1,
       cardsPinnedToDrills: 1,
+    });
+    expect(translationContext).toMatchObject({
+      state: 'active',
+      addedFrom: 'pinned_from_review',
     });
   });
 });

--- a/packages/database/src/tests/translation-drills.test.ts
+++ b/packages/database/src/tests/translation-drills.test.ts
@@ -253,7 +253,7 @@ describe('Translation Drills database operations', () => {
     expect(drawPiles[0]?.activeCards.map((card) => card.cardId)).toEqual(['card-active']);
     expect(drawPiles[0]?.snoozedCards.map((card) => card.cardId)).toEqual(['card-snoozed']);
     expect(contextCards.find((card) => card.cardId === 'card-pinned')?.sourceGroup).toBeNull();
-    expect(challengeCards.map((card) => card.cardId)).toEqual(['card-active', 'card-pinned']);
+    expect(challengeCards.map((card) => card.cardId)).toEqual(['card-pinned', 'card-active']);
   });
 
   it('draws the next eligible card from a configured pile and can pin cards from Card Review', async () => {
@@ -280,7 +280,7 @@ describe('Translation Drills database operations', () => {
       .from(translationDrillDailyStats)
       .where(eq(translationDrillDailyStats.date, '2026-05-10'));
 
-    expect(drawn.cardId).toBe('card-due');
+    expect(drawn.cardId).toBe('card-new');
     expect(drawn.sourceGroup).toEqual({ groupId: 'group-core', groupName: 'Core' });
     expect(allContextCards.find((card) => card.cardId === 'card-new')?.addedFrom).toBe('pinned_from_review');
     expect(dailyStats?.cardsDrawn).toBe(1);

--- a/packages/database/src/tests/translation-drills.test.ts
+++ b/packages/database/src/tests/translation-drills.test.ts
@@ -1,0 +1,354 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import postgres from 'postgres';
+import { eq } from 'drizzle-orm';
+import { setupTestDatabase, cleanupTestDatabase, resetTestTables, type TestDb } from '../test-utils.js';
+import {
+  cardGroups,
+  cards,
+  groups,
+  studyLanguages,
+  translationDrillContext,
+  translationDrillDailyStats,
+  translationDrillSrs,
+  users,
+} from '../schema.js';
+import {
+  disableTranslationDrillCard,
+  dismissTranslationDrillCard,
+  drawTranslationDrillCard,
+  getTranslationDrillDismissSchedule,
+  listTranslationDrillChallengeCards,
+  listTranslationDrillContextCards,
+  listTranslationDrillDrawPileGroups,
+  pinCardToTranslationDrillsContext,
+  snoozeTranslationDrillCard,
+  upsertTranslationDrillDrawPile,
+} from '../translation-drills.js';
+
+const TEST_USER = { userId: 'auth0|translation-drills-user', email: 'translation-drills@example.com' };
+const TEST_LANG = { userId: TEST_USER.userId, languageId: 'zh', languageName: 'Chinese', cefrLevel: 'B1' };
+const NOW = new Date('2026-05-10T12:00:00.000Z');
+
+describe('Translation Drills database operations', () => {
+  let db: TestDb;
+  let sql: ReturnType<typeof postgres>;
+
+  beforeAll(async () => {
+    ({ db, sql } = await setupTestDatabase());
+  });
+
+  afterAll(async () => {
+    if (sql) {
+      await cleanupTestDatabase(sql);
+    }
+  });
+
+  beforeEach(async () => {
+    await resetTestTables(db);
+    await db.insert(users).values(TEST_USER);
+    await db.insert(studyLanguages).values(TEST_LANG);
+  });
+
+  async function seedLibrary() {
+    await db.insert(groups).values([
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        groupId: 'group-core',
+        groupName: 'Core',
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        groupId: 'group-extended',
+        groupName: 'Extended',
+      },
+    ]);
+
+    await db.insert(cards).values([
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-due',
+        content: '补偿',
+        status: 'active',
+        meaning: 'to compensate',
+        llmInstructions: 'Prefer sentence-final aspect markers',
+        updatedAt: new Date('2026-05-01T12:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-new',
+        content: '巩固',
+        status: 'active',
+        meaning: 'to consolidate',
+        updatedAt: new Date('2026-05-05T12:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-active',
+        content: '经历',
+        status: 'active',
+        meaning: 'experience',
+        updatedAt: new Date('2026-05-03T12:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-snoozed',
+        content: '感觉',
+        status: 'active',
+        meaning: 'feeling',
+        updatedAt: new Date('2026-05-04T12:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-disabled',
+        content: '停用',
+        status: 'active',
+        meaning: 'disable',
+        updatedAt: new Date('2026-05-02T12:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-pinned',
+        content: '把握',
+        status: 'active',
+        meaning: 'grasp',
+        updatedAt: new Date('2026-05-06T12:00:00.000Z'),
+      },
+    ]);
+
+    await db.insert(cardGroups).values([
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-due',
+        groupId: 'group-core',
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-new',
+        groupId: 'group-core',
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-active',
+        groupId: 'group-core',
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-snoozed',
+        groupId: 'group-core',
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-disabled',
+        groupId: 'group-core',
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-pinned',
+        groupId: 'group-extended',
+      },
+    ]);
+
+    await upsertTranslationDrillDrawPile(TEST_USER.userId, TEST_LANG.languageId, 'group-core', { pileSizeLimit: 4 }, db);
+    await upsertTranslationDrillDrawPile(TEST_USER.userId, TEST_LANG.languageId, 'group-extended', { pileSizeLimit: 2 }, db);
+
+    await db.insert(translationDrillContext).values([
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-active',
+        state: 'active',
+        addedFrom: 'draw_pile:group-core',
+        addedAt: new Date('2026-05-08T12:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-snoozed',
+        state: 'snoozed',
+        stateUntil: new Date('2026-05-11T12:00:00.000Z'),
+        addedFrom: 'draw_pile:group-core',
+        addedAt: new Date('2026-05-08T12:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-disabled',
+        state: 'disabled',
+        addedFrom: 'draw_pile:group-core',
+        addedAt: new Date('2026-05-08T12:00:00.000Z'),
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-pinned',
+        state: 'active',
+        addedFrom: 'pinned_from_review',
+        addedAt: new Date('2026-05-09T12:00:00.000Z'),
+      },
+    ]);
+
+    await db.insert(translationDrillSrs).values([
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-due',
+        nextDue: Math.floor(new Date('2026-05-09T12:00:00.000Z').getTime() / 1_000),
+        intervalDays: 2,
+        usageCount: 2,
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-active',
+        nextDue: Math.floor(new Date('2026-05-12T12:00:00.000Z').getTime() / 1_000),
+        intervalDays: 5,
+        usageCount: 1,
+      },
+      {
+        userId: TEST_USER.userId,
+        languageId: TEST_LANG.languageId,
+        cardId: 'card-pinned',
+        nextDue: Math.floor(new Date('2026-05-13T12:00:00.000Z').getTime() / 1_000),
+        intervalDays: 3,
+        usageCount: 4,
+      },
+    ]);
+  }
+
+  it('loads configured draw piles, grouped context cards, and active challenge inputs', async () => {
+    await seedLibrary();
+
+    const [drawPiles, contextCards, challengeCards] = await Promise.all([
+      listTranslationDrillDrawPileGroups(TEST_USER.userId, TEST_LANG.languageId, { now: NOW }, db),
+      listTranslationDrillContextCards(TEST_USER.userId, TEST_LANG.languageId, db),
+      listTranslationDrillChallengeCards(TEST_USER.userId, TEST_LANG.languageId, db),
+    ]);
+
+    expect(drawPiles).toEqual([
+      expect.objectContaining({
+        groupId: 'group-core',
+        pileSizeLimit: 4,
+        remainingCardCount: 2,
+      }),
+      expect.objectContaining({
+        groupId: 'group-extended',
+        pileSizeLimit: 2,
+        remainingCardCount: 0,
+      }),
+    ]);
+    expect(drawPiles[0]?.activeCards.map((card) => card.cardId)).toEqual(['card-active']);
+    expect(drawPiles[0]?.snoozedCards.map((card) => card.cardId)).toEqual(['card-snoozed']);
+    expect(contextCards.find((card) => card.cardId === 'card-pinned')?.sourceGroup).toBeNull();
+    expect(challengeCards.map((card) => card.cardId)).toEqual(['card-active', 'card-pinned']);
+  });
+
+  it('draws the next eligible card from a configured pile and can pin cards from Card Review', async () => {
+    await seedLibrary();
+
+    const drawn = await drawTranslationDrillCard(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      'group-core',
+      { occurredAt: NOW },
+      db,
+    );
+    await pinCardToTranslationDrillsContext(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      'card-new',
+      { occurredAt: NOW },
+      db,
+    );
+
+    const allContextCards = await listTranslationDrillContextCards(TEST_USER.userId, TEST_LANG.languageId, db);
+    const [dailyStats] = await db
+      .select()
+      .from(translationDrillDailyStats)
+      .where(eq(translationDrillDailyStats.date, '2026-05-10'));
+
+    expect(drawn.cardId).toBe('card-due');
+    expect(drawn.sourceGroup).toEqual({ groupId: 'group-core', groupName: 'Core' });
+    expect(allContextCards.find((card) => card.cardId === 'card-new')?.addedFrom).toBe('pinned_from_review');
+    expect(dailyStats?.cardsDrawn).toBe(1);
+  });
+
+  it('updates snooze, dismiss, and disable state without touching core card status', async () => {
+    await seedLibrary();
+
+    await snoozeTranslationDrillCard(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      'card-active',
+      new Date('2026-05-11T12:00:00.000Z'),
+      { occurredAt: NOW },
+      db,
+    );
+
+    const dismissSchedule = await getTranslationDrillDismissSchedule(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      'card-snoozed',
+      db,
+    );
+
+    const dismissed = await dismissTranslationDrillCard(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      'card-snoozed',
+      new Date(`2026-05-${String(10 + dismissSchedule.recommendedDays).padStart(2, '0')}T12:00:00.000Z`),
+      { occurredAt: NOW },
+      db,
+    );
+    const disabled = await disableTranslationDrillCard(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      'card-active',
+      db,
+    );
+
+    const [storedSrs] = await db
+      .select()
+      .from(translationDrillSrs)
+      .where(eq(translationDrillSrs.cardId, 'card-snoozed'));
+    const [storedContext] = await db
+      .select()
+      .from(translationDrillContext)
+      .where(eq(translationDrillContext.cardId, 'card-active'));
+    const [storedCard] = await db
+      .select()
+      .from(cards)
+      .where(eq(cards.cardId, 'card-active'));
+    const [dailyStats] = await db
+      .select()
+      .from(translationDrillDailyStats)
+      .where(eq(translationDrillDailyStats.date, '2026-05-10'));
+
+    expect(dismissSchedule.optionDays).toEqual([1, 5, 15, 30]);
+    expect(dismissed.state).toBe('dismissed');
+    expect(disabled.state).toBe('disabled');
+    expect(storedSrs).toMatchObject({
+      intervalDays: 5,
+      usageCount: 1,
+    });
+    expect(storedContext.state).toBe('disabled');
+    expect(storedCard.status).toBe('active');
+    expect(dailyStats).toMatchObject({
+      cardsSnoozed: 1,
+      cardsDismissed: 1,
+    });
+  });
+});

--- a/packages/database/src/translation-drills.ts
+++ b/packages/database/src/translation-drills.ts
@@ -300,7 +300,7 @@ async function loadContextRows(
       ...(normalizedCardIds.length > 0 ? [inArray(translationDrillContext.cardId, normalizedCardIds)] : []),
     ))
     .orderBy(
-      asc(sql`${translationDrillContext.lastUsed} ASC NULLS FIRST`),
+      sql`${translationDrillContext.lastUsed} ASC NULLS FIRST`,
       asc(translationDrillContext.usageCount),
       desc(cards.updatedAt),
     );

--- a/packages/database/src/translation-drills.ts
+++ b/packages/database/src/translation-drills.ts
@@ -1,0 +1,901 @@
+import { and, asc, desc, eq, inArray, sql } from 'drizzle-orm';
+import type { PgDatabase } from 'drizzle-orm/pg-core';
+import { db, type TransactionCapableDatabaseConnection } from './index.js';
+import {
+  cards,
+  cardGroups,
+  groups,
+  translationDrillContext,
+  translationDrillDailyStats,
+  translationDrillDrawPiles,
+  translationDrillSrs,
+} from './schema.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyDb = PgDatabase<any, any, any>;
+
+export type TranslationDrillContextState = 'active' | 'snoozed' | 'dismissed' | 'disabled';
+
+type TranslationDrillContextRow = {
+  cardId: string;
+  content: string;
+  meaning: string | null;
+  cardType: string | null;
+  examples: unknown;
+  mnemonics: unknown;
+  llmInstructions: string | null;
+  updatedAt: Date | null;
+  addedFrom: string | null;
+  addedAt: Date | null;
+  lastUsedAt: Date | null;
+  contextUsageCount: number | null;
+  state: string | null;
+  stateUntil: Date | null;
+  cefrOverride: string | null;
+  metadata: unknown;
+  nextDue: number | null;
+  intervalDays: number | null;
+  srsUsageCount: number | null;
+  performanceScore: number | null;
+  srsLastUsed: number | null;
+};
+
+type TranslationDrillCandidateRow = {
+  cardId: string;
+  updatedAt: Date | null;
+  state: string | null;
+  nextDue: number | null;
+};
+
+export type TranslationDrillContextCard = {
+  cardId: string;
+  content: string;
+  meaning: string | null;
+  cardType: string | null;
+  examples: string[];
+  mnemonics: string[];
+  llmInstructions: string | null;
+  updatedAt: Date | null;
+  sourceGroup: { groupId: string; groupName: string } | null;
+  addedFrom: string | null;
+  addedAt: Date | null;
+  lastUsedAt: Date | null;
+  usageCount: number;
+  state: TranslationDrillContextState;
+  stateUntil: Date | null;
+  cefrOverride: string | null;
+  metadata: unknown;
+  nextDueAt: Date | null;
+  intervalDays: number | null;
+  performanceScore: number | null;
+};
+
+export type TranslationDrillDrawPileGroup = {
+  groupId: string;
+  groupName: string;
+  drawPileName: string | null;
+  pileSizeLimit: number;
+  remainingCardCount: number;
+  activeCards: TranslationDrillContextCard[];
+  snoozedCards: TranslationDrillContextCard[];
+};
+
+export type TranslationDrillDismissSchedule = {
+  cardId: string;
+  recommendedDays: number;
+  optionDays: number[];
+};
+
+export type TranslationDrillMutationResult = {
+  cardId: string;
+  state: TranslationDrillContextState;
+  stateUntil: Date | null;
+  nextDueAt: Date | null;
+  intervalDays: number | null;
+  usageCount: number;
+  performanceScore: number | null;
+};
+
+type TranslationDrillDailyStatIncrements = {
+  cardsDrawn?: number;
+  cardsSnoozed?: number;
+  cardsDismissed?: number;
+};
+
+function getConn(database?: AnyDb) {
+  return database ?? (db as AnyDb);
+}
+
+function normalizeGroupIds(groupIds?: string[] | null): string[] {
+  return [...new Set((groupIds ?? []).map((groupId) => groupId.trim()).filter(Boolean))];
+}
+
+function normalizeStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+}
+
+function toUnixSeconds(date: Date): number {
+  return Math.floor(date.getTime() / 1_000);
+}
+
+function fromUnixSeconds(value: number | null | undefined): Date | null {
+  return typeof value === 'number' ? new Date(value * 1_000) : null;
+}
+
+function toStatsDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function getContextState(value: string | null | undefined): TranslationDrillContextState {
+  if (value === 'snoozed' || value === 'dismissed' || value === 'disabled') {
+    return value;
+  }
+
+  return 'active';
+}
+
+function parseDrawPileSourceGroupId(addedFrom: string | null | undefined): string | null {
+  if (!addedFrom?.startsWith('draw_pile:')) {
+    return null;
+  }
+
+  const groupId = addedFrom.slice('draw_pile:'.length).trim();
+  return groupId.length > 0 ? groupId : null;
+}
+
+async function runInTransaction<T>(database: AnyDb | undefined, callback: (tx: AnyDb) => Promise<T>): Promise<T> {
+  const connection = getConn(database);
+
+  if ('transaction' in connection && typeof connection.transaction === 'function') {
+    return await (connection as TransactionCapableDatabaseConnection).transaction(async (tx: AnyDb) => callback(tx));
+  }
+
+  return await callback(connection);
+}
+
+async function upsertDailyStats(
+  userId: string,
+  languageId: string,
+  occurredAt: Date,
+  increments: TranslationDrillDailyStatIncrements,
+  database?: AnyDb,
+): Promise<void> {
+  const statsDate = toStatsDate(occurredAt);
+
+  await getConn(database)
+    .insert(translationDrillDailyStats)
+    .values({
+      userId,
+      languageId,
+      date: statsDate,
+      cardsDrawn: increments.cardsDrawn ?? 0,
+      cardsSnoozed: increments.cardsSnoozed ?? 0,
+      cardsDismissed: increments.cardsDismissed ?? 0,
+    })
+    .onConflictDoUpdate({
+      target: [
+        translationDrillDailyStats.userId,
+        translationDrillDailyStats.languageId,
+        translationDrillDailyStats.date,
+      ],
+      set: {
+        cardsDrawn: sql`${translationDrillDailyStats.cardsDrawn} + ${increments.cardsDrawn ?? 0}`,
+        cardsSnoozed: sql`${translationDrillDailyStats.cardsSnoozed} + ${increments.cardsSnoozed ?? 0}`,
+        cardsDismissed: sql`${translationDrillDailyStats.cardsDismissed} + ${increments.cardsDismissed ?? 0}`,
+      },
+    });
+}
+
+async function getConfiguredDrawPile(
+  userId: string,
+  languageId: string,
+  groupId: string,
+  database?: AnyDb,
+) {
+  const [row] = await getConn(database)
+    .select({
+      groupId: translationDrillDrawPiles.groupId,
+      enabled: translationDrillDrawPiles.enabled,
+      drawPileName: translationDrillDrawPiles.drawPileName,
+      pileSizeLimit: translationDrillDrawPiles.pileSizeLimit,
+      groupName: groups.groupName,
+    })
+    .from(translationDrillDrawPiles)
+    .innerJoin(groups, and(
+      eq(groups.userId, translationDrillDrawPiles.userId),
+      eq(groups.languageId, translationDrillDrawPiles.languageId),
+      eq(groups.groupId, translationDrillDrawPiles.groupId),
+    ))
+    .where(and(
+      eq(translationDrillDrawPiles.userId, userId),
+      eq(translationDrillDrawPiles.languageId, languageId),
+      eq(translationDrillDrawPiles.groupId, groupId),
+      eq(translationDrillDrawPiles.enabled, true),
+    ));
+
+  return row ?? null;
+}
+
+async function loadDrawPileGroupRows(
+  userId: string,
+  languageId: string,
+  database?: AnyDb,
+) {
+  return await getConn(database)
+    .select({
+      groupId: translationDrillDrawPiles.groupId,
+      groupName: groups.groupName,
+      drawPileName: translationDrillDrawPiles.drawPileName,
+      pileSizeLimit: translationDrillDrawPiles.pileSizeLimit,
+    })
+    .from(translationDrillDrawPiles)
+    .innerJoin(groups, and(
+      eq(groups.userId, translationDrillDrawPiles.userId),
+      eq(groups.languageId, translationDrillDrawPiles.languageId),
+      eq(groups.groupId, translationDrillDrawPiles.groupId),
+    ))
+    .where(and(
+      eq(translationDrillDrawPiles.userId, userId),
+      eq(translationDrillDrawPiles.languageId, languageId),
+      eq(translationDrillDrawPiles.enabled, true),
+    ))
+    .orderBy(asc(groups.groupName));
+}
+
+async function loadContextRows(
+  userId: string,
+  languageId: string,
+  database?: AnyDb,
+  cardIds?: string[],
+): Promise<TranslationDrillContextRow[]> {
+  const normalizedCardIds = normalizeGroupIds(cardIds);
+
+  if (cardIds && normalizedCardIds.length === 0) {
+    return [];
+  }
+
+  return await getConn(database)
+    .select({
+      cardId: cards.cardId,
+      content: cards.content,
+      meaning: cards.meaning,
+      cardType: cards.cardType,
+      examples: cards.examples,
+      mnemonics: cards.mnemonics,
+      llmInstructions: cards.llmInstructions,
+      updatedAt: cards.updatedAt,
+      addedFrom: translationDrillContext.addedFrom,
+      addedAt: translationDrillContext.addedAt,
+      lastUsedAt: translationDrillContext.lastUsed,
+      contextUsageCount: translationDrillContext.usageCount,
+      state: translationDrillContext.state,
+      stateUntil: translationDrillContext.stateUntil,
+      cefrOverride: translationDrillContext.cefrOverride,
+      metadata: translationDrillContext.metadata,
+      nextDue: translationDrillSrs.nextDue,
+      intervalDays: translationDrillSrs.intervalDays,
+      srsUsageCount: translationDrillSrs.usageCount,
+      performanceScore: translationDrillSrs.performanceScore,
+      srsLastUsed: translationDrillSrs.lastUsed,
+    })
+    .from(translationDrillContext)
+    .innerJoin(cards, and(
+      eq(cards.userId, translationDrillContext.userId),
+      eq(cards.languageId, translationDrillContext.languageId),
+      eq(cards.cardId, translationDrillContext.cardId),
+      eq(cards.status, 'active'),
+    ))
+    .leftJoin(translationDrillSrs, and(
+      eq(translationDrillSrs.userId, translationDrillContext.userId),
+      eq(translationDrillSrs.languageId, translationDrillContext.languageId),
+      eq(translationDrillSrs.cardId, translationDrillContext.cardId),
+    ))
+    .where(and(
+      eq(translationDrillContext.userId, userId),
+      eq(translationDrillContext.languageId, languageId),
+      ...(normalizedCardIds.length > 0 ? [inArray(translationDrillContext.cardId, normalizedCardIds)] : []),
+    ))
+    .orderBy(
+      asc(sql`${translationDrillContext.lastUsed} ASC NULLS FIRST`),
+      asc(translationDrillContext.usageCount),
+      desc(cards.updatedAt),
+    );
+}
+
+async function loadAvailableDrawCandidates(
+  userId: string,
+  languageId: string,
+  groupId: string,
+  database?: AnyDb,
+): Promise<TranslationDrillCandidateRow[]> {
+  return await getConn(database)
+    .select({
+      cardId: cards.cardId,
+      updatedAt: cards.updatedAt,
+      state: translationDrillContext.state,
+      nextDue: translationDrillSrs.nextDue,
+    })
+    .from(cardGroups)
+    .innerJoin(cards, and(
+      eq(cards.userId, cardGroups.userId),
+      eq(cards.languageId, cardGroups.languageId),
+      eq(cards.cardId, cardGroups.cardId),
+      eq(cards.status, 'active'),
+    ))
+    .leftJoin(translationDrillContext, and(
+      eq(translationDrillContext.userId, cardGroups.userId),
+      eq(translationDrillContext.languageId, cardGroups.languageId),
+      eq(translationDrillContext.cardId, cardGroups.cardId),
+    ))
+    .leftJoin(translationDrillSrs, and(
+      eq(translationDrillSrs.userId, cardGroups.userId),
+      eq(translationDrillSrs.languageId, cardGroups.languageId),
+      eq(translationDrillSrs.cardId, cardGroups.cardId),
+    ))
+    .where(and(
+      eq(cardGroups.userId, userId),
+      eq(cardGroups.languageId, languageId),
+      eq(cardGroups.groupId, groupId),
+    ))
+    .orderBy(
+      asc(sql<number>`COALESCE(${translationDrillSrs.nextDue}, 0)`),
+      desc(cards.updatedAt),
+    );
+}
+
+async function countAvailableCardsForGroup(
+  userId: string,
+  languageId: string,
+  groupId: string,
+  now: Date,
+  database?: AnyDb,
+): Promise<number> {
+  const nowSeconds = toUnixSeconds(now);
+  const rows = await loadAvailableDrawCandidates(userId, languageId, groupId, database);
+
+  return rows.filter((row) => {
+    const state = getContextState(row.state);
+
+    if (row.state === null || row.state === undefined) {
+      return true;
+    }
+
+    if (state === 'dismissed') {
+      return row.nextDue === null || row.nextDue <= nowSeconds;
+    }
+
+    return false;
+  }).length;
+}
+
+function buildGroupLookup(groupRows: Array<{ groupId: string; groupName: string }>) {
+  return new Map(groupRows.map((group) => [group.groupId, group.groupName]));
+}
+
+function mapContextCard(
+  row: TranslationDrillContextRow,
+  groupLookup: Map<string, string>,
+): TranslationDrillContextCard {
+  const sourceGroupId = parseDrawPileSourceGroupId(row.addedFrom);
+  const usageCount = row.contextUsageCount ?? row.srsUsageCount ?? 0;
+
+  return {
+    cardId: row.cardId,
+    content: row.content,
+    meaning: row.meaning,
+    cardType: row.cardType,
+    examples: normalizeStringList(row.examples),
+    mnemonics: normalizeStringList(row.mnemonics),
+    llmInstructions: row.llmInstructions,
+    updatedAt: row.updatedAt,
+    sourceGroup: sourceGroupId
+      ? {
+          groupId: sourceGroupId,
+          groupName: groupLookup.get(sourceGroupId) ?? sourceGroupId,
+        }
+      : null,
+    addedFrom: row.addedFrom,
+    addedAt: row.addedAt,
+    lastUsedAt: row.lastUsedAt ?? fromUnixSeconds(row.srsLastUsed),
+    usageCount,
+    state: getContextState(row.state),
+    stateUntil: row.stateUntil,
+    cefrOverride: row.cefrOverride,
+    metadata: row.metadata,
+    nextDueAt: fromUnixSeconds(row.nextDue),
+    intervalDays: row.intervalDays,
+    performanceScore: row.performanceScore,
+  };
+}
+
+async function requireContextCard(
+  userId: string,
+  languageId: string,
+  cardId: string,
+  database?: AnyDb,
+): Promise<TranslationDrillContextCard> {
+  const groupRows = await loadDrawPileGroupRows(userId, languageId, database);
+  const groupLookup = buildGroupLookup(groupRows.map((group) => ({ groupId: group.groupId, groupName: group.groupName })));
+  const rows = await loadContextRows(userId, languageId, database, [cardId]);
+  const row = rows[0];
+
+  if (!row) {
+    throw new Error('That card is not in the Translation Drills context.');
+  }
+
+  return mapContextCard(row, groupLookup);
+}
+
+export async function upsertTranslationDrillDrawPile(
+  userId: string,
+  languageId: string,
+  groupId: string,
+  options: {
+    enabled?: boolean;
+    drawPileName?: string | null;
+    pileSizeLimit?: number | null;
+  } = {},
+  database?: AnyDb,
+) {
+  const [group] = await getConn(database)
+    .select({
+      groupId: groups.groupId,
+      groupName: groups.groupName,
+    })
+    .from(groups)
+    .where(and(
+      eq(groups.userId, userId),
+      eq(groups.languageId, languageId),
+      eq(groups.groupId, groupId),
+    ));
+
+  if (!group) {
+    throw new Error('That group is not available for Translation Drills.');
+  }
+
+  await getConn(database)
+    .insert(translationDrillDrawPiles)
+    .values({
+      userId,
+      languageId,
+      groupId,
+      enabled: options.enabled ?? true,
+      drawPileName: options.drawPileName ?? null,
+      pileSizeLimit: options.pileSizeLimit ?? 10,
+    })
+    .onConflictDoUpdate({
+      target: [
+        translationDrillDrawPiles.userId,
+        translationDrillDrawPiles.languageId,
+        translationDrillDrawPiles.groupId,
+      ],
+      set: {
+        enabled: options.enabled ?? true,
+        drawPileName: options.drawPileName ?? null,
+        pileSizeLimit: options.pileSizeLimit ?? 10,
+      },
+    });
+
+  return {
+    groupId: group.groupId,
+    groupName: group.groupName,
+    enabled: options.enabled ?? true,
+    drawPileName: options.drawPileName ?? null,
+    pileSizeLimit: options.pileSizeLimit ?? 10,
+  };
+}
+
+export async function listTranslationDrillContextCards(
+  userId: string,
+  languageId: string,
+  database?: AnyDb,
+): Promise<TranslationDrillContextCard[]> {
+  const [groupRows, contextRows] = await Promise.all([
+    loadDrawPileGroupRows(userId, languageId, database),
+    loadContextRows(userId, languageId, database),
+  ]);
+  const groupLookup = buildGroupLookup(groupRows.map((group) => ({ groupId: group.groupId, groupName: group.groupName })));
+
+  return contextRows.map((row) => mapContextCard(row, groupLookup));
+}
+
+export async function listTranslationDrillChallengeCards(
+  userId: string,
+  languageId: string,
+  database?: AnyDb,
+): Promise<TranslationDrillContextCard[]> {
+  const cardsInContext = await listTranslationDrillContextCards(userId, languageId, database);
+
+  return cardsInContext.filter((card) => card.state === 'active');
+}
+
+export async function listTranslationDrillDrawPileGroups(
+  userId: string,
+  languageId: string,
+  options: { now?: Date } = {},
+  database?: AnyDb,
+): Promise<TranslationDrillDrawPileGroup[]> {
+  const now = options.now ?? new Date();
+  const groupRows = await loadDrawPileGroupRows(userId, languageId, database);
+  const groupLookup = buildGroupLookup(groupRows.map((group) => ({ groupId: group.groupId, groupName: group.groupName })));
+  const contextCards = await listTranslationDrillContextCards(userId, languageId, database);
+
+  const cardsByGroup = new Map<string, { active: TranslationDrillContextCard[]; snoozed: TranslationDrillContextCard[] }>();
+
+  for (const card of contextCards) {
+    const groupId = card.sourceGroup?.groupId;
+
+    if (!groupId) {
+      continue;
+    }
+
+    const bucket = cardsByGroup.get(groupId) ?? { active: [], snoozed: [] };
+
+    if (card.state === 'active') {
+      bucket.active.push(card);
+    } else if (card.state === 'snoozed') {
+      bucket.snoozed.push(card);
+    }
+
+    cardsByGroup.set(groupId, bucket);
+  }
+
+  const remainingCounts = await Promise.all(groupRows.map(async (group) => ({
+    groupId: group.groupId,
+    remainingCardCount: await countAvailableCardsForGroup(userId, languageId, group.groupId, now, database),
+  })));
+  const remainingByGroup = new Map(remainingCounts.map((entry) => [entry.groupId, entry.remainingCardCount]));
+
+  return groupRows.map((group) => {
+    const groupedCards = cardsByGroup.get(group.groupId) ?? { active: [], snoozed: [] };
+
+    return {
+      groupId: group.groupId,
+      groupName: groupLookup.get(group.groupId) ?? group.groupName,
+      drawPileName: group.drawPileName,
+      pileSizeLimit: group.pileSizeLimit ?? 10,
+      remainingCardCount: remainingByGroup.get(group.groupId) ?? 0,
+      activeCards: groupedCards.active,
+      snoozedCards: groupedCards.snoozed,
+    };
+  });
+}
+
+export async function getTranslationDrillDismissSchedule(
+  userId: string,
+  languageId: string,
+  cardId: string,
+  database?: AnyDb,
+): Promise<TranslationDrillDismissSchedule> {
+  await requireContextCard(userId, languageId, cardId, database);
+
+  const [row] = await getConn(database)
+    .select({
+      intervalDays: translationDrillSrs.intervalDays,
+    })
+    .from(translationDrillSrs)
+    .where(and(
+      eq(translationDrillSrs.userId, userId),
+      eq(translationDrillSrs.languageId, languageId),
+      eq(translationDrillSrs.cardId, cardId),
+    ));
+
+  const baseInterval = Math.max(row?.intervalDays ?? 1, 1);
+  const recommendedDays = Math.min(60, Math.max(5, Math.round(baseInterval * 2)));
+  const optionDays = [...new Set([
+    1,
+    recommendedDays,
+    Math.min(60, Math.max(14, Math.round(recommendedDays * 3))),
+    Math.min(90, Math.max(30, Math.round(recommendedDays * 6))),
+  ])].sort((left, right) => left - right);
+
+  return {
+    cardId,
+    recommendedDays,
+    optionDays,
+  };
+}
+
+export async function activateTranslationDrillCard(
+  userId: string,
+  languageId: string,
+  cardId: string,
+  options: {
+    addedFrom?: string | null;
+    occurredAt?: Date;
+    trackDrawStat?: boolean;
+  } = {},
+  database?: AnyDb,
+): Promise<TranslationDrillContextCard> {
+  const occurredAt = options.occurredAt ?? new Date();
+
+  return await runInTransaction(database, async (tx) => {
+    const [card] = await tx
+      .select({
+        cardId: cards.cardId,
+      })
+      .from(cards)
+      .where(and(
+        eq(cards.userId, userId),
+        eq(cards.languageId, languageId),
+        eq(cards.cardId, cardId),
+        eq(cards.status, 'active'),
+      ));
+
+    if (!card) {
+      throw new Error('That card is not available for Translation Drills.');
+    }
+
+    await tx
+      .insert(translationDrillContext)
+      .values({
+        userId,
+        languageId,
+        cardId,
+        state: 'active',
+        addedFrom: options.addedFrom ?? null,
+        addedAt: occurredAt,
+        lastUsed: null,
+        usageCount: 0,
+        stateUntil: null,
+      })
+      .onConflictDoUpdate({
+        target: [
+          translationDrillContext.userId,
+          translationDrillContext.languageId,
+          translationDrillContext.cardId,
+        ],
+        set: {
+          state: 'active',
+          addedFrom: options.addedFrom ?? translationDrillContext.addedFrom,
+          addedAt: occurredAt,
+          stateUntil: null,
+        },
+      });
+
+    if (options.trackDrawStat) {
+      await upsertDailyStats(userId, languageId, occurredAt, { cardsDrawn: 1 }, tx);
+    }
+
+    return await requireContextCard(userId, languageId, cardId, tx);
+  });
+}
+
+export async function pinCardToTranslationDrillsContext(
+  userId: string,
+  languageId: string,
+  cardId: string,
+  options: { occurredAt?: Date } = {},
+  database?: AnyDb,
+): Promise<TranslationDrillContextCard> {
+  return await activateTranslationDrillCard(
+    userId,
+    languageId,
+    cardId,
+    {
+      addedFrom: 'pinned_from_review',
+      occurredAt: options.occurredAt,
+      trackDrawStat: false,
+    },
+    database,
+  );
+}
+
+export async function drawTranslationDrillCard(
+  userId: string,
+  languageId: string,
+  groupId: string,
+  options: { occurredAt?: Date } = {},
+  database?: AnyDb,
+): Promise<TranslationDrillContextCard> {
+  const occurredAt = options.occurredAt ?? new Date();
+  const nowSeconds = toUnixSeconds(occurredAt);
+
+  return await runInTransaction(database, async (tx) => {
+    const drawPile = await getConfiguredDrawPile(userId, languageId, groupId, tx);
+
+    if (!drawPile) {
+      throw new Error('That group is not configured as a Translation Drills draw pile.');
+    }
+
+    const contextCards = await listTranslationDrillContextCards(userId, languageId, tx);
+    const currentGroupCards = contextCards.filter((card) =>
+      card.sourceGroup?.groupId === groupId && (card.state === 'active' || card.state === 'snoozed'));
+
+    if (currentGroupCards.length >= (drawPile.pileSizeLimit ?? 10)) {
+      throw new Error('That draw pile is already at its active limit.');
+    }
+
+    const candidates = await loadAvailableDrawCandidates(userId, languageId, groupId, tx);
+    const nextCard = candidates.find((candidate) => {
+      if (candidate.state === null) {
+        return true;
+      }
+
+      const state = getContextState(candidate.state);
+
+      if (state !== 'dismissed') {
+        return false;
+      }
+
+      return candidate.nextDue === null || candidate.nextDue <= nowSeconds;
+    });
+
+    if (!nextCard) {
+      throw new Error('There are no cards available to draw from that pile right now.');
+    }
+
+    return await activateTranslationDrillCard(
+      userId,
+      languageId,
+      nextCard.cardId,
+      {
+        addedFrom: `draw_pile:${groupId}`,
+        occurredAt,
+        trackDrawStat: true,
+      },
+      tx,
+    );
+  });
+}
+
+export async function snoozeTranslationDrillCard(
+  userId: string,
+  languageId: string,
+  cardId: string,
+  snoozedUntil: Date,
+  options: { occurredAt?: Date } = {},
+  database?: AnyDb,
+): Promise<TranslationDrillMutationResult> {
+  const occurredAt = options.occurredAt ?? new Date();
+  const existing = await requireContextCard(userId, languageId, cardId, database);
+
+  if (existing.state !== 'active') {
+    throw new Error('That card is not active in Translation Drills.');
+  }
+
+  return await runInTransaction(database, async (tx) => {
+    await tx
+      .update(translationDrillContext)
+      .set({
+        state: 'snoozed',
+        stateUntil: snoozedUntil,
+      })
+      .where(and(
+        eq(translationDrillContext.userId, userId),
+        eq(translationDrillContext.languageId, languageId),
+        eq(translationDrillContext.cardId, cardId),
+      ));
+
+    await upsertDailyStats(userId, languageId, occurredAt, { cardsSnoozed: 1 }, tx);
+    const updated = await requireContextCard(userId, languageId, cardId, tx);
+
+    return {
+      cardId,
+      state: updated.state,
+      stateUntil: updated.stateUntil,
+      nextDueAt: updated.nextDueAt,
+      intervalDays: updated.intervalDays,
+      usageCount: updated.usageCount,
+      performanceScore: updated.performanceScore,
+    };
+  });
+}
+
+export async function disableTranslationDrillCard(
+  userId: string,
+  languageId: string,
+  cardId: string,
+  database?: AnyDb,
+): Promise<TranslationDrillMutationResult> {
+  await requireContextCard(userId, languageId, cardId, database);
+
+  return await runInTransaction(database, async (tx) => {
+    await tx
+      .update(translationDrillContext)
+      .set({
+        state: 'disabled',
+        stateUntil: null,
+      })
+      .where(and(
+        eq(translationDrillContext.userId, userId),
+        eq(translationDrillContext.languageId, languageId),
+        eq(translationDrillContext.cardId, cardId),
+      ));
+
+    const updated = await requireContextCard(userId, languageId, cardId, tx);
+
+    return {
+      cardId,
+      state: updated.state,
+      stateUntil: updated.stateUntil,
+      nextDueAt: updated.nextDueAt,
+      intervalDays: updated.intervalDays,
+      usageCount: updated.usageCount,
+      performanceScore: updated.performanceScore,
+    };
+  });
+}
+
+export async function dismissTranslationDrillCard(
+  userId: string,
+  languageId: string,
+  cardId: string,
+  returnAt: Date,
+  options: {
+    occurredAt?: Date;
+    performanceScore?: number | null;
+  } = {},
+  database?: AnyDb,
+): Promise<TranslationDrillMutationResult> {
+  const occurredAt = options.occurredAt ?? new Date();
+  const existing = await requireContextCard(userId, languageId, cardId, database);
+
+  if (existing.state !== 'active' && existing.state !== 'snoozed') {
+    throw new Error('That card cannot be dismissed from Translation Drills right now.');
+  }
+
+  return await runInTransaction(database, async (tx) => {
+    const intervalDays = Math.max(1, Math.round((returnAt.getTime() - occurredAt.getTime()) / 86_400_000));
+    const nextDue = toUnixSeconds(returnAt);
+    const previousUsageCount = existing.usageCount;
+
+    await tx
+      .insert(translationDrillSrs)
+      .values({
+        userId,
+        languageId,
+        cardId,
+        nextDue,
+        intervalDays,
+        usageCount: previousUsageCount + 1,
+        lastUsed: toUnixSeconds(occurredAt),
+        performanceScore: options.performanceScore ?? existing.performanceScore ?? null,
+      })
+      .onConflictDoUpdate({
+        target: [
+          translationDrillSrs.userId,
+          translationDrillSrs.languageId,
+          translationDrillSrs.cardId,
+        ],
+        set: {
+          nextDue,
+          intervalDays,
+          usageCount: previousUsageCount + 1,
+          lastUsed: toUnixSeconds(occurredAt),
+          performanceScore: options.performanceScore ?? existing.performanceScore ?? null,
+        },
+      });
+
+    await tx
+      .update(translationDrillContext)
+      .set({
+        state: 'dismissed',
+        stateUntil: returnAt,
+        lastUsed: occurredAt,
+        usageCount: previousUsageCount + 1,
+      })
+      .where(and(
+        eq(translationDrillContext.userId, userId),
+        eq(translationDrillContext.languageId, languageId),
+        eq(translationDrillContext.cardId, cardId),
+      ));
+
+    await upsertDailyStats(userId, languageId, occurredAt, { cardsDismissed: 1 }, tx);
+    const updated = await requireContextCard(userId, languageId, cardId, tx);
+
+    return {
+      cardId,
+      state: updated.state,
+      stateUntil: updated.stateUntil,
+      nextDueAt: updated.nextDueAt,
+      intervalDays: updated.intervalDays,
+      usageCount: updated.usageCount,
+      performanceScore: updated.performanceScore,
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- add Translation Drills database operations for draw piles, context cards, challenge inputs, and draw/snooze/dismiss/disable mutations
- add Translation Drills server contracts and route wiring for the home loader and app-owned action endpoint
- cover the new foundations with Translation Drills database/server tests and verify Card Review pinning activates Translation Drills context

## Testing
- pnpm turbo test lint build --filter=web
- pnpm --filter @studypuck/database test:docker:raw *(blocked locally: Postgres test DB on localhost:5433 unavailable, ECONNREFUSED)*

Closes #197