### PR TITLE
Implement Translation Drills active drill flow and context actions

### DIFF
--- a/apps/web/src/lib/command-bar/shared.ts
+++ b/apps/web/src/lib/command-bar/shared.ts
@@ -92,6 +92,12 @@ export const COMMANDS: CommandDefinition[] = [
     commandContext: 'translation-drills',
     insertText: '/draw ',
   },
+  {
+    command: '/context',
+    description: 'List the cards currently active in Translation Drills.',
+    commandContext: 'translation-drills',
+    insertText: '/context',
+  },
 ];
 
 export function defaultRouteContext(): RouteContext {

--- a/apps/web/src/lib/command-bar/translation-drills.test.ts
+++ b/apps/web/src/lib/command-bar/translation-drills.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { translationDrillSession } from '$lib/stores/translationDrillSession.js';
+import { resolveTranslationDrillCommandResponse } from './translation-drills.js';
+import { translationDrillSessionActions } from '$lib/stores/translationDrillSessionActions.js';
+import type { TranslationDrillHomeData } from '$lib/server/translation-drills.js';
+
+function createHome(): TranslationDrillHomeData {
+  return {
+    summary: {
+      configuredGroupCount: 1,
+      activeCardCount: 1,
+      snoozedCardCount: 0,
+      dismissedCardCount: 0,
+      disabledCardCount: 0,
+      remainingDrawCount: 2,
+      hasConfiguredDrawPiles: true,
+      hasVisibleContext: true,
+    },
+    availableGroups: [{ groupId: 'group-1', groupName: 'HSK2' }],
+    configuredGroups: [{
+      groupId: 'group-1',
+      groupName: 'HSK2',
+      drawPileName: null,
+      pileSizeLimit: 4,
+      remainingCardCount: 2,
+      activeCards: [{
+        cardId: 'card-1',
+        content: '经历',
+        meaning: 'to experience',
+        cardType: 'word',
+        examples: [],
+        mnemonics: [],
+        llmInstructions: null,
+        updatedAtIso: null,
+        sourceGroup: { groupId: 'group-1', groupName: 'HSK2' },
+        addedFrom: 'draw_pile:group-1',
+        addedAtIso: null,
+        lastUsedAtIso: null,
+        usageCount: 0,
+        state: 'active',
+        stateUntilIso: null,
+        cefrOverride: null,
+        nextDueAtIso: null,
+        intervalDays: null,
+        performanceScore: null,
+        dismissSchedule: {
+          recommendedDays: 5,
+          optionDays: [1, 5, 15, 30],
+        },
+      }],
+      snoozedCards: [],
+    }],
+    ungroupedContextCards: [],
+    challenge: {
+      activeChallenge: null,
+      generationInput: {
+        activeCardCount: 1,
+        cefrLevel: 'B1',
+        cards: [{
+          cardId: 'card-1',
+          content: '经历',
+          meaning: 'to experience',
+          cardType: 'word',
+          examples: [],
+          mnemonics: [],
+          llmInstructions: null,
+          updatedAtIso: null,
+          sourceGroup: { groupId: 'group-1', groupName: 'HSK2' },
+          addedFrom: 'draw_pile:group-1',
+          addedAtIso: null,
+          lastUsedAtIso: null,
+          usageCount: 0,
+          state: 'active',
+          stateUntilIso: null,
+          cefrOverride: null,
+          nextDueAtIso: null,
+          intervalDays: null,
+          performanceScore: null,
+          dismissSchedule: {
+            recommendedDays: 5,
+            optionDays: [1, 5, 15, 30],
+          },
+        }],
+        suggestedSourceCardIds: ['card-1'],
+      },
+    },
+  };
+}
+
+describe('resolveTranslationDrillCommandResponse', () => {
+  beforeEach(() => {
+    translationDrillSession.reset();
+    vi.restoreAllMocks();
+  });
+
+  it('returns a context summary for /context', async () => {
+    translationDrillSession.sync({
+      lang: 'zh',
+      home: createHome(),
+      activeChallenge: null,
+      focusedCardId: 'card-1',
+    });
+
+    await expect(resolveTranslationDrillCommandResponse('/context')).resolves.toBe('Active context: 经历.');
+  });
+
+  it('dispatches /next through the Translation Drills action store', async () => {
+    translationDrillSession.sync({
+      lang: 'zh',
+      home: createHome(),
+      activeChallenge: null,
+      focusedCardId: 'card-1',
+    });
+
+    const nextSpy = vi.spyOn(translationDrillSessionActions, 'requestNext').mockResolvedValue({
+      message: 'New challenge ready.',
+      conversationReset: true,
+    });
+
+    await expect(resolveTranslationDrillCommandResponse('/next')).resolves.toEqual({
+      message: 'New challenge ready.',
+      conversationReset: true,
+    });
+    expect(nextSpy).toHaveBeenCalled();
+  });
+
+  it('falls back to the first active card for snooze or dismiss commands', async () => {
+    translationDrillSession.sync({
+      lang: 'zh',
+      home: createHome(),
+      activeChallenge: null,
+      focusedCardId: null,
+    });
+
+    const snoozeSpy = vi.spyOn(translationDrillSessionActions, 'requestSnooze').mockResolvedValue({
+      message: '经历 snoozed.',
+    });
+    const dismissSpy = vi.spyOn(translationDrillSessionActions, 'requestDismiss').mockResolvedValue({
+      message: '经历 dismissed.',
+    });
+
+    await expect(resolveTranslationDrillCommandResponse('/snooze')).resolves.toEqual({
+      message: '经历 snoozed.',
+    });
+    await expect(resolveTranslationDrillCommandResponse('/dismiss')).resolves.toEqual({
+      message: '经历 dismissed.',
+    });
+    expect(snoozeSpy).toHaveBeenCalledWith('card-1');
+    expect(dismissSpy).toHaveBeenCalledWith('card-1');
+  });
+});

--- a/apps/web/src/lib/command-bar/translation-drills.ts
+++ b/apps/web/src/lib/command-bar/translation-drills.ts
@@ -1,0 +1,138 @@
+import { get } from 'svelte/store';
+import { translationDrillSession } from '$lib/stores/translationDrillSession.js';
+import {
+  translationDrillSessionActions,
+  type TranslationDrillLocalResponse,
+} from '$lib/stores/translationDrillSessionActions.js';
+
+function parseTranslationDrillCommand(input: string) {
+  const trimmedInput = input.trim();
+
+  if (!trimmedInput.startsWith('/')) {
+    return null;
+  }
+
+  const [typedCommand, ...rest] = trimmedInput.split(/\s+/);
+
+  if (!typedCommand) {
+    return null;
+  }
+
+  return {
+    command: typedCommand,
+    argument: rest.join(' ').trim(),
+  };
+}
+
+function formatContextSummary() {
+  const state = get(translationDrillSession);
+
+  if (state.activeCards.length === 0) {
+    return 'There are no active Translation Drills cards yet.';
+  }
+
+  return `Active context: ${state.activeCards.map((card) => card.content).join(', ')}.`;
+}
+
+function resolveTargetCardId() {
+  const state = get(translationDrillSession);
+
+  return state.focusedCardId ?? state.activeCards[0]?.cardId ?? null;
+}
+
+function resolveGroupId(argument: string) {
+  const state = get(translationDrillSession);
+
+  if (state.configuredGroups.length === 0) {
+    return {
+      groupId: null,
+      message: 'Configure at least one draw pile before using /draw.',
+    };
+  }
+
+  if (!argument) {
+    if (state.configuredGroups.length === 1) {
+      return {
+        groupId: state.configuredGroups[0]?.groupId ?? null,
+        message: null,
+      };
+    }
+
+    return {
+      groupId: null,
+      message: `Specify which pile to draw from: ${state.configuredGroups.map((group) => group.groupName).join(', ')}.`,
+    };
+  }
+
+  const normalizedArgument = argument.trim().toLocaleLowerCase();
+  const matchingGroup = state.configuredGroups.find((group) =>
+    group.groupName.toLocaleLowerCase() === normalizedArgument
+    || group.groupName.toLocaleLowerCase().startsWith(normalizedArgument),
+  );
+
+  if (!matchingGroup) {
+    return {
+      groupId: null,
+      message: `No Translation Drills pile matched "${argument}".`,
+    };
+  }
+
+  return {
+    groupId: matchingGroup.groupId,
+    message: null,
+  };
+}
+
+export async function resolveTranslationDrillCommandResponse(input: string): Promise<TranslationDrillLocalResponse | string | null> {
+  const parsed = parseTranslationDrillCommand(input);
+
+  if (!parsed) {
+    return null;
+  }
+
+  if (parsed.command === '/context') {
+    return formatContextSummary();
+  }
+
+  if (parsed.command === '/next') {
+    const state = get(translationDrillSession);
+
+    if (!state.generationInput || state.generationInput.activeCardCount === 0) {
+      return 'Draw or pin at least one active card before starting a challenge.';
+    }
+
+    return translationDrillSessionActions.requestNext();
+  }
+
+  if (parsed.command === '/draw') {
+    const group = resolveGroupId(parsed.argument);
+
+    if (!group.groupId) {
+      return group.message;
+    }
+
+    return translationDrillSessionActions.requestDraw(group.groupId);
+  }
+
+  if (parsed.command === '/snooze') {
+    const cardId = resolveTargetCardId();
+
+    if (!cardId) {
+      return 'Focus a Translation Drills card before using /snooze.';
+    }
+
+    return translationDrillSessionActions.requestSnooze(cardId);
+  }
+
+  if (parsed.command === '/dismiss') {
+    const cardId = resolveTargetCardId();
+
+    if (!cardId) {
+      return 'Focus a Translation Drills card before using /dismiss.';
+    }
+
+    return translationDrillSessionActions.requestDismiss(cardId);
+  }
+
+  return null;
+}

--- a/apps/web/src/lib/components/CommandBar.svelte
+++ b/apps/web/src/lib/components/CommandBar.svelte
@@ -8,6 +8,9 @@
   import type { ChatSuggestion } from '$lib/chat.js';
   import { resolveCardReviewCommandResponse } from '$lib/command-bar/card-review.js';
   import { resolveCardEntryCommandResponse } from '$lib/command-bar/card-entry.js';
+  import { resolveTranslationDrillCommandResponse } from '$lib/command-bar/translation-drills.js';
+  import { translationDrillSession } from '$lib/stores/translationDrillSession.js';
+  import { translationDrillSessionActions } from '$lib/stores/translationDrillSessionActions.js';
   import { activeCardSuggestionActions } from '$lib/stores/activeCardSuggestionActions.js';
   import { cardReviewSessionActions } from '$lib/stores/cardReviewSessionActions.js';
   import { cardEntrySuggestionActions } from '$lib/stores/cardEntrySuggestionActions.js';
@@ -49,6 +52,7 @@
   const showMobileConversation = $derived(
     !isDesktop && $commandBar.mobileSheetOpen && ($commandBar.messages.length > 0 || $commandBar.isWaiting),
   );
+  const activeTranslationDrillChallenge = $derived($translationDrillSession.activeChallenge);
 
   function updateDesktopMode() {
     isDesktop = mediaQueryList?.matches ?? false;
@@ -207,6 +211,12 @@
         return cardReviewCommandResponse;
       }
 
+      const translationDrillCommandResponse = await resolveTranslationDrillCommandResponse(input);
+
+      if (translationDrillCommandResponse !== null) {
+        return translationDrillCommandResponse;
+      }
+
       const promptHistory = commandBar.getPromptHistory(submissionState);
 
       // URL param takes priority; fall back to the store's active note, then omit.
@@ -313,6 +323,20 @@
 
   function handleAutocompleteMouseDown(event: MouseEvent) {
     event.preventDefault();
+  }
+
+  async function handleNewTranslationChallenge() {
+    try {
+      const result = await translationDrillSessionActions.requestNext();
+      commandBar.applyLocalResponse(result);
+      await tick();
+      resizeInput();
+      focusInput();
+    } catch (error) {
+      commandBar.applyLocalResponse({
+        message: error instanceof Error ? error.message : 'The new challenge could not be created right now.',
+      });
+    }
   }
 
   /**
@@ -578,6 +602,16 @@
           </div>
 
           <div class="cluster conversation-header__actions">
+            {#if $commandBar.routeContext.commandContext === 'translation-drills'}
+              <button
+                type="button"
+                class="conversation-header__button conversation-header__button--primary"
+                aria-label="Start a new Translation Drills challenge"
+                onclick={() => void handleNewTranslationChallenge()}
+              >
+                New Challenge
+              </button>
+            {/if}
             <button
               type="button"
               class="conversation-header__button"
@@ -597,37 +631,61 @@
           </div>
         </header>
 
-        <div class="conversation-thread" aria-live="polite" aria-atomic="false">
+        {#if $commandBar.routeContext.commandContext === 'translation-drills' && activeTranslationDrillChallenge}
+          <section class="translation-drill-challenge stack" style="--stack-space: var(--space-1)" role="status" aria-live="polite">
+            <p class="translation-drill-challenge__eyebrow">Translate to {$translationDrillSession.lang ? $translationDrillSession.lang.toUpperCase() : 'your language'}</p>
+            <p class="translation-drill-challenge__prompt">{activeTranslationDrillChallenge.prompt}</p>
+          </section>
+        {/if}
+
+        <div
+          class="conversation-thread"
+          class:conversation-thread--challenge={$commandBar.routeContext.commandContext === 'translation-drills' && Boolean(activeTranslationDrillChallenge)}
+          aria-live="polite"
+          aria-atomic="false"
+        >
           {#if $commandBar.messages.length === 0 && !$commandBar.isWaiting}
             <div class="conversation-empty stack" style="--stack-space: var(--space-2)">
-              <p class="conversation-empty__title">No conversation yet</p>
-              <p class="text-muted">Responses will appear here after you send a message or run a conversational command.</p>
+              <p class="conversation-empty__title">
+                {$commandBar.routeContext.commandContext === 'translation-drills' && !activeTranslationDrillChallenge
+                  ? 'No active challenge'
+                  : 'No conversation yet'}
+              </p>
+              <p class="text-muted">
+                {$commandBar.routeContext.commandContext === 'translation-drills' && !activeTranslationDrillChallenge
+                  ? 'Click New Challenge or type /next below to begin.'
+                  : 'Responses will appear here after you send a message or run a conversational command.'}
+              </p>
             </div>
           {/if}
 
           {#each $commandBar.messages as message}
-            <article
-              class="message"
-              class:message--user={message.role === 'user'}
-              class:message--assistant={message.role !== 'user'}
-            >
-              <p class="message__label">{message.role === 'user' ? 'You' : 'StudyPuck'}</p>
-              <p>{message.content}</p>
-              {#if message.suggestions && message.suggestions.length > 0}
-                <div class="message__suggestions cluster" style="--cluster-space: var(--space-2)">
-                  {#each message.suggestions as suggestion}
-                    <button
-                      type="button"
-                      class="suggestion-button"
-                      onclick={() => void handleSuggestionClick(suggestion)}
-                    >
-                      <span class="suggestion-button__text">{getSuggestionText(suggestion)}</span>
-                      <span class="suggestion-button__meta">{getSuggestionLabel(suggestion)}</span>
-                    </button>
-                  {/each}
-                </div>
-              {/if}
-            </article>
+            {#if message.role === 'system'}
+              <p class="conversation-divider">{message.content}</p>
+            {:else}
+              <article
+                class="message"
+                class:message--user={message.role === 'user'}
+                class:message--assistant={message.role !== 'user'}
+              >
+                <p class="message__label">{message.role === 'user' ? 'You' : 'StudyPuck'}</p>
+                <p>{message.content}</p>
+                {#if message.suggestions && message.suggestions.length > 0}
+                  <div class="message__suggestions cluster" style="--cluster-space: var(--space-2)">
+                    {#each message.suggestions as suggestion}
+                      <button
+                        type="button"
+                        class="suggestion-button"
+                        onclick={() => void handleSuggestionClick(suggestion)}
+                      >
+                        <span class="suggestion-button__text">{getSuggestionText(suggestion)}</span>
+                        <span class="suggestion-button__meta">{getSuggestionLabel(suggestion)}</span>
+                      </button>
+                    {/each}
+                  </div>
+                {/if}
+              </article>
+            {/if}
           {/each}
 
           {#if $commandBar.isWaiting}
@@ -671,30 +729,60 @@
         <span aria-hidden="true"></span>
       </button>
 
+      {#if $commandBar.routeContext.commandContext === 'translation-drills'}
+        <div class="conversation-sheet__actions cluster">
+          <button
+            type="button"
+            class="conversation-header__button conversation-header__button--primary"
+            onclick={() => void handleNewTranslationChallenge()}
+          >
+            New Challenge
+          </button>
+          <button
+            type="button"
+            class="conversation-header__button"
+            onclick={() => commandBar.closeMobileSheet()}
+          >
+            Cards
+          </button>
+        </div>
+      {/if}
+
+      {#if $commandBar.routeContext.commandContext === 'translation-drills' && activeTranslationDrillChallenge}
+        <section class="translation-drill-challenge stack" style="--stack-space: var(--space-1)" role="status" aria-live="polite">
+          <p class="translation-drill-challenge__eyebrow">Translate to {$translationDrillSession.lang ? $translationDrillSession.lang.toUpperCase() : 'your language'}</p>
+          <p class="translation-drill-challenge__prompt">{activeTranslationDrillChallenge.prompt}</p>
+        </section>
+      {/if}
+
       <div class="conversation-sheet__thread" aria-live="polite" aria-atomic="false">
         {#each $commandBar.messages as message}
-          <article
-            class="message"
-            class:message--user={message.role === 'user'}
-            class:message--assistant={message.role !== 'user'}
-          >
-            <p class="message__label">{message.role === 'user' ? 'You' : 'StudyPuck'}</p>
-            <p>{message.content}</p>
-            {#if message.suggestions && message.suggestions.length > 0}
-              <div class="message__suggestions cluster" style="--cluster-space: var(--space-2)">
-                {#each message.suggestions as suggestion}
-                  <button
-                    type="button"
-                    class="suggestion-button"
-                    onclick={() => void handleSuggestionClick(suggestion)}
-                  >
-                    <span class="suggestion-button__text">{getSuggestionText(suggestion)}</span>
-                    <span class="suggestion-button__meta">{getSuggestionLabel(suggestion)}</span>
-                  </button>
-                {/each}
-              </div>
-            {/if}
-          </article>
+          {#if message.role === 'system'}
+            <p class="conversation-divider">{message.content}</p>
+          {:else}
+            <article
+              class="message"
+              class:message--user={message.role === 'user'}
+              class:message--assistant={message.role !== 'user'}
+            >
+              <p class="message__label">{message.role === 'user' ? 'You' : 'StudyPuck'}</p>
+              <p>{message.content}</p>
+              {#if message.suggestions && message.suggestions.length > 0}
+                <div class="message__suggestions cluster" style="--cluster-space: var(--space-2)">
+                  {#each message.suggestions as suggestion}
+                    <button
+                      type="button"
+                      class="suggestion-button"
+                      onclick={() => void handleSuggestionClick(suggestion)}
+                    >
+                      <span class="suggestion-button__text">{getSuggestionText(suggestion)}</span>
+                      <span class="suggestion-button__meta">{getSuggestionLabel(suggestion)}</span>
+                    </button>
+                  {/each}
+                </div>
+              {/if}
+            </article>
+          {/if}
         {/each}
 
         {#if $commandBar.isWaiting}
@@ -1057,6 +1145,12 @@
     font-size: var(--font-size-caption);
   }
 
+  .conversation-header__button--primary {
+    border-color: var(--color-primary);
+    background: var(--color-primary);
+    color: var(--color-text-inverse);
+  }
+
   .conversation-thread,
   .conversation-sheet__thread {
     display: flex;
@@ -1066,6 +1160,21 @@
     overflow: auto;
   }
 
+  .conversation-thread--challenge {
+    min-block-size: 12rem;
+  }
+
+  .conversation-divider {
+    margin: 0;
+    padding: var(--space-2) 0;
+    text-align: center;
+    font-family: var(--font-ui);
+    font-size: var(--font-size-caption);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+  }
+
   .conversation-empty {
     justify-content: center;
     min-block-size: 100%;
@@ -1073,6 +1182,35 @@
     border: 1px dashed var(--color-border);
     border-radius: var(--radius-lg);
     background: color-mix(in srgb, var(--color-surface) 80%, transparent);
+  }
+
+  .translation-drill-challenge {
+    margin-block-end: var(--space-4);
+    padding: var(--space-3) var(--space-4);
+    border: 1px solid color-mix(in srgb, var(--color-primary) 28%, var(--color-border));
+    border-radius: var(--radius-lg);
+    background: var(--color-primary-subtle);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .translation-drill-challenge__eyebrow,
+  .conversation-sheet__actions {
+    margin: 0;
+    font-family: var(--font-ui);
+    font-size: var(--font-size-caption);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .translation-drill-challenge__eyebrow {
+    color: var(--color-primary-text);
+  }
+
+  .translation-drill-challenge__prompt {
+    margin: 0;
+    font-size: var(--font-size-body);
+    font-weight: 600;
+    line-height: var(--leading-body);
   }
 
   .conversation-empty__title {
@@ -1116,6 +1254,8 @@
     }
 
     .workspace-pane--conversation {
+      display: flex;
+      flex-direction: column;
       padding: var(--space-4);
       background: var(--color-surface);
     }
@@ -1236,6 +1376,11 @@
       border-radius: var(--radius-lg);
       background: var(--color-surface-raised);
       box-shadow: var(--shadow-lg);
+    }
+
+    .conversation-sheet__actions {
+      justify-content: space-between;
+      gap: var(--space-2);
     }
 
     .conversation-sheet__handle {

--- a/apps/web/src/lib/components/translation-drills/TranslationDrillsHome.svelte
+++ b/apps/web/src/lib/components/translation-drills/TranslationDrillsHome.svelte
@@ -1,8 +1,18 @@
 <script lang="ts">
+  import { get } from 'svelte/store';
+  import { getLanguageByCode } from '$lib/config/languages.js';
+  import ActiveCardDrawer from '$lib/components/cards/ActiveCardDrawer.svelte';
+  import type { CardLibraryCardDetailData } from '$lib/server/cards.js';
   import type {
     TranslationDrillContextCardData,
     TranslationDrillHomeData,
+    TranslationDrillActionResult,
   } from '$lib/server/translation-drills.js';
+  import { translationDrillSession } from '$lib/stores/translationDrillSession.js';
+  import {
+    translationDrillSessionActions,
+    type TranslationDrillLocalResponse,
+  } from '$lib/stores/translationDrillSessionActions.js';
 
   export let lang: string;
   export let home: TranslationDrillHomeData | null;
@@ -30,9 +40,11 @@
         usageCount: number;
         performanceScore: number | null;
         message: string;
-      };
+      }
+    | Extract<TranslationDrillActionResult, { action: 'challenge-start' | 'challenge-clear' }>;
 
   const DRAW_PILE_STACK_LAYERS = [0, 1, 2];
+  const defaultLanguageLabel = 'your target language';
 
   let homeState: HomeState | null = home ? structuredClone(home) : null;
   let previousHome = home;
@@ -45,6 +57,13 @@
   let learnMoreExpanded = false;
   let dismissCard: TranslationDrillContextCardData | null = null;
   let dismissOptions: number[] = [1];
+  let activeChallenge: Extract<TranslationDrillActionResult, { action: 'challenge-start' }>['challenge'] | null = null;
+  let focusedCardId: string | null = null;
+  let drawerCardId: string | null = null;
+  let drawerCard: TranslationDrillContextCardData | null = null;
+  let drawerCardDetail: CardLibraryCardDetailData | null = null;
+  let availableDrawerGroups: Array<{ groupId: string; groupName: string }> = [];
+  let lastHandledSessionActionId = get(translationDrillSessionActions)?.actionId ?? 0;
 
   $: if (home !== previousHome) {
     homeState = home ? structuredClone(home) : null;
@@ -56,10 +75,61 @@
     dismissCardId = null;
     dismissReturnInDays = 1;
     learnMoreExpanded = false;
+    activeChallenge = home?.challenge.activeChallenge ?? null;
+    focusedCardId = null;
+    drawerCardId = null;
+    if (homeState) {
+      syncGenerationInput();
+    }
   }
 
   $: dismissCard = dismissCardId ? findCard(dismissCardId)?.card ?? null : null;
   $: dismissOptions = dismissCard?.dismissSchedule?.optionDays ?? [1];
+  $: drawerCard = drawerCardId ? findCard(drawerCardId)?.card ?? null : null;
+  $: drawerCardDetail = drawerCard ? toDrawerCard(drawerCard) : null;
+  $: availableDrawerGroups = homeState?.availableGroups ?? [];
+  $: translationDrillSession.sync({
+    lang,
+    home: homeState,
+    activeChallenge,
+    focusedCardId,
+  });
+  $: if ($translationDrillSessionActions && $translationDrillSessionActions.actionId !== lastHandledSessionActionId) {
+    lastHandledSessionActionId = $translationDrillSessionActions.actionId;
+    void handleRequestedSessionAction($translationDrillSessionActions);
+  }
+
+  function getActiveContextCards() {
+    if (!homeState) {
+      return [];
+    }
+
+    return [
+      ...homeState.configuredGroups.flatMap((group) => group.activeCards),
+      ...homeState.ungroupedContextCards.filter((card) => card.state === 'active'),
+    ];
+  }
+
+  function syncGenerationInput() {
+    if (!homeState) {
+      return;
+    }
+
+    const activeCards = getActiveContextCards();
+
+    homeState = {
+      ...homeState,
+      challenge: {
+        ...homeState.challenge,
+        generationInput: {
+          ...homeState.challenge.generationInput,
+          activeCardCount: activeCards.length,
+          cards: activeCards,
+          suggestedSourceCardIds: activeCards.slice(0, 2).map((card) => card.cardId),
+        },
+      },
+    };
+  }
 
   function recalculateSummary() {
     if (!homeState) {
@@ -86,6 +156,7 @@
         hasVisibleContext: activeCardCount + snoozedCardCount > 0,
       },
     };
+    syncGenerationInput();
   }
 
   function shouldShowEmptyOverlay() {
@@ -265,6 +336,10 @@
     }
   }
 
+  function setFocusedCard(cardId: string | null) {
+    focusedCardId = cardId;
+  }
+
   async function postAction(payload: Record<string, unknown>): Promise<TranslationDrillActionResponse> {
     const response = await fetch(`/${lang}/translation-drills/actions`, {
       method: 'POST',
@@ -293,6 +368,7 @@
   }
 
   async function handleDraw(groupId: string) {
+    setFocusedCard(null);
     setPendingAction(`draw:${groupId}`);
     openMenuCardId = null;
 
@@ -322,6 +398,7 @@
       return;
     }
 
+    setFocusedCard(cardId);
     setPendingAction(`card:${cardId}:snooze`);
     openMenuCardId = null;
 
@@ -357,6 +434,7 @@
       return;
     }
 
+    setFocusedCard(cardId);
     dismissCardId = cardId;
     dismissReturnInDays = card.dismissSchedule?.recommendedDays ?? card.dismissSchedule?.optionDays[0] ?? 1;
     openMenuCardId = null;
@@ -416,6 +494,7 @@
       return;
     }
 
+    setFocusedCard(cardId);
     setPendingAction(`card:${cardId}:disable`);
     openMenuCardId = null;
 
@@ -482,6 +561,129 @@
 
   function isActionPending(key: string) {
     return pendingActionKey === key;
+  }
+
+  function buildChallengePrompt() {
+    if (!homeState) {
+      throw new Error('Translation Drills is not ready yet.');
+    }
+
+    const languageLabel = getLanguageByCode(lang)?.label ?? defaultLanguageLabel;
+    const generationInput = homeState.challenge.generationInput;
+    const sourceCards = generationInput.cards
+      .filter((card) => generationInput.suggestedSourceCardIds.includes(card.cardId))
+      .slice(0, 2);
+
+    if (sourceCards.length === 0) {
+      throw new Error('Draw or pin at least one active card before starting a challenge.');
+    }
+
+    const formatMeaning = (card: TranslationDrillContextCardData) => card.meaning?.replace(/^to\s+/i, '') ?? `use "${card.content}"`;
+    const [firstCard, secondCard] = sourceCards;
+    const firstMeaning = formatMeaning(firstCard);
+    const secondMeaning = secondCard ? formatMeaning(secondCard) : null;
+    const sentence = secondMeaning
+      ? `We should ${firstMeaning} this carefully before we ${secondMeaning}.`
+      : `I want to ${firstMeaning} this more clearly today.`;
+
+    return {
+      prompt: sentence,
+      sourceCardIds: sourceCards.map((card) => card.cardId),
+      languageLabel,
+    };
+  }
+
+  async function startChallenge(): Promise<TranslationDrillLocalResponse> {
+    if (!homeState) {
+      throw new Error('Translation Drills is not available right now.');
+    }
+
+    const challengeInput = buildChallengePrompt();
+    setPendingAction('challenge:next');
+
+    try {
+      const result = await postAction({
+        action: 'challenge-start',
+        challenge: {
+          prompt: challengeInput.prompt,
+          sourceCardIds: challengeInput.sourceCardIds,
+        },
+      });
+
+      if (result.action !== 'challenge-start') {
+        throw new Error('Unexpected response while starting a Translation Drills challenge.');
+      }
+
+      activeChallenge = result.challenge;
+      actionMessage = result.message;
+      return {
+        message: `${result.message} Translate to ${challengeInput.languageLabel}: "${result.challenge.prompt}"`,
+        conversationReset: true,
+      };
+    } catch (error) {
+      actionError = error instanceof Error ? error.message : 'The challenge could not be created right now.';
+      throw error instanceof Error ? error : new Error(actionError);
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  function toDrawerCard(card: TranslationDrillContextCardData): CardLibraryCardDetailData {
+    return {
+      cardId: card.cardId,
+      content: card.content,
+      meaning: card.meaning,
+      cardType: card.cardType,
+      examples: card.examples,
+      mnemonics: card.mnemonics,
+      llmInstructions: card.llmInstructions,
+      updatedAtIso: card.updatedAtIso,
+      groups: card.sourceGroup ? [card.sourceGroup] : [],
+    };
+  }
+
+  function openDrawer(cardId: string) {
+    setFocusedCard(cardId);
+    drawerCardId = cardId;
+    openMenuCardId = null;
+  }
+
+  function closeDrawer() {
+    drawerCardId = null;
+  }
+
+  async function handleRequestedSessionAction(
+    actionRequest: import('$lib/stores/translationDrillSessionActions.js').TranslationDrillSessionActionRequest,
+  ) {
+    try {
+      if (actionRequest.action === 'next') {
+        actionRequest.resolve(await startChallenge());
+        return;
+      }
+
+      if (actionRequest.action === 'draw') {
+        await handleDraw(actionRequest.groupId);
+        actionRequest.resolve({
+          message: actionMessage || 'Card drawn into Translation Drills.',
+        });
+        return;
+      }
+
+      if (actionRequest.action === 'snooze') {
+        await handleSnooze(actionRequest.cardId);
+        actionRequest.resolve({
+          message: actionMessage || 'Card snoozed.',
+        });
+        return;
+      }
+
+      openDismissDialog(actionRequest.cardId);
+      actionRequest.resolve({
+        message: 'Choose when the card should return in the dismiss dialog.',
+      });
+    } catch (error) {
+      actionRequest.reject(error instanceof Error ? error : new Error('The Translation Drills action could not be completed right now.'));
+    }
   }
 </script>
 
@@ -588,7 +790,13 @@
 
                     {#if openMenuCardId === card.cardId}
                       <div class="card-row__menu stack" style="--stack-space: var(--space-1)" role="menu">
-                        <a class="card-row__menu-link" href={`/${lang}/cards?card=${card.cardId}`}>View in Cards</a>
+                        <button
+                          type="button"
+                          class="card-row__menu-button"
+                          onclick={() => openDrawer(card.cardId)}
+                        >
+                          View card detail
+                        </button>
                         <button
                           type="button"
                           class="card-row__menu-button"
@@ -640,7 +848,13 @@
 
                     {#if openMenuCardId === card.cardId}
                       <div class="card-row__menu stack" style="--stack-space: var(--space-1)" role="menu">
-                        <a class="card-row__menu-link" href={`/${lang}/cards?card=${card.cardId}`}>View in Cards</a>
+                        <button
+                          type="button"
+                          class="card-row__menu-button"
+                          onclick={() => openDrawer(card.cardId)}
+                        >
+                          View card detail
+                        </button>
                         <button
                           type="button"
                           class="card-row__menu-button"
@@ -807,6 +1021,19 @@
         </button>
       </div>
     </div>
+  {/if}
+
+  {#if drawerCardDetail}
+    <ActiveCardDrawer
+      lang={lang}
+      card={drawerCardDetail}
+      availableGroups={availableDrawerGroups}
+      selectedIndex={0}
+      totalCount={1}
+      disabled={true}
+      allowDelete={false}
+      on:close={closeDrawer}
+    />
   {/if}
 {/if}
 

--- a/apps/web/src/lib/components/translation-drills/TranslationDrillsHome.svelte
+++ b/apps/web/src/lib/components/translation-drills/TranslationDrillsHome.svelte
@@ -949,8 +949,8 @@
             Translation Drills uses cards from your groups as practice material. Add one or more groups, then draw cards into your active context like a hand of cards.
           </p>
           <div class="translation-drills__overlay-actions cluster">
-            <a class="translation-drills__button translation-drills__button--primary" href={`/${lang}/cards`}>
-              Go to Cards
+            <a class="translation-drills__button translation-drills__button--primary" href={`/${lang}/cards/groups`}>
+              Go to Groups
             </a>
             <button
               type="button"

--- a/apps/web/src/lib/components/translation-drills/TranslationDrillsHome.test.ts
+++ b/apps/web/src/lib/components/translation-drills/TranslationDrillsHome.test.ts
@@ -120,7 +120,7 @@ describe('TranslationDrillsHome', () => {
     });
 
     expect(screen.getByRole('heading', { name: 'Add groups to start drilling' })).toBeTruthy();
-    expect(screen.getByRole('link', { name: 'Go to Cards' }).getAttribute('href')).toBe('/zh/cards');
+    expect(screen.getByRole('link', { name: 'Go to Groups' }).getAttribute('href')).toBe('/zh/cards/groups');
   });
 
   it('draws cards from a pile and updates the visible count', async () => {

--- a/apps/web/src/lib/server/chat.test.ts
+++ b/apps/web/src/lib/server/chat.test.ts
@@ -101,7 +101,7 @@ describe('handleStudyPuckChatRequest', () => {
         generateStructured,
       }),
     ).resolves.toEqual({
-      message: 'Available commands in Translation Drills: /add, /lang, /help, /next, /dismiss, and /draw.',
+      message: 'Available commands in Translation Drills: /add, /lang, /help, /next, /dismiss, /draw, and /context.',
       suggestions: [],
     });
 

--- a/apps/web/src/lib/stores/commandBar.ts
+++ b/apps/web/src/lib/stores/commandBar.ts
@@ -52,7 +52,17 @@ export type CommandResponder = (
   routeContext: RouteContext,
   /** The captured store state at the moment the user's message was submitted. */
   submissionState: CommandBarState,
-) => ChatResponse | string | null | Promise<ChatResponse | string | null>;
+) => CommandResponderResult | Promise<CommandResponderResult>;
+
+export type CommandResponderResult =
+  | ChatResponse
+  | {
+      message: string;
+      suggestions?: ChatSuggestion[];
+      conversationReset?: boolean;
+    }
+  | string
+  | null;
 
 const DEFAULT_CONTEXT_WIDTH: Record<CommandContext, number> = {
   global: 62,
@@ -165,6 +175,7 @@ function createCommandBarStore() {
     clearPendingTimer();
     let responseContent: string;
     let responseSuggestions: ChatSuggestion[] = [];
+    let conversationReset = false;
 
     try {
       const result = (await responder?.(input, routeContext, submissionState)) ?? buildAssistantResponse(input, routeContext);
@@ -172,6 +183,7 @@ function createCommandBarStore() {
       if (result !== null && typeof result === 'object' && 'message' in result) {
         responseContent = result.message;
         responseSuggestions = result.suggestions ?? [];
+        conversationReset = 'conversationReset' in result && Boolean(result.conversationReset);
       } else {
         responseContent = result ?? buildAssistantResponse(input, routeContext);
       }
@@ -184,11 +196,18 @@ function createCommandBarStore() {
         return state;
       }
 
+      const nextMessages = conversationReset
+        ? [
+            createMessage('system', 'New conversation'),
+            createMessage('assistant', responseContent, responseSuggestions),
+          ]
+        : [...state.messages, createMessage('assistant', responseContent, responseSuggestions)];
+
       return {
         ...state,
         isWaiting: false,
         lastSubmittedInput: null,
-        messages: [...state.messages, createMessage('assistant', responseContent, responseSuggestions)],
+        messages: nextMessages,
         desktopConversationCollapsed: false,
         mobileSheetOpen: true,
         unreadCount: 0,
@@ -456,6 +475,23 @@ function createCommandBarStore() {
       store.update((state) => ({
         ...state,
         messages: [...state.messages, createMessage('assistant', content)],
+        desktopConversationCollapsed: false,
+        mobileSheetOpen: true,
+        unreadCount: 0,
+      }));
+    },
+
+    applyLocalResponse(response: { message: string; suggestions?: ChatSuggestion[]; conversationReset?: boolean }) {
+      store.update((state) => ({
+        ...state,
+        isWaiting: false,
+        lastSubmittedInput: null,
+        messages: response.conversationReset
+          ? [
+              createMessage('system', 'New conversation'),
+              createMessage('assistant', response.message, response.suggestions ?? []),
+            ]
+          : [...state.messages, createMessage('assistant', response.message, response.suggestions ?? [])],
         desktopConversationCollapsed: false,
         mobileSheetOpen: true,
         unreadCount: 0,

--- a/apps/web/src/lib/stores/translationDrillSession.ts
+++ b/apps/web/src/lib/stores/translationDrillSession.ts
@@ -1,0 +1,60 @@
+import { writable } from 'svelte/store';
+import type {
+  TranslationDrillContextCardData,
+  TranslationDrillHomeData,
+  TranslationDrillActionResult,
+} from '$lib/server/translation-drills.js';
+
+export type ActiveTranslationDrillChallenge = Extract<TranslationDrillActionResult, { action: 'challenge-start' }>['challenge'];
+
+export type TranslationDrillSessionState = {
+  lang: string | null;
+  activeChallenge: ActiveTranslationDrillChallenge | null;
+  generationInput: TranslationDrillHomeData['challenge']['generationInput'] | null;
+  configuredGroups: Array<{ groupId: string; groupName: string }>;
+  activeCards: TranslationDrillContextCardData[];
+  focusedCardId: string | null;
+};
+
+const initialState: TranslationDrillSessionState = {
+  lang: null,
+  activeChallenge: null,
+  generationInput: null,
+  configuredGroups: [],
+  activeCards: [],
+  focusedCardId: null,
+};
+
+function createTranslationDrillSessionStore() {
+  const { subscribe, update } = writable<TranslationDrillSessionState>(initialState);
+
+  return {
+    subscribe,
+    sync(
+      input: {
+        lang: string | null;
+        home: TranslationDrillHomeData | null;
+        activeChallenge: ActiveTranslationDrillChallenge | null;
+        focusedCardId: string | null;
+      },
+    ) {
+      update((state) => ({
+        ...state,
+        lang: input.lang,
+        activeChallenge: input.activeChallenge,
+        generationInput: input.home?.challenge.generationInput ?? null,
+        configuredGroups: input.home?.configuredGroups.map((group) => ({
+          groupId: group.groupId,
+          groupName: group.groupName,
+        })) ?? [],
+        activeCards: input.home?.challenge.generationInput.cards ?? [],
+        focusedCardId: input.focusedCardId,
+      }));
+    },
+    reset() {
+      update(() => initialState);
+    },
+  };
+}
+
+export const translationDrillSession = createTranslationDrillSessionStore();

--- a/apps/web/src/lib/stores/translationDrillSessionActions.ts
+++ b/apps/web/src/lib/stores/translationDrillSessionActions.ts
@@ -1,0 +1,77 @@
+import { writable } from 'svelte/store';
+
+export type TranslationDrillLocalResponse = {
+  message: string;
+  conversationReset?: boolean;
+};
+
+export type TranslationDrillSessionActionRequest =
+  | {
+      actionId: number;
+      action: 'next';
+      resolve: (response: TranslationDrillLocalResponse) => void;
+      reject: (error: Error) => void;
+    }
+  | {
+      actionId: number;
+      action: 'draw';
+      groupId: string;
+      resolve: (response: TranslationDrillLocalResponse) => void;
+      reject: (error: Error) => void;
+    }
+  | {
+      actionId: number;
+      action: 'snooze' | 'dismiss';
+      cardId: string;
+      resolve: (response: TranslationDrillLocalResponse) => void;
+      reject: (error: Error) => void;
+    };
+
+type TranslationDrillSessionActionPayload =
+  | {
+      action: 'next';
+    }
+  | {
+      action: 'draw';
+      groupId: string;
+    }
+  | {
+      action: 'snooze' | 'dismiss';
+      cardId: string;
+    };
+
+function createTranslationDrillSessionActionsStore() {
+  const { subscribe, set } = writable<TranslationDrillSessionActionRequest | null>(null);
+  let actionCounter = 0;
+
+  function dispatch(request: TranslationDrillSessionActionPayload) {
+    actionCounter += 1;
+
+    return new Promise<TranslationDrillLocalResponse>((resolve, reject) => {
+      set({
+        actionId: actionCounter,
+        ...request,
+        resolve,
+        reject,
+      } as TranslationDrillSessionActionRequest);
+    });
+  }
+
+  return {
+    subscribe,
+    requestNext() {
+      return dispatch({ action: 'next' });
+    },
+    requestDraw(groupId: string) {
+      return dispatch({ action: 'draw', groupId });
+    },
+    requestSnooze(cardId: string) {
+      return dispatch({ action: 'snooze', cardId });
+    },
+    requestDismiss(cardId: string) {
+      return dispatch({ action: 'dismiss', cardId });
+    },
+  };
+}
+
+export const translationDrillSessionActions = createTranslationDrillSessionActionsStore();


### PR DESCRIPTION
## Summary
- sync Translation Drills challenge state into the shared command bar
- add local Translation Drills slash commands and conversation reset handling
- open drill card details in the shared drawer and cover the new flow with tests

Closes #199