### PR TITLE
Fix Translation Drills draw pile actions

### DIFF
--- a/packages/database/src/tests/translation-drills.test.ts
+++ b/packages/database/src/tests/translation-drills.test.ts
@@ -286,6 +286,25 @@ describe('Translation Drills database operations', () => {
     expect(dailyStats?.cardsDrawn).toBe(1);
   });
 
+  it('draws from a configured pile inside an existing transaction', async () => {
+    await seedLibrary();
+
+    const drawn = await db.transaction(async (tx) => drawTranslationDrillCard(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      'group-core',
+      { occurredAt: NOW },
+      tx,
+    ));
+    const [dailyStats] = await db
+      .select()
+      .from(translationDrillDailyStats)
+      .where(eq(translationDrillDailyStats.date, '2026-05-10'));
+
+    expect(drawn.cardId).toBe('card-new');
+    expect(dailyStats?.cardsDrawn).toBe(1);
+  });
+
   it('updates snooze, dismiss, and disable state without touching core card status', async () => {
     await seedLibrary();
 

--- a/packages/database/src/translation-drills.ts
+++ b/packages/database/src/translation-drills.ts
@@ -190,6 +190,68 @@ async function upsertDailyStats(
     });
 }
 
+async function activateTranslationDrillCardInConnection(
+  userId: string,
+  languageId: string,
+  cardId: string,
+  connection: AnyDb,
+  options: {
+    addedFrom?: string | null;
+    occurredAt?: Date;
+    trackDrawStat?: boolean;
+  } = {},
+): Promise<TranslationDrillContextCard> {
+  const occurredAt = options.occurredAt ?? new Date();
+  const [card] = await connection
+    .select({
+      cardId: cards.cardId,
+    })
+    .from(cards)
+    .where(and(
+      eq(cards.userId, userId),
+      eq(cards.languageId, languageId),
+      eq(cards.cardId, cardId),
+      eq(cards.status, 'active'),
+    ));
+
+  if (!card) {
+    throw new Error('That card is not available for Translation Drills.');
+  }
+
+  await connection
+    .insert(translationDrillContext)
+    .values({
+      userId,
+      languageId,
+      cardId,
+      state: 'active',
+      addedFrom: options.addedFrom ?? null,
+      addedAt: occurredAt,
+      lastUsed: null,
+      usageCount: 0,
+      stateUntil: null,
+    })
+    .onConflictDoUpdate({
+      target: [
+        translationDrillContext.userId,
+        translationDrillContext.languageId,
+        translationDrillContext.cardId,
+      ],
+      set: {
+        state: 'active',
+        addedFrom: options.addedFrom ?? translationDrillContext.addedFrom,
+        addedAt: occurredAt,
+        stateUntil: null,
+      },
+    });
+
+  if (options.trackDrawStat) {
+    await upsertDailyStats(userId, languageId, occurredAt, { cardsDrawn: 1 }, connection);
+  }
+
+  return await requireContextCard(userId, languageId, cardId, connection);
+}
+
 async function getConfiguredDrawPile(
   userId: string,
   languageId: string,
@@ -611,57 +673,14 @@ export async function activateTranslationDrillCard(
   } = {},
   database?: AnyDb,
 ): Promise<TranslationDrillContextCard> {
-  const occurredAt = options.occurredAt ?? new Date();
-
   return await runInTransaction(database, async (tx) => {
-    const [card] = await tx
-      .select({
-        cardId: cards.cardId,
-      })
-      .from(cards)
-      .where(and(
-        eq(cards.userId, userId),
-        eq(cards.languageId, languageId),
-        eq(cards.cardId, cardId),
-        eq(cards.status, 'active'),
-      ));
-
-    if (!card) {
-      throw new Error('That card is not available for Translation Drills.');
-    }
-
-    await tx
-      .insert(translationDrillContext)
-      .values({
-        userId,
-        languageId,
-        cardId,
-        state: 'active',
-        addedFrom: options.addedFrom ?? null,
-        addedAt: occurredAt,
-        lastUsed: null,
-        usageCount: 0,
-        stateUntil: null,
-      })
-      .onConflictDoUpdate({
-        target: [
-          translationDrillContext.userId,
-          translationDrillContext.languageId,
-          translationDrillContext.cardId,
-        ],
-        set: {
-          state: 'active',
-          addedFrom: options.addedFrom ?? translationDrillContext.addedFrom,
-          addedAt: occurredAt,
-          stateUntil: null,
-        },
-      });
-
-    if (options.trackDrawStat) {
-      await upsertDailyStats(userId, languageId, occurredAt, { cardsDrawn: 1 }, tx);
-    }
-
-    return await requireContextCard(userId, languageId, cardId, tx);
+    return await activateTranslationDrillCardInConnection(
+      userId,
+      languageId,
+      cardId,
+      tx,
+      options,
+    );
   });
 }
 
@@ -729,16 +748,16 @@ export async function drawTranslationDrillCard(
       throw new Error('There are no cards available to draw from that pile right now.');
     }
 
-    return await activateTranslationDrillCard(
+    return await activateTranslationDrillCardInConnection(
       userId,
       languageId,
       nextCard.cardId,
+      tx,
       {
         addedFrom: `draw_pile:${groupId}`,
         occurredAt,
         trackDrawStat: true,
       },
-      tx,
     );
   });
 }


### PR DESCRIPTION
## Summary
- avoid nested Translation Drills transactions when drawing from a configured pile
- reuse the active database connection for draw activation/upsert work
- add regression coverage for drawing inside an existing transaction

## Validation
- pnpm turbo test lint build --filter=web
- database integration spec requires Postgres on localhost:5433 and was not available in this environment

Closes #211