### PR TITLE
Add Translation Drills draw-pile setup to Cards groups

### DIFF
--- a/apps/web/src/lib/cards/groups.test.ts
+++ b/apps/web/src/lib/cards/groups.test.ts
@@ -5,12 +5,12 @@ describe('sortCardLibraryGroupItems', () => {
   it('sorts groups alphabetically by name', () => {
     expect(
       sortCardLibraryGroupItems([
-        { groupId: 'g2', groupName: 'Travel', description: null, activeCardCount: 1 },
-        { groupId: 'g1', groupName: 'Daily', description: null, activeCardCount: 0 },
+        { groupId: 'g2', groupName: 'Travel', description: null, activeCardCount: 1, translationDrills: { enabled: false, drawPileName: null, pileSizeLimit: 10 } },
+        { groupId: 'g1', groupName: 'Daily', description: null, activeCardCount: 0, translationDrills: { enabled: true, drawPileName: 'Daily drills', pileSizeLimit: 4 } },
       ]),
     ).toEqual([
-      { groupId: 'g1', groupName: 'Daily', description: null, activeCardCount: 0 },
-      { groupId: 'g2', groupName: 'Travel', description: null, activeCardCount: 1 },
+      { groupId: 'g1', groupName: 'Daily', description: null, activeCardCount: 0, translationDrills: { enabled: true, drawPileName: 'Daily drills', pileSizeLimit: 4 } },
+      { groupId: 'g2', groupName: 'Travel', description: null, activeCardCount: 1, translationDrills: { enabled: false, drawPileName: null, pileSizeLimit: 10 } },
     ]);
   });
 });
@@ -18,10 +18,10 @@ describe('sortCardLibraryGroupItems', () => {
 describe('buildDeleteGroupMessage', () => {
   it('uses concise copy for empty groups and dissociation copy for non-empty groups', () => {
     expect(
-      buildDeleteGroupMessage({ groupId: 'g1', groupName: 'Greetings', description: null, activeCardCount: 0 }),
+      buildDeleteGroupMessage({ groupId: 'g1', groupName: 'Greetings', description: null, activeCardCount: 0, translationDrills: { enabled: false, drawPileName: null, pileSizeLimit: 10 } }),
     ).toBe('Are you sure? This cannot be undone.');
     expect(
-      buildDeleteGroupMessage({ groupId: 'g2', groupName: 'Daily', description: null, activeCardCount: 2 }),
+      buildDeleteGroupMessage({ groupId: 'g2', groupName: 'Daily', description: null, activeCardCount: 2, translationDrills: { enabled: false, drawPileName: null, pileSizeLimit: 10 } }),
     ).toContain('This group has 2 cards.');
   });
 });

--- a/apps/web/src/lib/server/cards.test.ts
+++ b/apps/web/src/lib/server/cards.test.ts
@@ -6,6 +6,7 @@ import {
   loadCardLibraryGroupsData,
   loadGroupDetailData,
   loadActiveCardDetailData,
+  updateGroupTranslationDrillsForLanguage,
 } from './cards.js';
 
 describe('Card Library server helpers', () => {
@@ -44,6 +45,17 @@ describe('Card Library server helpers', () => {
         createdAt: null,
         metadata: null,
         activeCardCount: 1,
+      },
+    ]),
+    listTranslationDrillDrawPileGroups: vi.fn(async () => [
+      {
+        groupId: 'group-chat',
+        groupName: 'Chat',
+        drawPileName: 'Chat practice',
+        pileSizeLimit: 6,
+        remainingCardCount: 4,
+        activeCards: [],
+        snoozedCards: [],
       },
     ]),
     getGroupWithActiveCardCount: vi.fn(async () => ({
@@ -138,6 +150,11 @@ describe('Card Library server helpers', () => {
       groupName: 'Chat',
       description: 'Conversation cards',
       activeCardCount: 1,
+      translationDrills: {
+        enabled: true,
+        drawPileName: 'Chat practice',
+        pileSizeLimit: 6,
+      },
     });
     expect(result.cards.filters).toEqual({
       searchText: 'chat',
@@ -197,7 +214,47 @@ describe('Card Library server helpers', () => {
     const result = await loadCardLibraryGroupsData('user-1', 'zh', database, baseDeps);
 
     expect(result.items.map((group) => group.groupName)).toEqual(['Alpha', 'Zeta']);
+    expect(result.items[0]?.translationDrills).toEqual({
+      enabled: false,
+      drawPileName: null,
+      pileSizeLimit: 10,
+    });
+    expect(result.items[1]?.translationDrills).toEqual({
+      enabled: false,
+      drawPileName: null,
+      pileSizeLimit: 10,
+    });
     expect(result.totalCount).toBe(2);
+  });
+
+  it('updates Translation Drills settings for a group', async () => {
+    const result = await updateGroupTranslationDrillsForLanguage(
+      'user-1',
+      'zh',
+      'group-chat',
+      {
+        enabled: true,
+        drawPileName: 'Focused chat',
+        pileSizeLimit: 8,
+      },
+      database,
+      {
+        getActiveUserLanguages: baseDeps.getActiveUserLanguages,
+        upsertTranslationDrillDrawPile: vi.fn(async () => ({
+          groupId: 'group-chat',
+          groupName: 'Chat',
+          enabled: true,
+          drawPileName: 'Focused chat',
+          pileSizeLimit: 8,
+        })),
+      },
+    );
+
+    expect(result).toEqual({
+      enabled: true,
+      drawPileName: 'Focused chat',
+      pileSizeLimit: 8,
+    });
   });
 
   it('excludes current group members from addable cards in group detail', async () => {

--- a/apps/web/src/lib/server/cards.test.ts
+++ b/apps/web/src/lib/server/cards.test.ts
@@ -7,6 +7,7 @@ import {
   loadGroupDetailData,
   loadActiveCardDetailData,
   updateGroupTranslationDrillsForLanguage,
+  updateGroupDetailForLanguage,
 } from './cards.js';
 
 describe('Card Library server helpers', () => {
@@ -115,6 +116,18 @@ describe('Card Library server helpers', () => {
         metadata: null,
       },
     ]),
+    updateGroup: vi.fn(async () => ({
+      userId: 'user-1',
+      languageId: 'zh',
+      groupId: 'group-chat',
+      groupName: 'Focused Chat',
+      description: 'Conversation cards',
+      embedding: null,
+      embeddingModel: null,
+      embeddingGeneratedAt: null,
+      createdAt: null,
+      metadata: null,
+    })),
   };
 
   it('loads Card Library data with the active query/filter state and filtered ids', async () => {
@@ -254,6 +267,38 @@ describe('Card Library server helpers', () => {
       enabled: true,
       drawPileName: 'Focused chat',
       pileSizeLimit: 8,
+    });
+  });
+
+  it('preserves Translation Drills config when updating group metadata', async () => {
+    const result = await updateGroupDetailForLanguage(
+      'user-1',
+      'zh',
+      'group-chat',
+      {
+        groupName: 'Focused Chat',
+        description: 'Conversation cards',
+      },
+      database,
+      {
+        getActiveUserLanguages: baseDeps.getActiveUserLanguages,
+        getGroupWithActiveCardCount: baseDeps.getGroupWithActiveCardCount,
+        getGroups: baseDeps.getGroups,
+        updateGroup: baseDeps.updateGroup,
+        listTranslationDrillDrawPileGroups: baseDeps.listTranslationDrillDrawPileGroups,
+      },
+    );
+
+    expect(result).toEqual({
+      groupId: 'group-chat',
+      groupName: 'Focused Chat',
+      description: 'Conversation cards',
+      activeCardCount: 1,
+      translationDrills: {
+        enabled: true,
+        drawPileName: 'Chat practice',
+        pileSizeLimit: 6,
+      },
     });
   });
 

--- a/apps/web/src/lib/server/cards.ts
+++ b/apps/web/src/lib/server/cards.ts
@@ -11,8 +11,10 @@ import {
   listActiveCards,
   listActiveCardsInGroup,
   listGroupsWithActiveCardCounts,
+  listTranslationDrillDrawPileGroups,
   removeCardFromGroup,
   softDeleteActiveCards,
+  upsertTranslationDrillDrawPile,
   updateActiveCard,
   updateGroup,
   type ActiveCardDetail,
@@ -42,6 +44,7 @@ type LoaderDeps = {
   getActiveUserLanguages: typeof getActiveUserLanguages;
   listActiveCards: typeof listActiveCards;
   listGroupsWithActiveCardCounts: typeof listGroupsWithActiveCardCounts;
+  listTranslationDrillDrawPileGroups: typeof listTranslationDrillDrawPileGroups;
   getGroupWithActiveCardCount: typeof getGroupWithActiveCardCount;
   listActiveCardsInGroup: typeof listActiveCardsInGroup;
   getActiveCardWithGroups: typeof getActiveCardWithGroups;
@@ -52,6 +55,7 @@ const defaultLoaderDeps: LoaderDeps = {
   getActiveUserLanguages,
   listActiveCards,
   listGroupsWithActiveCardCounts,
+  listTranslationDrillDrawPileGroups,
   getGroupWithActiveCardCount,
   listActiveCardsInGroup,
   getActiveCardWithGroups,
@@ -71,6 +75,12 @@ export class CardLibraryRequestError extends Error {
 export type CardLibraryGroupData = {
   groupId: string;
   groupName: string;
+};
+
+export type TranslationDrillGroupConfigData = {
+  enabled: boolean;
+  drawPileName: string | null;
+  pileSizeLimit: number;
 };
 
 export type CardLibraryGroupFilterOption = CardLibraryGroupData & {
@@ -119,6 +129,7 @@ export type GroupDetailData = {
     groupName: string;
     description: string | null;
     activeCardCount: number;
+    translationDrills: TranslationDrillGroupConfigData;
   };
   cards: CardLibraryData;
   addableCards: {
@@ -132,6 +143,7 @@ export type CardLibraryGroupListItemData = {
   groupName: string;
   description: string | null;
   activeCardCount: number;
+  translationDrills: TranslationDrillGroupConfigData;
 };
 
 export type CardLibraryGroupsData = {
@@ -147,6 +159,23 @@ const cardLibraryGroupCreateSchema = z.object({
 const groupDetailGroupUpdateSchema = z.object({
   groupName: editableGroupNameSchema,
   description: editableCardOptionalTextSchema.optional().default(null),
+});
+
+const DEFAULT_TRANSLATION_DRILL_PILE_SIZE_LIMIT = 10;
+
+const translationDrillGroupConfigUpdateSchema = z.object({
+  enabled: z.boolean(),
+  drawPileName: z
+    .union([z.string(), z.null(), z.undefined()])
+    .transform((value) => {
+      if (typeof value !== 'string') {
+        return null;
+      }
+
+      const trimmed = value.trim();
+      return trimmed.length > 0 ? trimmed : null;
+    }),
+  pileSizeLimit: z.coerce.number().int().min(1, 'Pile size limit must be at least 1.').max(100, 'Pile size limit must be 100 or fewer.'),
 });
 
 function normalizeStringList(value: unknown): string[] {
@@ -301,12 +330,43 @@ function mapGroupFilterOption(group: GroupWithActiveCardCount): CardLibraryGroup
   };
 }
 
-function mapGroupListItem(group: GroupWithActiveCardCount): CardLibraryGroupListItemData {
+function createDefaultTranslationDrillGroupConfig(): TranslationDrillGroupConfigData {
+  return {
+    enabled: false,
+    drawPileName: null,
+    pileSizeLimit: DEFAULT_TRANSLATION_DRILL_PILE_SIZE_LIMIT,
+  };
+}
+
+function createTranslationDrillGroupConfigLookup(
+  groups: Array<{
+    groupId: string;
+    drawPileName: string | null;
+    pileSizeLimit: number;
+  }>,
+) {
+  return new Map<string, TranslationDrillGroupConfigData>(
+    groups.map((group) => [
+      group.groupId,
+      {
+        enabled: true,
+        drawPileName: group.drawPileName,
+        pileSizeLimit: group.pileSizeLimit ?? DEFAULT_TRANSLATION_DRILL_PILE_SIZE_LIMIT,
+      },
+    ]),
+  );
+}
+
+function mapGroupListItem(
+  group: GroupWithActiveCardCount,
+  translationDrillConfig = createDefaultTranslationDrillGroupConfig(),
+): CardLibraryGroupListItemData {
   return {
     groupId: group.groupId,
     groupName: group.groupName,
     description: group.description ?? null,
     activeCardCount: group.activeCardCount,
+    translationDrills: translationDrillConfig,
   };
 }
 
@@ -504,10 +564,17 @@ export async function loadCardLibraryGroupsData(
 ): Promise<CardLibraryGroupsData> {
   await assertUserHasLanguage(userId, languageId, database, deps);
 
-  const groups = await deps.listGroupsWithActiveCardCounts(userId, languageId, database as never);
+  const [groups, translationDrillGroups] = await Promise.all([
+    deps.listGroupsWithActiveCardCounts(userId, languageId, database as never),
+    deps.listTranslationDrillDrawPileGroups(userId, languageId, {}, database as never),
+  ]);
+  const translationDrillConfigByGroupId = createTranslationDrillGroupConfigLookup(translationDrillGroups);
 
   return {
-    items: sortGroupsByName(groups.map((group) => mapGroupListItem(group))),
+    items: sortGroupsByName(groups.map((group) => mapGroupListItem(
+      group,
+      translationDrillConfigByGroupId.get(group.groupId) ?? createDefaultTranslationDrillGroupConfig(),
+    ))),
     totalCount: groups.length,
   };
 }
@@ -524,7 +591,7 @@ export async function loadGroupDetailData(
 
   const parsedGroupId = parseGroupId(groupId);
   const filters = parseFilters(url);
-  const [group, items, allActiveCards, availableGroups] = await Promise.all([
+  const [group, items, allActiveCards, availableGroups, translationDrillGroups] = await Promise.all([
     deps.getGroupWithActiveCardCount(userId, languageId, parsedGroupId, database as never),
     deps.listActiveCardsInGroup(
       userId,
@@ -538,11 +605,14 @@ export async function loadGroupDetailData(
     ),
     deps.listActiveCards(userId, languageId, {}, database as never),
     deps.listGroupsWithActiveCardCounts(userId, languageId, database as never),
+    deps.listTranslationDrillDrawPileGroups(userId, languageId, {}, database as never),
   ]);
 
   if (!group) {
     throw new CardLibraryRequestError(404, 'Group not found.');
   }
+
+  const translationDrillConfigByGroupId = createTranslationDrillGroupConfigLookup(translationDrillGroups);
 
   return {
     group: {
@@ -550,6 +620,7 @@ export async function loadGroupDetailData(
       groupName: group.groupName,
       description: group.description ?? null,
       activeCardCount: group.activeCardCount,
+      translationDrills: translationDrillConfigByGroupId.get(parsedGroupId) ?? createDefaultTranslationDrillGroupConfig(),
     },
     cards: {
       items: items.map((item) => mapCardListItem(item)),
@@ -803,6 +874,62 @@ export async function updateGroupDetailForLanguage(
     description: updatedGroup.description ?? null,
     activeCardCount: existingGroup.activeCardCount,
   };
+}
+
+export async function updateGroupTranslationDrillsForLanguage(
+  userId: string,
+  languageId: string,
+  groupId: unknown,
+  input: unknown,
+  database: DatabaseClient,
+  deps: {
+    getActiveUserLanguages: typeof getActiveUserLanguages;
+    upsertTranslationDrillDrawPile: typeof upsertTranslationDrillDrawPile;
+  } = {
+    getActiveUserLanguages,
+    upsertTranslationDrillDrawPile,
+  },
+): Promise<TranslationDrillGroupConfigData> {
+  await assertUserHasLanguage(userId, languageId, database, deps);
+
+  const parsedGroupId = parseGroupId(groupId);
+  const parsedInput = translationDrillGroupConfigUpdateSchema.safeParse(input);
+
+  if (!parsedInput.success) {
+    throw new CardLibraryRequestError(
+      400,
+      parsedInput.error.issues[0]?.message ?? 'Translation Drills settings are invalid.',
+    );
+  }
+
+  try {
+    const updatedConfig = await deps.upsertTranslationDrillDrawPile(
+      userId,
+      languageId,
+      parsedGroupId,
+      {
+        enabled: parsedInput.data.enabled,
+        drawPileName: parsedInput.data.drawPileName,
+        pileSizeLimit: parsedInput.data.pileSizeLimit,
+      },
+      database as never,
+    );
+
+    return {
+      enabled: updatedConfig.enabled,
+      drawPileName: updatedConfig.drawPileName,
+      pileSizeLimit: updatedConfig.pileSizeLimit,
+    };
+  } catch (error) {
+    if (
+      error instanceof Error
+      && error.message === 'That group is not available for Translation Drills.'
+    ) {
+      throw new CardLibraryRequestError(404, error.message);
+    }
+
+    throw error;
+  }
 }
 
 export async function addCardsToGroupDetailForLanguage(

--- a/apps/web/src/lib/server/cards.ts
+++ b/apps/web/src/lib/server/cards.ts
@@ -407,10 +407,11 @@ async function ensureUniqueGroupName(
   database: DatabaseClient,
   options?: {
     excludeGroupId?: string;
+    getGroups?: typeof getGroups;
   },
 ) {
   const normalizedName = normalizeGroupName(groupName);
-  const existingGroups = await getGroups(userId, languageId, database as never);
+  const existingGroups = await (options?.getGroups ?? getGroups)(userId, languageId, database as never);
   const duplicateGroup = existingGroups.find((group) => {
     if (options?.excludeGroupId && group.groupId === options.excludeGroupId) {
       return false;
@@ -826,8 +827,21 @@ export async function updateGroupDetailForLanguage(
   groupId: unknown,
   input: unknown,
   database: DatabaseClient,
+  deps: {
+    getActiveUserLanguages: typeof getActiveUserLanguages;
+    getGroupWithActiveCardCount: typeof getGroupWithActiveCardCount;
+    getGroups: typeof getGroups;
+    updateGroup: typeof updateGroup;
+    listTranslationDrillDrawPileGroups: typeof listTranslationDrillDrawPileGroups;
+  } = {
+    getActiveUserLanguages,
+    getGroupWithActiveCardCount,
+    getGroups,
+    updateGroup,
+    listTranslationDrillDrawPileGroups,
+  },
 ) {
-  await assertUserHasLanguage(userId, languageId, database);
+  await assertUserHasLanguage(userId, languageId, database, deps);
 
   const parsedGroupId = parseGroupId(groupId);
   const parsedInput = groupDetailGroupUpdateSchema.safeParse(input);
@@ -839,7 +853,7 @@ export async function updateGroupDetailForLanguage(
     );
   }
 
-  const existingGroup = await getGroupWithActiveCardCount(userId, languageId, parsedGroupId, database as never);
+  const existingGroup = await deps.getGroupWithActiveCardCount(userId, languageId, parsedGroupId, database as never);
 
   if (!existingGroup) {
     throw new CardLibraryRequestError(404, 'Group not found.');
@@ -850,10 +864,13 @@ export async function updateGroupDetailForLanguage(
     languageId,
     parsedInput.data.groupName,
     database,
-    { excludeGroupId: parsedGroupId },
+    {
+      excludeGroupId: parsedGroupId,
+      getGroups: deps.getGroups,
+    },
   );
 
-  const updatedGroup = await updateGroup(
+  const updatedGroup = await deps.updateGroup(
     userId,
     languageId,
     parsedGroupId,
@@ -868,11 +885,16 @@ export async function updateGroupDetailForLanguage(
     throw new CardLibraryRequestError(404, 'Group not found.');
   }
 
+  const translationDrillConfig = createTranslationDrillGroupConfigLookup(
+    await deps.listTranslationDrillDrawPileGroups(userId, languageId, database as never),
+  ).get(parsedGroupId) ?? createDefaultTranslationDrillGroupConfig();
+
   return {
     groupId: updatedGroup.groupId,
     groupName: updatedGroup.groupName,
     description: updatedGroup.description ?? null,
     activeCardCount: existingGroup.activeCardCount,
+    translationDrills: translationDrillConfig,
   };
 }
 

--- a/apps/web/src/routes/[lang]/cards/groups/+page.svelte
+++ b/apps/web/src/routes/[lang]/cards/groups/+page.svelte
@@ -321,6 +321,14 @@
           >
             <div class="groups-page__name stack" style="--stack-space: var(--space-1)">
               <h2>{group.groupName}</h2>
+              {#if group.translationDrills.enabled}
+                <div class="groups-page__meta cluster" style="--cluster-space: var(--space-2)">
+                  <span class="groups-page__badge">Translation Drills</span>
+                  <span class="groups-page__meta-copy">
+                    {group.translationDrills.drawPileName ?? `${group.translationDrills.pileSizeLimit}-card pile`}
+                  </span>
+                </div>
+              {/if}
               <p class="groups-page__mobile-count">{group.activeCardCount}</p>
             </div>
             <p class="groups-page__description">{group.description ?? 'No description yet.'}</p>
@@ -452,7 +460,8 @@
   .groups-page__description,
   .groups-page__count,
   .groups-page__mobile-count,
-  .groups-page__feedback-title {
+  .groups-page__feedback-title,
+  .groups-page__meta-copy {
     color: var(--color-text-secondary);
     font-family: var(--font-ui);
   }
@@ -550,6 +559,25 @@
 
   .groups-page__mobile-count {
     display: none;
+  }
+
+  .groups-page__meta {
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .groups-page__badge {
+    display: inline-flex;
+    align-items: center;
+    min-block-size: 1.5rem;
+    padding-inline: var(--space-2);
+    border-radius: var(--radius-pill);
+    background: color-mix(in srgb, var(--color-primary-subtle) 85%, var(--color-surface) 15%);
+    color: var(--color-text-accent);
+    font-family: var(--font-ui);
+    font-size: var(--font-size-caption);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
   }
 
   .groups-page__delete {

--- a/apps/web/src/routes/[lang]/cards/groups/[groupId]/+page.svelte
+++ b/apps/web/src/routes/[lang]/cards/groups/[groupId]/+page.svelte
@@ -80,6 +80,11 @@
   let groupNameInput: HTMLInputElement | null = null;
   let groupDescriptionInput: HTMLTextAreaElement | null = null;
   let groupSavePending = false;
+  let translationDrillsEnabled = data.groupDetail.group.translationDrills.enabled;
+  let translationDrillDrawPileName = data.groupDetail.group.translationDrills.drawPileName ?? '';
+  let translationDrillPileSizeLimit = String(data.groupDetail.group.translationDrills.pileSizeLimit);
+  let translationDrillsSavePending = false;
+  let translationDrillsError = '';
 
   let deleteDialogOpen = false;
   let deleteGroupPending = false;
@@ -148,6 +153,10 @@
     group = data.groupDetail.group;
     cards = data.groupDetail.cards;
     addableCards = data.groupDetail.addableCards;
+    translationDrillsEnabled = data.groupDetail.group.translationDrills.enabled;
+    translationDrillDrawPileName = data.groupDetail.group.translationDrills.drawPileName ?? '';
+    translationDrillPileSizeLimit = String(data.groupDetail.group.translationDrills.pileSizeLimit);
+    translationDrillsError = '';
     previousGroupDetail = data.groupDetail;
   }
 
@@ -183,6 +192,10 @@
   $: hasActiveFilters = searchQuery.trim().length > 0 || selectedType !== null;
   $: filteredAddableCards = filterAddableGroupCards(addableCards.items, addCardsSearchQuery);
   $: sortedAssignableGroups = sortCardLibraryGroups(cards.availableGroups.filter((item) => item.groupId !== currentGroupId));
+  $: translationDrillsDirty =
+    translationDrillsEnabled !== group.translationDrills.enabled
+    || translationDrillDrawPileName.trim() !== (group.translationDrills.drawPileName ?? '')
+    || Number(translationDrillPileSizeLimit) !== group.translationDrills.pileSizeLimit;
 
   function scheduleFilterNavigation(nextFilterState: string) {
     if (filterSyncTimer) {
@@ -716,6 +729,54 @@
       firstElement?.focus();
     }
   }
+
+  async function saveTranslationDrillsSettings() {
+    if (translationDrillsSavePending || !currentLang) {
+      return;
+    }
+
+    translationDrillsSavePending = true;
+    translationDrillsError = '';
+    actionFeedback = null;
+
+    try {
+      const response = await fetch(`/${currentLang}/cards/groups/${currentGroupId}/actions`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          action: 'update-translation-drills',
+          enabled: translationDrillsEnabled,
+          drawPileName: translationDrillDrawPileName,
+          pileSizeLimit: translationDrillPileSizeLimit,
+        }),
+      });
+
+      const responseBody = (await response.json().catch(() => null)) as
+        | {
+            translationDrills?: GroupDetailData['group']['translationDrills'];
+            message?: string;
+          }
+        | null;
+
+      if (!response.ok || !responseBody?.translationDrills) {
+        throw new Error(responseBody?.message ?? 'Translation Drills settings could not be updated right now.');
+      }
+
+      group = {
+        ...group,
+        translationDrills: responseBody.translationDrills,
+      };
+      translationDrillsEnabled = responseBody.translationDrills.enabled;
+      translationDrillDrawPileName = responseBody.translationDrills.drawPileName ?? '';
+      translationDrillPileSizeLimit = String(responseBody.translationDrills.pileSizeLimit);
+    } catch (error) {
+      translationDrillsError = error instanceof Error ? error.message : 'Translation Drills settings could not be updated right now.';
+    } finally {
+      translationDrillsSavePending = false;
+    }
+  }
 </script>
 
 <svelte:window on:keydown={handleWindowKeydown} />
@@ -797,6 +858,75 @@
       </div>
     </div>
   </header>
+
+  <section class="group-detail-page__translation-drills stack" style="--stack-space: var(--space-3)">
+    <div class="group-detail-page__translation-drills-header cluster">
+      <div class="stack" style="--stack-space: var(--space-1)">
+        <p class="group-detail-page__translation-drills-eyebrow">Translation Drills</p>
+        <h2>Draw pile setup</h2>
+        <p class="group-detail-page__translation-drills-copy">
+          Enable this group as a Translation Drills draw pile so the drills screen can draw cards from it.
+        </p>
+      </div>
+    </div>
+
+    <label class="group-detail-page__translation-drills-toggle">
+      <input
+        type="checkbox"
+        bind:checked={translationDrillsEnabled}
+        disabled={translationDrillsSavePending}
+      />
+      <span>Use this group in Translation Drills</span>
+    </label>
+
+    {#if translationDrillsEnabled}
+      <div class="group-detail-page__translation-drills-fields">
+        <label class="stack" style="--stack-space: var(--space-1)">
+          <span class="group-detail-page__translation-drills-label">Draw pile label</span>
+          <input
+            type="text"
+            class="group-detail-page__translation-drills-input"
+            bind:value={translationDrillDrawPileName}
+            placeholder={`${group.groupName} draw pile`}
+            disabled={translationDrillsSavePending}
+          />
+        </label>
+
+        <label class="stack" style="--stack-space: var(--space-1)">
+          <span class="group-detail-page__translation-drills-label">Active pile limit</span>
+          <input
+            type="number"
+            min="1"
+            max="100"
+            class="group-detail-page__translation-drills-input"
+            bind:value={translationDrillPileSizeLimit}
+            disabled={translationDrillsSavePending}
+          />
+        </label>
+      </div>
+    {/if}
+
+    {#if translationDrillsError}
+      <p class="group-detail-page__error" role="alert">{translationDrillsError}</p>
+    {/if}
+
+    <div class="group-detail-page__translation-drills-actions cluster">
+      <button
+        type="button"
+        class="group-detail-page__translation-drills-button"
+        disabled={translationDrillsSavePending || !translationDrillsDirty}
+        on:click={() => void saveTranslationDrillsSettings()}
+      >
+        {translationDrillsSavePending
+          ? 'Saving...'
+          : translationDrillsEnabled && !group.translationDrills.enabled
+            ? 'Enable Translation Drills'
+            : !translationDrillsEnabled && group.translationDrills.enabled
+              ? 'Remove from Translation Drills'
+              : 'Save Translation Drills settings'}
+      </button>
+    </div>
+  </section>
 
   <div class="group-detail-page__toolbar">
     <CardListFilterBar
@@ -1127,6 +1257,20 @@
     align-items: end;
   }
 
+  .group-detail-page__translation-drills {
+    padding: var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface);
+  }
+
+  .group-detail-page__translation-drills-header,
+  .group-detail-page__translation-drills-actions {
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
   .group-detail-page__back-link,
   .group-detail-page__count,
   .group-detail-page__feedback-title,
@@ -1134,14 +1278,16 @@
   .group-detail-row__updated,
   .group-detail-page__description,
   .group-detail-page__drawer-row-empty,
-  .group-detail-page__drawer-row-updated {
+  .group-detail-page__drawer-row-updated,
+  .group-detail-page__translation-drills-copy,
+  .group-detail-page__translation-drills-label,
+  .group-detail-page__translation-drills-eyebrow {
     color: var(--color-text-secondary);
     font-family: var(--font-ui);
   }
 
   .group-detail-page h1,
   .group-detail-page h2,
-  .group-detail-page h3,
   .group-detail-page p {
     margin: 0;
   }
@@ -1172,7 +1318,8 @@
 
   .group-detail-page__name-input,
   .group-detail-page__description-input,
-  .group-detail-page__drawer-search-input {
+  .group-detail-page__drawer-search-input,
+  .group-detail-page__translation-drills-input {
     inline-size: 100%;
     min-block-size: 2.75rem;
     padding: 0.7rem 0.95rem;
@@ -1197,7 +1344,8 @@
   .group-detail-page__toolbar-button,
   .group-detail-page__state-cta,
   .group-detail-page__dialog-button,
-  .group-detail-page__drawer-submit {
+  .group-detail-page__drawer-submit,
+  .group-detail-page__translation-drills-button {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -1214,10 +1362,36 @@
 
   .group-detail-page__toolbar-button,
   .group-detail-page__drawer-submit,
-  .group-detail-page__dialog-button--primary {
+  .group-detail-page__dialog-button--primary,
+  .group-detail-page__translation-drills-button {
     border-color: var(--color-primary);
     background: var(--color-primary);
     color: var(--color-text-inverse);
+  }
+
+  .group-detail-page__translation-drills-eyebrow {
+    font-size: var(--font-size-caption);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .group-detail-page__translation-drills-fields {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(10rem, 1fr);
+    gap: var(--space-3);
+  }
+
+  .group-detail-page__translation-drills-toggle {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-family: var(--font-ui);
+  }
+
+  .group-detail-page__translation-drills-label {
+    font-size: var(--font-size-caption);
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
   }
 
   .group-detail-page__header-button--danger,
@@ -1382,12 +1556,14 @@
   .group-detail-page__state-cta:focus-visible,
   .group-detail-page__dialog-button:focus-visible,
   .group-detail-page__drawer-submit:focus-visible,
+  .group-detail-page__translation-drills-button:focus-visible,
   .group-detail-page__feedback-dismiss:focus-visible,
   .group-detail-page__name-button:focus-visible,
   .group-detail-page__description-button:focus-visible,
   .group-detail-page__name-input:focus-visible,
   .group-detail-page__description-input:focus-visible,
   .group-detail-page__drawer-search-input:focus-visible,
+  .group-detail-page__translation-drills-input:focus-visible,
   .group-detail-page__drawer-close:focus-visible,
   .group-detail-page__back-link:focus-visible {
     outline: 2px solid var(--color-primary);
@@ -1400,7 +1576,8 @@
     }
 
     .group-detail-page__header-main,
-    .group-detail-page__toolbar {
+    .group-detail-page__toolbar,
+    .group-detail-page__translation-drills-fields {
       grid-template-columns: 1fr;
     }
 

--- a/apps/web/src/routes/[lang]/cards/groups/[groupId]/actions/+server.ts
+++ b/apps/web/src/routes/[lang]/cards/groups/[groupId]/actions/+server.ts
@@ -7,6 +7,7 @@ import {
   deleteCardLibraryGroupForLanguage,
   removeCardsFromGroupDetailForLanguage,
   updateGroupDetailForLanguage,
+  updateGroupTranslationDrillsForLanguage,
 } from '$lib/server/cards.js';
 
 type GroupDetailActionRequestBody =
@@ -21,6 +22,12 @@ type GroupDetailActionRequestBody =
     }
   | {
       action?: 'delete-group';
+    }
+  | {
+      action?: 'update-translation-drills';
+      enabled?: boolean;
+      drawPileName?: string | null;
+      pileSizeLimit?: number | string;
     };
 
 export const POST: RequestHandler = async (event) => {
@@ -89,6 +96,22 @@ export const POST: RequestHandler = async (event) => {
       if (body.action === 'delete-group') {
         return {
           deleted: await deleteCardLibraryGroupForLanguage(userId, languageId, groupId, database as never),
+        };
+      }
+
+      if (body.action === 'update-translation-drills') {
+        return {
+          translationDrills: await updateGroupTranslationDrillsForLanguage(
+            userId,
+            languageId,
+            groupId,
+            {
+              enabled: body.enabled,
+              drawPileName: body.drawPileName,
+              pileSizeLimit: body.pileSizeLimit,
+            },
+            database as never,
+          ),
         };
       }
 

--- a/apps/web/src/routes/[lang]/cards/groups/[groupId]/group-detail-page.test.ts
+++ b/apps/web/src/routes/[lang]/cards/groups/[groupId]/group-detail-page.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+
+import { writable } from 'svelte/store';
+import { render, screen } from '@testing-library/svelte';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type MockPageStoreValue = {
+  params: { lang: string; groupId?: string; noteId?: string };
+  route: { id: string };
+  status: number;
+  error: null;
+  data: Record<string, never>;
+  form: undefined;
+  state: Record<string, never>;
+  url: URL;
+};
+
+const pageStore = writable<MockPageStoreValue>({
+  params: { lang: 'zh', groupId: 'group-1' },
+  route: { id: '/[lang]/cards/groups/[groupId]' },
+  status: 200,
+  error: null,
+  data: {},
+  form: undefined,
+  state: {},
+  url: new URL('https://studypuck.test/zh/cards/groups/group-1'),
+});
+
+vi.mock('$app/stores', () => ({
+  page: pageStore,
+}));
+
+vi.mock('$app/navigation', () => ({
+  goto: vi.fn(),
+}));
+
+describe('Group detail page', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }) as typeof window.matchMedia;
+  });
+
+  afterAll(() => {
+    vi.doUnmock('$app/stores');
+    vi.doUnmock('$app/navigation');
+  });
+
+  it('shows Translation Drills setup controls for the current group', async () => {
+    const { default: GroupDetailPage } = await import('./+page.svelte');
+
+    render(GroupDetailPage, {
+      props: {
+        data: {
+          session: null,
+          authError: undefined,
+          availableLanguages: [],
+          cardEntryShell: {
+            unprocessedNoteCount: 0,
+          },
+          groupDetail: {
+            group: {
+              groupId: 'group-1',
+              groupName: 'Chat',
+              description: 'Conversation cards',
+              activeCardCount: 3,
+              translationDrills: {
+                enabled: true,
+                drawPileName: 'Chat practice',
+                pileSizeLimit: 6,
+              },
+            },
+            cards: {
+              items: [],
+              totalCount: 0,
+              filteredCardIds: [],
+              filters: {
+                searchText: '',
+                groupIds: [],
+                cardType: null,
+              },
+              availableGroups: [],
+            },
+            addableCards: {
+              items: [],
+              totalCount: 0,
+            },
+          },
+          selectedCard: null,
+          selectedCardAvailableGroups: [],
+        },
+      },
+    });
+
+    expect(screen.getByRole('heading', { name: 'Draw pile setup' })).toBeTruthy();
+    const toggle = screen.getByLabelText('Use this group in Translation Drills') as HTMLInputElement;
+    expect(toggle.checked).toBe(true);
+    expect(screen.getByDisplayValue('Chat practice')).toBeTruthy();
+    expect(screen.getByDisplayValue('6')).toBeTruthy();
+  });
+});

--- a/apps/web/src/routes/[lang]/cards/groups/groups-page.test.ts
+++ b/apps/web/src/routes/[lang]/cards/groups/groups-page.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { writable } from 'svelte/store';
+import { render, screen } from '@testing-library/svelte';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type MockPageStoreValue = {
+  params: { lang: string; groupId?: string; noteId?: string };
+  route: { id: string };
+  status: number;
+  error: null;
+  data: Record<string, never>;
+  form: undefined;
+  state: Record<string, never>;
+  url: URL;
+};
+
+const pageStore = writable<MockPageStoreValue>({
+  params: { lang: 'zh' },
+  route: { id: '/[lang]/cards/groups' },
+  status: 200,
+  error: null,
+  data: {},
+  form: undefined,
+  state: {},
+  url: new URL('https://studypuck.test/zh/cards/groups'),
+});
+
+vi.mock('$app/stores', () => ({
+  page: pageStore,
+}));
+
+vi.mock('$app/navigation', () => ({
+  goto: vi.fn(),
+}));
+
+describe('Groups page', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }) as typeof window.matchMedia;
+  });
+
+  afterAll(() => {
+    vi.doUnmock('$app/stores');
+    vi.doUnmock('$app/navigation');
+  });
+
+  it('renders a Translation Drills badge for configured groups', async () => {
+    const { default: GroupsPage } = await import('./+page.svelte');
+
+    render(GroupsPage, {
+      props: {
+        data: {
+          session: null,
+          authError: undefined,
+          availableLanguages: [],
+          cardEntryShell: {
+            unprocessedNoteCount: 0,
+          },
+          groups: {
+            items: [
+              {
+                groupId: 'group-1',
+                groupName: 'Chat',
+                description: 'Conversation cards',
+                activeCardCount: 5,
+                translationDrills: {
+                  enabled: true,
+                  drawPileName: 'Chat practice',
+                  pileSizeLimit: 6,
+                },
+              },
+              {
+                groupId: 'group-2',
+                groupName: 'Travel',
+                description: null,
+                activeCardCount: 2,
+                translationDrills: {
+                  enabled: false,
+                  drawPileName: null,
+                  pileSizeLimit: 10,
+                },
+              },
+            ],
+            totalCount: 2,
+          },
+        },
+      },
+    });
+
+    expect(screen.getByText('Translation Drills')).toBeTruthy();
+    expect(screen.getByText('Chat practice')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add Translation Drills config loading and update handling to Cards groups data/actions
- show configured Translation Drills state on the Groups list and add setup controls on Group Detail
- add server/UI coverage for the new setup flow

## Testing
- pnpm turbo test lint build --filter=web