### PR TITLE
Install Prettier in Codespaces environment

### DIFF
--- a/.devcontainer/bootstrap.sh
+++ b/.devcontainer/bootstrap.sh
@@ -14,6 +14,13 @@ pnpm --version
 echo "Installing workspace dependencies..."
 pnpm install --frozen-lockfile
 
+expected_prettier_version="$(pnpm exec prettier --version)"
+
+if ! command -v prettier >/dev/null 2>&1 || [ "$(prettier --version)" != "$expected_prettier_version" ]; then
+	echo "Installing Prettier CLI..."
+	npm install --global "prettier@$expected_prettier_version"
+fi
+
 if ! command -v bw >/dev/null 2>&1; then
 	echo "Installing Bitwarden CLI..."
 	npm install --global @bitwarden/cli

--- a/docs/ops/remote-development.md
+++ b/docs/ops/remote-development.md
@@ -21,6 +21,7 @@ The remote devcontainer is designed to match the current StudyPuck stack:
 - **GitHub CLI**: Installed via devcontainer feature
 - **PNPM**: Enabled through Corepack using the repository's pinned package manager version
 - **Dependencies**: Installed by `.devcontainer/bootstrap.sh`
+- **Prettier CLI**: Installed by `.devcontainer/bootstrap.sh` and kept aligned with the repo version
 - **Bitwarden CLI**: Installed by `.devcontainer/bootstrap.sh`
 - **Wrangler**: Used through the existing `apps/web` dependency and scripts
 - **Copilot CLI**: Installed by `.devcontainer/bootstrap.sh` into the user-local tool path
@@ -71,7 +72,7 @@ The container runs:
 bash .devcontainer/bootstrap.sh
 ```
 
-This enables PNPM, verifies `gh`, installs workspace dependencies, installs Bitwarden CLI if missing, and installs Copilot CLI if missing.
+This enables PNPM, verifies `gh`, installs workspace dependencies, installs a matching global `prettier` binary, installs Bitwarden CLI if missing, and installs Copilot CLI if missing.
 
 If the container is running as a non-root user, the bootstrap script installs Corepack shims into a user-writable bin directory instead of `/usr/local/bin`.
 
@@ -82,6 +83,7 @@ Run:
 ```bash
 gh --version
 pnpm --version
+prettier --version
 copilot --version
 bw --version
 pnpm --filter web exec wrangler --version

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "clean": "turbo clean"
   },
   "devDependencies": {
+    "prettier": "^3.8.3",
     "turbo": "^2.7.2",
     "varlock": "^0.6.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     devDependencies:
+      prettier:
+        specifier: ^3.8.3
+        version: 3.8.3
       turbo:
         specifier: ^2.7.2
         version: 2.7.2
@@ -2879,6 +2882,12 @@ packages:
   /preact@10.24.3:
     resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
     dev: false
+
+  /prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true
 
   /pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}


### PR DESCRIPTION
## Summary
- add Prettier as a root dev dependency so repo formatting commands resolve in Codespaces
- update the devcontainer bootstrap script to install a matching global `prettier` CLI without requiring a rebuild
- document the Prettier availability in the remote development guide

## Validation
- pnpm turbo test lint build --filter=web

Closes #137