### PR TITLE
Fix translation drills reliability

### DIFF
--- a/apps/web/src/lib/chat.ts
+++ b/apps/web/src/lib/chat.ts
@@ -97,7 +97,7 @@ export const translationDrillsSurfaceContextSchema = z.object({
   activeChallenge: z.object({
     challengeId: z.string().trim().min(1).max(160),
     prompt: z.string().trim().min(1).max(400),
-    sourceCardIds: z.array(activeCardIdSchema).min(1).max(10),
+    sourceCardIds: z.array(activeCardIdSchema).min(1).max(2),
     startedAtIso: z.string().datetime(),
   }).nullable(),
   focusedCardId: activeCardIdSchema.nullable().optional(),

--- a/apps/web/src/lib/components/CommandBar.dom.test.ts
+++ b/apps/web/src/lib/components/CommandBar.dom.test.ts
@@ -685,7 +685,80 @@ describe('CommandBar component behavior', () => {
 
     translationDrillSession.sync({
       lang: 'zh',
-      home: null,
+      home: {
+        summary: {
+          configuredGroupCount: 1,
+          activeCardCount: 1,
+          snoozedCardCount: 0,
+          dismissedCardCount: 0,
+          disabledCardCount: 0,
+          remainingDrawCount: 0,
+          hasConfiguredDrawPiles: true,
+          hasVisibleContext: true,
+        },
+        availableGroups: [{ groupId: 'group-1', groupName: 'Core' }],
+        configuredGroups: [{
+          groupId: 'group-1',
+          groupName: 'Core',
+          drawPileName: null,
+          pileSizeLimit: 4,
+          remainingCardCount: 0,
+          activeCards: [{
+            cardId: 'card-1',
+            content: '谈论',
+            meaning: 'to discuss',
+            cardType: 'word',
+            examples: [],
+            mnemonics: [],
+            llmInstructions: null,
+            updatedAtIso: null,
+            sourceGroup: { groupId: 'group-1', groupName: 'Core' },
+            addedFrom: 'draw_pile:group-1',
+            addedAtIso: null,
+            lastUsedAtIso: null,
+            usageCount: 0,
+            state: 'active',
+            stateUntilIso: null,
+            cefrOverride: null,
+            nextDueAtIso: null,
+            intervalDays: null,
+            performanceScore: null,
+            dismissSchedule: null,
+          }],
+          snoozedCards: [],
+        }],
+        ungroupedContextCards: [],
+        challenge: {
+          activeChallenge: null,
+          generationInput: {
+            activeCardCount: 1,
+            cefrLevel: 'B1',
+            cards: [{
+              cardId: 'card-1',
+              content: '谈论',
+              meaning: 'to discuss',
+              cardType: 'word',
+              examples: [],
+              mnemonics: [],
+              llmInstructions: null,
+              updatedAtIso: null,
+              sourceGroup: { groupId: 'group-1', groupName: 'Core' },
+              addedFrom: 'draw_pile:group-1',
+              addedAtIso: null,
+              lastUsedAtIso: null,
+              usageCount: 0,
+              state: 'active',
+              stateUntilIso: null,
+              cefrOverride: null,
+              nextDueAtIso: null,
+              intervalDays: null,
+              performanceScore: null,
+              dismissSchedule: null,
+            }],
+            suggestedSourceCardIds: ['card-1'],
+          },
+        },
+      },
       activeChallenge: {
         challengeId: 'challenge-1',
         prompt: 'That is all.',
@@ -720,5 +793,6 @@ describe('CommandBar component behavior', () => {
     });
 
     expect(screen.getByText('Translate to Chinese (Mandarin)')).toBeTruthy();
+    expect(screen.queryByRole('list', { name: 'Challenge focus cards' })).toBeNull();
   });
 });

--- a/apps/web/src/lib/components/cards/ActiveCardDrawer.svelte
+++ b/apps/web/src/lib/components/cards/ActiveCardDrawer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher, onDestroy, tick } from 'svelte';
+  import { createEventDispatcher, onDestroy, onMount, tick } from 'svelte';
   import { get } from 'svelte/store';
   import {
     addEditableGroup,
@@ -69,6 +69,7 @@
   let groupSearchInput: HTMLInputElement | null = null;
   let llmInstructionsOpen = Boolean(card.llmInstructions);
   let lastHandledSuggestionActionId = get(activeCardSuggestionActions)?.actionId ?? 0;
+  let backdropCloseReady = false;
 
   function serializePayload(payload: ReturnType<typeof buildPayload>) {
     return JSON.stringify(payload);
@@ -348,6 +349,11 @@
   async function handleClose() {
     deleteConfirmOpen = false;
 
+    if (disabled) {
+      dispatch('close');
+      return;
+    }
+
     if (await persistDraft()) {
       dispatch('close');
     }
@@ -461,6 +467,25 @@
   onDestroy(() => {
     clearSavedIndicatorTimer();
   });
+
+  onMount(() => {
+    const frameId = requestAnimationFrame(() => {
+      backdropCloseReady = true;
+      drawerElement?.focus();
+    });
+
+    return () => {
+      cancelAnimationFrame(frameId);
+    };
+  });
+
+  function handleBackdropClick() {
+    if (!backdropCloseReady) {
+      return;
+    }
+
+    void handleClose();
+  }
 </script>
 
 <svelte:window on:keydown={handleWindowKeydown} />
@@ -469,7 +494,7 @@
   type="button"
   class="active-card-drawer__backdrop"
   aria-label="Close card detail drawer"
-  on:click={() => void handleClose()}
+  on:click={handleBackdropClick}
 ></button>
 
 <div
@@ -516,7 +541,7 @@
           type="button"
           class="active-card-drawer__close"
           aria-label="Close drawer"
-          disabled={disabled || removePending}
+          disabled={removePending}
           on:click={() => void handleClose()}
         >
           ✕

--- a/apps/web/src/lib/components/cards/ActiveCardDrawer.test.ts
+++ b/apps/web/src/lib/components/cards/ActiveCardDrawer.test.ts
@@ -306,4 +306,5 @@ describe('ActiveCardDrawer', () => {
       });
     });
   });
+
 });

--- a/apps/web/src/lib/components/translation-drills/TranslationDrillsHome.svelte
+++ b/apps/web/src/lib/components/translation-drills/TranslationDrillsHome.svelte
@@ -65,8 +65,22 @@
   let availableDrawerGroups: Array<{ groupId: string; groupName: string }> = [];
   let lastHandledSessionActionId = get(translationDrillSessionActions)?.actionId ?? 0;
 
+  function hasCard(homeData: HomeState | null, cardId: string | null) {
+    if (!homeData || !cardId) {
+      return false;
+    }
+
+    return homeData.configuredGroups.some((group) =>
+      group.activeCards.some((card) => card.cardId === cardId) ||
+      group.snoozedCards.some((card) => card.cardId === cardId),
+    ) || homeData.ungroupedContextCards.some((card) => card.cardId === cardId);
+  }
+
   $: if (home !== previousHome) {
-    homeState = home ? structuredClone(home) : null;
+    const nextHomeState = home ? structuredClone(home) : null;
+    const nextDrawerCardId = hasCard(nextHomeState, drawerCardId) ? drawerCardId : null;
+
+    homeState = nextHomeState;
     previousHome = home;
     actionMessage = '';
     actionError = null;
@@ -77,7 +91,7 @@
     learnMoreExpanded = false;
     activeChallenge = home?.challenge.activeChallenge ?? null;
     focusedCardId = null;
-    drawerCardId = null;
+    drawerCardId = nextDrawerCardId;
     if (homeState) {
       syncGenerationInput();
     }

--- a/apps/web/src/lib/components/translation-drills/TranslationDrillsHome.test.ts
+++ b/apps/web/src/lib/components/translation-drills/TranslationDrillsHome.test.ts
@@ -218,4 +218,53 @@ describe('TranslationDrillsHome', () => {
       expect(screen.queryByRole('button', { name: '💤 Snooze' })).toBeNull();
     });
   });
+
+  it('opens card detail from the drill context and lets the user close the drawer', async () => {
+    render(TranslationDrillsHome, {
+      props: {
+        lang: 'zh',
+        home: createHome(),
+        loadError: null,
+      },
+    });
+
+    const activeCardRow = screen.getByLabelText('经历').closest('article');
+    expect(activeCardRow).toBeTruthy();
+    await fireEvent.click(within(activeCardRow as HTMLElement).getByRole('button', { name: '···' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'View card detail' }));
+
+    const closeButton = await screen.findByRole('button', { name: 'Close drawer' });
+    expect(closeButton.hasAttribute('disabled')).toBe(false);
+
+    await fireEvent.click(closeButton);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Close drawer' })).toBeNull();
+    });
+  });
+
+  it('keeps the drawer open when the home prop is refreshed with the same visible card', async () => {
+    const view = render(TranslationDrillsHome, {
+      props: {
+        lang: 'zh',
+        home: createHome(),
+        loadError: null,
+      },
+    });
+
+    const activeCardRow = screen.getByLabelText('经历').closest('article');
+    expect(activeCardRow).toBeTruthy();
+    await fireEvent.click(within(activeCardRow as HTMLElement).getByRole('button', { name: '···' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'View card detail' }));
+
+    await screen.findByRole('button', { name: 'Close drawer' });
+
+    await view.rerender({
+      lang: 'zh',
+      home: createHome(),
+      loadError: null,
+    });
+
+    expect(screen.getByRole('button', { name: 'Close drawer' })).toBeTruthy();
+  });
 });

--- a/apps/web/src/lib/server/ai-prompts/chat.test.ts
+++ b/apps/web/src/lib/server/ai-prompts/chat.test.ts
@@ -317,6 +317,13 @@ describe('buildStructuredChatPrompt', () => {
     expect(prompt.userPrompt).toContain('{"type":"next_translation_drill_challenge","payload":{}}');
     expect(prompt.userPrompt).toContain('The active Translation Drills challenge is authoritative app state.');
     expect(prompt.userPrompt).toContain('If the user message looks like an attempted translation for the active challenge');
+    expect(prompt.userPrompt).toContain('You may proactively suggest add_inbox_note when the drill reveals a durable usage distinction');
+    expect(prompt.userPrompt).toContain('If the learner gives a natural, correct translation that uses a valid synonym');
+    expect(prompt.userPrompt).toContain('If the learner leaves an English word or phrase in the answer');
+    expect(prompt.userPrompt).toContain('If the missing English word is the intended source-card target');
+    expect(prompt.userPrompt).toContain('If the missing English word is not the intended source-card target');
+    expect(prompt.userPrompt).toContain('If prior conversation history shows you already hinted');
+    expect(prompt.userPrompt).toContain('Only call the answer plainly wrong when it is ungrammatical');
     expect(prompt.userPrompt).toContain('follow-up question about the challenge');
     expect(prompt.userPrompt).toContain('Use exact groupId and cardId values from the Translation Drills machine context');
   });

--- a/apps/web/src/lib/server/ai-prompts/chat.ts
+++ b/apps/web/src/lib/server/ai-prompts/chat.ts
@@ -161,6 +161,14 @@ function buildGenericContextBlock(
     blocks.push(
       'The active Translation Drills challenge is authoritative app state.',
       'If the user message looks like an attempted translation for the active challenge, evaluate the attempt, explain corrections, and avoid returning drill-action suggestions unless the user also asks for an app action.',
+      'You may proactively suggest add_inbox_note when the drill reveals a durable usage distinction, contrast, or reminder that would be worth saving for later study even if the user did not explicitly ask to save a note.',
+      'Treat the listed source cards as the intended challenge focus, but accept other correct target-language solutions when they answer the English prompt naturally.',
+      'If the learner gives a natural, correct translation that uses a valid synonym or alternate idiom instead of the intended source card, acknowledge that it works, then give a brief hint toward the target card rather than immediately revealing it.',
+      'If the learner leaves an English word or phrase in the answer because they do not know it, first decide whether that missing word is the intended source-card target or a different supporting word.',
+      'If the missing English word is the intended source-card target, respond like the valid-but-off-target case: hint toward the target card first and avoid fully revealing it immediately.',
+      'If the missing English word is not the intended source-card target, you may directly give a good target-language word or phrase for that missing piece while still helping the learner complete the sentence.',
+      'If prior conversation history shows you already hinted and the learner still has not used the intended card, reveal the target wording and explain why it was the preferred practice target for this challenge.',
+      'Only call the answer plainly wrong when it is ungrammatical, semantically off, or a materially worse fit for the prompt.',
       'If the user asks a follow-up question about the challenge, source cards, or context, answer the question directly instead of treating it as a new translation attempt.',
     );
   }

--- a/apps/web/src/lib/server/ai-prompts/translation-drills.test.ts
+++ b/apps/web/src/lib/server/ai-prompts/translation-drills.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { buildTranslationDrillChallengePrompt } from './translation-drills.js';
+
+describe('buildTranslationDrillChallengePrompt', () => {
+  it('allows slightly silly but semantically sound challenge meanings', () => {
+    const prompt = buildTranslationDrillChallengePrompt({
+      targetLanguageName: 'Chinese',
+      cefrLevel: 'B1',
+      candidateCards: [{
+        cardId: 'card-1',
+        content: '当然',
+        meaning: 'of course',
+        cardType: 'word',
+        sourceGroupName: 'Core',
+        examples: ['当然可以。'],
+        mnemonics: [],
+        llmInstructions: null,
+        usageCount: 0,
+        lastUsedAtIso: null,
+        cefrOverride: null,
+      }],
+    });
+
+    expect(prompt.userPrompt).toContain('Slightly absurd, playful, or silly meanings are acceptable');
+    expect(prompt.userPrompt).toContain('Phrase and idiom cards should be placed in coherent situations');
+  });
+});

--- a/apps/web/src/lib/server/ai-prompts/translation-drills.ts
+++ b/apps/web/src/lib/server/ai-prompts/translation-drills.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+
+export const translationDrillChallengePlanSchema = z.object({
+  prompt: z.string().trim().min(8).max(220),
+  sourceCardIds: z.array(z.string().trim().min(1).max(128)).min(1).max(2),
+});
+
+export type TranslationDrillChallengePromptCard = {
+  cardId: string;
+  content: string;
+  meaning: string | null;
+  cardType: string | null;
+  sourceGroupName: string | null;
+  examples: string[];
+  mnemonics: string[];
+  llmInstructions: string | null;
+  usageCount: number;
+  lastUsedAtIso: string | null;
+  cefrOverride: string | null;
+};
+
+export function buildTranslationDrillChallengePrompt(input: {
+  targetLanguageName: string;
+  cefrLevel: string | null;
+  candidateCards: TranslationDrillChallengePromptCard[];
+  previousSourceCardIds?: readonly string[];
+  mustUseAllCandidateCards?: boolean;
+}) {
+  const selectionGuidance = input.mustUseAllCandidateCards
+    ? [
+        'Use every candidate card below as a challenge focus.',
+        'Return all of their cardIds in sourceCardIds, preserving only the cards that were explicitly provided.',
+      ]
+    : [
+        'Choose the best 1 or 2 candidate cards for a single coherent challenge.',
+        'Prefer one focus card unless a second card makes the challenge more natural.',
+        'Avoid returning the exact previous card combination when another equally good challenge is available.',
+      ];
+
+  return {
+    systemPrompt: [
+      'You design Translation Drills challenges for StudyPuck.',
+      'Return only JSON.',
+      'Write one natural English sentence or short utterance for the learner to translate into the target language.',
+      'Do not mention StudyPuck, cards, drills, or source-card metadata in the prompt.',
+    ].join(' '),
+    userPrompt: [
+      `Target language: ${input.targetLanguageName}`,
+      `Learner CEFR level: ${input.cefrLevel ?? 'unknown'}`,
+      'Challenge quality rubric:',
+      '- The prompt must sound like something a real person might say or write.',
+      '- The prompt must create a clear reason to use the chosen target-language card or cards.',
+      '- Phrase and idiom cards should be placed in coherent situations, not dictionary-style gloss templates.',
+      '- Slightly absurd, playful, or silly meanings are acceptable when the sentence remains grammatically correct and semantically sound.',
+      '- Use card examples and llmInstructions as guidance for natural usage, register, and grammar pressure.',
+      '- Do not copy target-language text into the English prompt.',
+      '- Avoid awkward English that mechanically mirrors the source-card meaning.',
+      '- Keep the challenge focused enough that the learner can reasonably answer with one sentence.',
+      ...selectionGuidance,
+      `Previous sourceCardIds: ${JSON.stringify(input.previousSourceCardIds ?? [])}`,
+      'Candidate cards:',
+      JSON.stringify(input.candidateCards, null, 2),
+      'Return this JSON shape exactly:',
+      '{"prompt":"string","sourceCardIds":["card-id-1"]}',
+    ].join('\n'),
+  };
+}

--- a/apps/web/src/lib/server/ai-service.test.ts
+++ b/apps/web/src/lib/server/ai-service.test.ts
@@ -124,6 +124,119 @@ describe('createAiService', () => {
     expect(silentHooks.onRequestFailure).toHaveBeenCalledTimes(1);
   });
 
+  it('repairs malformed JSON deterministically before falling back to another provider', async () => {
+    const geminiGenerator = vi.fn(async () => '{"draftCards":[{"content":"say "hola""}]}');
+    const openAiGenerator = vi.fn(async () => '{"draftCards":[{"content":"fallback"}]}');
+    const service = createAiService({
+      privateEnv: {
+        GEMINI_API_KEY: 'test-gemini-key',
+        OPENAI_API_KEY: 'test-openai-key',
+      },
+      hooks: silentHooks,
+      providerGenerators: {
+        gemini: geminiGenerator,
+        openai: openAiGenerator,
+      },
+    });
+
+    const response = await service.generateStructured({
+      metadata: {
+        feature: 'chat',
+        operation: 'conversation',
+        userId: 'user-1',
+        languageId: 'zh',
+        routeContextType: 'translation-drills',
+      },
+      systemPrompt: 'system',
+      userPrompt: 'user',
+      responseSchema,
+    });
+
+    expect(response).toEqual({
+      draftCards: [{ content: 'say "hola"' }],
+    });
+    expect(geminiGenerator).toHaveBeenCalledTimes(1);
+    expect(openAiGenerator).not.toHaveBeenCalled();
+  });
+
+  it('uses an LLM repair pass before falling back to another provider', async () => {
+    const geminiGenerator = vi.fn(async (request: { systemPrompt: string }) =>
+      request.systemPrompt.includes('repair malformed JSON')
+        ? '{"draftCards":[{"content":"repaired"}]}'
+        : '{"draftCards":[{"content":"hola"}]',
+    );
+    const openAiGenerator = vi.fn(async () => '{"draftCards":[{"content":"fallback"}]}');
+    const service = createAiService({
+      privateEnv: {
+        GEMINI_API_KEY: 'test-gemini-key',
+        OPENAI_API_KEY: 'test-openai-key',
+      },
+      hooks: silentHooks,
+      providerGenerators: {
+        gemini: geminiGenerator,
+        openai: openAiGenerator,
+      },
+    });
+
+    const response = await service.generateStructured({
+      metadata: {
+        feature: 'chat',
+        operation: 'conversation',
+        userId: 'user-1',
+        languageId: 'zh',
+        routeContextType: 'translation-drills',
+      },
+      systemPrompt: 'system',
+      userPrompt: 'user',
+      responseSchema,
+    });
+
+    expect(response).toEqual({
+      draftCards: [{ content: 'repaired' }],
+    });
+    expect(geminiGenerator).toHaveBeenCalledTimes(2);
+    expect(openAiGenerator).not.toHaveBeenCalled();
+  });
+
+  it('falls back to OpenAI after deterministic and LLM repair both fail', async () => {
+    const geminiGenerator = vi.fn(async (request: { systemPrompt: string }) =>
+      request.systemPrompt.includes('repair malformed JSON')
+        ? '{"draftCards":['
+        : '{"draftCards":[{"content":"hola"}]',
+    );
+    const openAiGenerator = vi.fn(async () => '{"draftCards":[{"content":"fallback"}]}');
+    const service = createAiService({
+      privateEnv: {
+        GEMINI_API_KEY: 'test-gemini-key',
+        OPENAI_API_KEY: 'test-openai-key',
+      },
+      hooks: silentHooks,
+      providerGenerators: {
+        gemini: geminiGenerator,
+        openai: openAiGenerator,
+      },
+    });
+
+    const response = await service.generateStructured({
+      metadata: {
+        feature: 'chat',
+        operation: 'conversation',
+        userId: 'user-1',
+        languageId: 'zh',
+        routeContextType: 'translation-drills',
+      },
+      systemPrompt: 'system',
+      userPrompt: 'user',
+      responseSchema,
+    });
+
+    expect(response).toEqual({
+      draftCards: [{ content: 'fallback' }],
+    });
+    expect(geminiGenerator).toHaveBeenCalledTimes(2);
+    expect(openAiGenerator).toHaveBeenCalledTimes(1);
+  });
+
   it('throws a configuration error when no providers are configured', async () => {
     const service = createAiService({
       privateEnv: {},

--- a/apps/web/src/lib/server/ai-service.ts
+++ b/apps/web/src/lib/server/ai-service.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 export type AiProviderName = 'gemini' | 'openai';
 
 export type AiRequestMetadata = {
-  feature: 'card-entry' | 'chat';
-  operation: 'preprocess-note' | 'semantic-embedding' | 'conversation';
+  feature: 'card-entry' | 'chat' | 'translation-drills';
+  operation: 'preprocess-note' | 'semantic-embedding' | 'conversation' | 'plan-challenge';
   userId: string;
   languageId: string;
   noteId?: string;
@@ -202,6 +202,154 @@ function extractJsonText(rawText: string): string {
 function buildRawTextPreview(rawText: string): string {
   const normalized = rawText.replace(/\s+/g, ' ').trim();
   return normalized.length > 400 ? `${normalized.slice(0, 400)}…` : normalized;
+}
+
+function nextNonWhitespaceCharacter(text: string, startIndex: number): string | null {
+  for (let index = startIndex; index < text.length; index += 1) {
+    const character = text[index];
+
+    if (character && !/\s/.test(character)) {
+      return character;
+    }
+  }
+
+  return null;
+}
+
+function repairJsonStringContent(jsonText: string): string {
+  let repaired = '';
+  let inString = false;
+  let escaping = false;
+
+  for (let index = 0; index < jsonText.length; index += 1) {
+    const character = jsonText[index];
+
+    if (!character) {
+      continue;
+    }
+
+    if (!inString) {
+      if (character === '"') {
+        inString = true;
+      }
+
+      repaired += character;
+      continue;
+    }
+
+    if (escaping) {
+      if (/["\\/bfnrt]/.test(character)) {
+        repaired += character;
+      } else if (character === 'u') {
+        const unicodeCandidate = jsonText.slice(index + 1, index + 5);
+
+        if (/^[0-9a-fA-F]{4}$/.test(unicodeCandidate)) {
+          repaired += `u${unicodeCandidate}`;
+          index += 4;
+        } else {
+          repaired += `\\u${unicodeCandidate}`;
+          index += Math.max(0, unicodeCandidate.length);
+        }
+      } else {
+        repaired += `\\${character}`;
+      }
+
+      escaping = false;
+      continue;
+    }
+
+    if (character === '\\') {
+      repaired += character;
+      escaping = true;
+      continue;
+    }
+
+    if (character === '"') {
+      const nextCharacter = nextNonWhitespaceCharacter(jsonText, index + 1);
+
+      if (nextCharacter === null || nextCharacter === ',' || nextCharacter === '}' || nextCharacter === ']' || nextCharacter === ':') {
+        inString = false;
+        repaired += character;
+      } else {
+        repaired += '\\"';
+      }
+
+      continue;
+    }
+
+    if (character === '\n') {
+      repaired += '\\n';
+      continue;
+    }
+
+    if (character === '\r') {
+      repaired += '\\r';
+      continue;
+    }
+
+    if (character === '\t') {
+      repaired += '\\t';
+      continue;
+    }
+
+    repaired += character;
+  }
+
+  return inString ? `${repaired}"` : repaired;
+}
+
+function attemptDeterministicJsonRepair(rawText: string): string | null {
+  let jsonText = rawText.trim();
+
+  try {
+    jsonText = extractJsonText(rawText);
+  } catch {
+    jsonText = rawText.trim();
+  }
+
+  const repaired = repairJsonStringContent(
+    jsonText
+      .replace(/^\uFEFF/, '')
+      .replace(/[“”]/g, '"')
+      .replace(/[‘’]/g, '\'')
+      .replace(/,\s*([}\]])/g, '$1'),
+  );
+
+  return repaired === jsonText ? null : repaired;
+}
+
+function buildJsonRepairPrompt(request: {
+  systemPrompt: string;
+  userPrompt: string;
+  rawText: string;
+  error: AiStructuredResponseError;
+}) {
+  return {
+    systemPrompt: [
+      'You repair malformed JSON produced by another model.',
+      'Return only valid JSON.',
+      'Do not wrap the answer in markdown or code fences.',
+      'Preserve the original meaning and suggestion payloads whenever possible.',
+      'Do not add commentary before or after the JSON.',
+    ].join('\n'),
+    userPrompt: [
+      'Repair the malformed JSON response below so it satisfies the original request.',
+      '',
+      'Original system prompt:',
+      request.systemPrompt,
+      '',
+      'Original user prompt:',
+      request.userPrompt,
+      '',
+      `Parsing failure stage: ${request.error.stage}`,
+      `Parsing failure message: ${request.error.message}`,
+      '',
+      'Malformed model output:',
+      request.rawText,
+      '',
+      'Return repaired valid JSON only.',
+    ].join('\n'),
+  };
 }
 
 async function parseStructuredResponse<T>(rawText: string, responseSchema: z.ZodType<T>): Promise<T> {
@@ -487,7 +635,49 @@ export function createAiService(options: {
             systemPrompt: request.systemPrompt,
             userPrompt: request.userPrompt,
           });
-          const parsed = await parseStructuredResponse(rawText, request.responseSchema);
+          let parsed: T | undefined;
+
+          try {
+            parsed = await parseStructuredResponse(rawText, request.responseSchema);
+          } catch (error) {
+            if (!(error instanceof AiStructuredResponseError) || (error.stage !== 'json_extract' && error.stage !== 'json_parse')) {
+              throw error;
+            }
+
+            const deterministicallyRepaired = attemptDeterministicJsonRepair(rawText);
+
+            if (deterministicallyRepaired) {
+              try {
+                parsed = await parseStructuredResponse(deterministicallyRepaired, request.responseSchema);
+              } catch {
+                // Fall through to the LLM repair attempt.
+              }
+            }
+
+            if (parsed === undefined) {
+              const repairPrompt = buildJsonRepairPrompt({
+                systemPrompt: request.systemPrompt,
+                userPrompt: request.userPrompt,
+                rawText,
+                error,
+              });
+              const repairedRawText = await providerGenerators[provider.name]({
+                config: provider,
+                systemPrompt: repairPrompt.systemPrompt,
+                userPrompt: repairPrompt.userPrompt,
+              });
+
+              parsed = await parseStructuredResponse(repairedRawText, request.responseSchema);
+            }
+          }
+
+          if (parsed === undefined) {
+            throw new AiStructuredResponseError({
+              message: 'The AI response could not be repaired into valid structured output.',
+              stage: 'json_parse',
+              rawTextPreview: rawText,
+            });
+          }
 
           await hooks.onRequestSuccess({
             provider: provider.name,

--- a/apps/web/src/lib/server/translation-drill-challenges.ts
+++ b/apps/web/src/lib/server/translation-drill-challenges.ts
@@ -1,0 +1,124 @@
+import type { TranslationDrillContextCard } from '@studypuck/database';
+import { createAiService } from '$lib/server/ai-service.js';
+import {
+  buildTranslationDrillChallengePrompt,
+  translationDrillChallengePlanSchema,
+  type TranslationDrillChallengePromptCard,
+} from '$lib/server/ai-prompts/translation-drills.js';
+
+type StructuredResponseGenerator = (request: {
+  metadata: {
+    feature: 'translation-drills';
+    operation: 'plan-challenge';
+    userId: string;
+    languageId: string;
+  };
+  systemPrompt: string;
+  userPrompt: string;
+  responseSchema: typeof translationDrillChallengePlanSchema;
+}) => Promise<{
+  prompt: string;
+  sourceCardIds: string[];
+}>;
+
+export type TranslationDrillChallengePlannerInput = {
+  userId: string;
+  languageId: string;
+  targetLanguageName: string;
+  cefrLevel: string | null;
+  candidateCards: TranslationDrillContextCard[];
+  previousSourceCardIds?: readonly string[];
+  mustUseAllCandidateCards?: boolean;
+};
+
+export type TranslationDrillChallengePlan = {
+  prompt: string;
+  sourceCardIds: string[];
+};
+
+function toPromptCard(card: TranslationDrillContextCard): TranslationDrillChallengePromptCard {
+  return {
+    cardId: card.cardId,
+    content: card.content,
+    meaning: card.meaning,
+    cardType: card.cardType,
+    sourceGroupName: card.sourceGroup?.groupName ?? null,
+    examples: card.examples.slice(0, 2),
+    mnemonics: card.mnemonics.slice(0, 1),
+    llmInstructions: card.llmInstructions,
+    usageCount: card.usageCount,
+    lastUsedAtIso: card.lastUsedAt?.toISOString() ?? null,
+    cefrOverride: card.cefrOverride,
+  };
+}
+
+function normalizeSourceCardIds(sourceCardIds: readonly string[]) {
+  return [...new Set(sourceCardIds.map((cardId) => cardId.trim()).filter(Boolean))];
+}
+
+function validateChallengePlan(
+  plan: TranslationDrillChallengePlan,
+  input: TranslationDrillChallengePlannerInput,
+): TranslationDrillChallengePlan {
+  const candidateCardIds = new Set(input.candidateCards.map((card) => card.cardId));
+  const normalizedSourceCardIds = normalizeSourceCardIds(plan.sourceCardIds);
+
+  if (normalizedSourceCardIds.length === 0) {
+    throw new Error('The challenge generator returned no source cards.');
+  }
+
+  if (normalizedSourceCardIds.some((cardId) => !candidateCardIds.has(cardId))) {
+    throw new Error('The challenge generator returned cards outside the active Translation Drills context.');
+  }
+
+  if (input.mustUseAllCandidateCards) {
+    const requiredCardIds = normalizeSourceCardIds(input.candidateCards.map((card) => card.cardId));
+
+    if (
+      normalizedSourceCardIds.length !== requiredCardIds.length
+      || normalizedSourceCardIds.some((cardId, index) => cardId !== requiredCardIds[index])
+    ) {
+      throw new Error('The challenge generator did not keep the requested Translation Drills source cards.');
+    }
+  }
+
+  return {
+    prompt: plan.prompt.trim(),
+    sourceCardIds: normalizedSourceCardIds,
+  };
+}
+
+export async function planTranslationDrillChallenge(
+  input: TranslationDrillChallengePlannerInput & {
+    privateEnv: Record<string, string | undefined>;
+    generateStructured?: StructuredResponseGenerator;
+  },
+): Promise<TranslationDrillChallengePlan> {
+  if (input.candidateCards.length === 0) {
+    throw new Error('Draw or pin at least one active card before starting a challenge.');
+  }
+
+  const prompt = buildTranslationDrillChallengePrompt({
+    targetLanguageName: input.targetLanguageName,
+    cefrLevel: input.cefrLevel,
+    candidateCards: input.candidateCards.map((card) => toPromptCard(card)),
+    previousSourceCardIds: input.previousSourceCardIds,
+    mustUseAllCandidateCards: input.mustUseAllCandidateCards,
+  });
+  const generateStructured = input.generateStructured ?? createAiService({
+    privateEnv: input.privateEnv,
+  }).generateStructured;
+  const result = await generateStructured({
+    metadata: {
+      feature: 'translation-drills',
+      operation: 'plan-challenge',
+      userId: input.userId,
+      languageId: input.languageId,
+    },
+    systemPrompt: prompt.systemPrompt,
+    userPrompt: prompt.userPrompt,
+    responseSchema: translationDrillChallengePlanSchema,
+  });
+
+  return validateChallengePlan(result, input);
+}

--- a/apps/web/src/lib/server/translation-drills.test.ts
+++ b/apps/web/src/lib/server/translation-drills.test.ts
@@ -291,6 +291,7 @@ describe('applyTranslationDrillAction', () => {
       usageCount: 1,
       performanceScore: null,
     })),
+    recordTranslationDrillChallengeUsage: vi.fn(async () => undefined),
     getTranslationDrillDismissSchedule: vi.fn(async () => ({
       cardId: 'card-1',
       recommendedDays: 5,
@@ -376,6 +377,10 @@ describe('applyTranslationDrillAction', () => {
   });
 
   it('validates challenge source cards against the active context', async () => {
+    const planChallenge = vi.fn(async () => ({
+      prompt: 'Can you make up for the delay before everyone notices?',
+      sourceCardIds: ['card-1'],
+    }));
     const result = await applyTranslationDrillAction(
       'user-1',
       'zh',
@@ -385,19 +390,33 @@ describe('applyTranslationDrillAction', () => {
       },
       database,
       deps,
+      { planChallenge },
     );
 
+    expect(planChallenge).toHaveBeenCalledWith(expect.objectContaining({
+      targetLanguageName: 'Chinese',
+      cefrLevel: 'B1',
+      previousSourceCardIds: undefined,
+      mustUseAllCandidateCards: true,
+    }));
+    expect(actionDeps.recordTranslationDrillChallengeUsage).toHaveBeenCalledWith(
+      'user-1',
+      'zh',
+      ['card-1'],
+      { occurredAt: now },
+      database,
+    );
     expect(result).toMatchObject({
       action: 'challenge-start',
       conversationReset: true,
       challenge: {
-        prompt: 'I want to compensate this more clearly today.',
+        prompt: 'Can you make up for the delay before everyone notices?',
         sourceCardIds: ['card-1'],
       },
     });
   });
 
-  it('rotates default challenge source cards away from the previous challenge when possible', async () => {
+  it('passes the full active challenge context to the planner for automatic challenge selection', async () => {
     const rotatingDeps = {
       ...actionDeps,
       listTranslationDrillChallengeCards: vi.fn(async () => [
@@ -447,6 +466,10 @@ describe('applyTranslationDrillAction', () => {
         },
       ]),
     } as unknown as TranslationDrillActionDeps;
+    const planChallenge = vi.fn(async () => ({
+      prompt: 'She finally got a handle on the situation.',
+      sourceCardIds: ['card-2'],
+    }));
 
     const result = await applyTranslationDrillAction(
       'user-1',
@@ -457,15 +480,193 @@ describe('applyTranslationDrillAction', () => {
       },
       database,
       rotatingDeps,
+      { planChallenge },
     );
 
+    expect(planChallenge).toHaveBeenCalledWith(expect.objectContaining({
+      previousSourceCardIds: ['card-2', 'card-1'],
+      mustUseAllCandidateCards: false,
+      candidateCards: expect.arrayContaining([
+        expect.objectContaining({ cardId: 'card-2' }),
+        expect.objectContaining({ cardId: 'card-1' }),
+      ]),
+    }));
+    expect(actionDeps.recordTranslationDrillChallengeUsage).toHaveBeenCalledWith(
+      'user-1',
+      'zh',
+      ['card-2'],
+      { occurredAt: now },
+      database,
+    );
     expect(result).toMatchObject({
       action: 'challenge-start',
       challenge: {
-        prompt: 'We should compensate this carefully before we grasp.',
-        sourceCardIds: ['card-1', 'card-2'],
+        prompt: 'She finally got a handle on the situation.',
+        sourceCardIds: ['card-2'],
       },
     });
+  });
+
+  it('shortlists automatic challenge candidates to the least-used half before planning', async () => {
+    const shortlistDeps = {
+      ...actionDeps,
+      listTranslationDrillChallengeCards: vi.fn(async () => [
+        {
+          cardId: 'card-1',
+          content: '补偿',
+          meaning: 'to compensate',
+          cardType: 'word',
+          examples: [],
+          mnemonics: [],
+          llmInstructions: null,
+          updatedAt: new Date('2026-05-01T12:00:00.000Z'),
+          sourceGroup: { groupId: 'group-core', groupName: 'Core' },
+          addedFrom: 'draw_pile:group-core',
+          addedAt: new Date('2026-05-08T12:00:00.000Z'),
+          lastUsedAt: null,
+          usageCount: 0,
+          state: 'active' as const,
+          stateUntil: null,
+          cefrOverride: null,
+          metadata: null,
+          nextDueAt: null,
+          intervalDays: null,
+          performanceScore: null,
+        },
+        {
+          cardId: 'card-2',
+          content: '把握',
+          meaning: 'to grasp',
+          cardType: 'word',
+          examples: [],
+          mnemonics: [],
+          llmInstructions: 'Prefer aspect pairs',
+          updatedAt: new Date('2026-05-02T12:00:00.000Z'),
+          sourceGroup: null,
+          addedFrom: 'pinned_from_review',
+          addedAt: new Date('2026-05-09T12:00:00.000Z'),
+          lastUsedAt: new Date('2026-05-09T12:05:00.000Z'),
+          usageCount: 1,
+          state: 'active' as const,
+          stateUntil: null,
+          cefrOverride: 'B2',
+          metadata: null,
+          nextDueAt: new Date('2026-05-13T12:00:00.000Z'),
+          intervalDays: 3,
+          performanceScore: 0.8,
+        },
+        {
+          cardId: 'card-3',
+          content: '当然',
+          meaning: 'of course',
+          cardType: 'word',
+          examples: [],
+          mnemonics: [],
+          llmInstructions: null,
+          updatedAt: new Date('2026-05-03T12:00:00.000Z'),
+          sourceGroup: null,
+          addedFrom: 'pinned_from_review',
+          addedAt: new Date('2026-05-09T12:10:00.000Z'),
+          lastUsedAt: new Date('2026-05-09T12:10:00.000Z'),
+          usageCount: 2,
+          state: 'active' as const,
+          stateUntil: null,
+          cefrOverride: null,
+          metadata: null,
+          nextDueAt: null,
+          intervalDays: null,
+          performanceScore: null,
+        },
+        {
+          cardId: 'card-4',
+          content: '解决',
+          meaning: 'to solve',
+          cardType: 'word',
+          examples: [],
+          mnemonics: [],
+          llmInstructions: null,
+          updatedAt: new Date('2026-05-04T12:00:00.000Z'),
+          sourceGroup: null,
+          addedFrom: 'pinned_from_review',
+          addedAt: new Date('2026-05-09T12:12:00.000Z'),
+          lastUsedAt: new Date('2026-05-09T12:12:00.000Z'),
+          usageCount: 3,
+          state: 'active' as const,
+          stateUntil: null,
+          cefrOverride: null,
+          metadata: null,
+          nextDueAt: null,
+          intervalDays: null,
+          performanceScore: null,
+        },
+        {
+          cardId: 'card-5',
+          content: '其实',
+          meaning: 'actually',
+          cardType: 'word',
+          examples: [],
+          mnemonics: [],
+          llmInstructions: null,
+          updatedAt: new Date('2026-05-05T12:00:00.000Z'),
+          sourceGroup: null,
+          addedFrom: 'pinned_from_review',
+          addedAt: new Date('2026-05-09T12:15:00.000Z'),
+          lastUsedAt: new Date('2026-05-09T12:15:00.000Z'),
+          usageCount: 4,
+          state: 'active' as const,
+          stateUntil: null,
+          cefrOverride: null,
+          metadata: null,
+          nextDueAt: null,
+          intervalDays: null,
+          performanceScore: null,
+        },
+      ]),
+    } as unknown as TranslationDrillActionDeps;
+    const planChallenge = vi.fn(async () => ({
+      prompt: 'Of course we can solve that later.',
+      sourceCardIds: ['card-1'],
+    }));
+
+    await applyTranslationDrillAction(
+      'user-1',
+      'zh',
+      {
+        action: 'challenge-start',
+      },
+      database,
+      shortlistDeps,
+      { planChallenge },
+    );
+
+    expect(planChallenge).toHaveBeenCalledWith(expect.objectContaining({
+      candidateCards: [
+        expect.objectContaining({ cardId: 'card-1' }),
+        expect.objectContaining({ cardId: 'card-2' }),
+      ],
+    }));
+  });
+
+  it('rejects invalid planner output before returning a challenge', async () => {
+    await expect(applyTranslationDrillAction(
+      'user-1',
+      'zh',
+      {
+        action: 'challenge-start',
+        sourceCardIds: ['card-1'],
+      },
+      database,
+      deps,
+      {
+        planChallenge: vi.fn(async () => ({
+          prompt: 'Use the bad card.',
+          sourceCardIds: ['card-2'],
+        })),
+      },
+    )).rejects.toMatchObject({
+      status: 500,
+      message: 'The challenge generator returned an invalid source-card selection.',
+    } satisfies Partial<TranslationDrillRequestError>);
   });
 
   it('rejects invalid Translation Drills action payloads', async () => {

--- a/apps/web/src/lib/server/translation-drills.ts
+++ b/apps/web/src/lib/server/translation-drills.ts
@@ -5,6 +5,7 @@ import {
   getActiveUserLanguages,
   getDb,
   getGroups,
+  recordTranslationDrillChallengeUsage,
   getTranslationDrillDismissSchedule,
   listTranslationDrillChallengeCards,
   listTranslationDrillContextCards,
@@ -15,6 +16,11 @@ import {
 } from '@studypuck/database';
 import { z } from 'zod';
 import { activeCardIdSchema, activeGroupIdSchema } from '$lib/schemas/cards.js';
+import {
+  planTranslationDrillChallenge,
+  type TranslationDrillChallengePlan,
+  type TranslationDrillChallengePlannerInput,
+} from '$lib/server/translation-drill-challenges.js';
 
 type DatabaseClient = ReturnType<typeof getDb>;
 
@@ -32,6 +38,7 @@ export type TranslationDrillActionDeps = Pick<TranslationDrillLoaderDeps, 'getAc
   snoozeTranslationDrillCard: typeof snoozeTranslationDrillCard;
   disableTranslationDrillCard: typeof disableTranslationDrillCard;
   dismissTranslationDrillCard: typeof dismissTranslationDrillCard;
+  recordTranslationDrillChallengeUsage: typeof recordTranslationDrillChallengeUsage;
   getTranslationDrillDismissSchedule: typeof getTranslationDrillDismissSchedule;
   now: () => Date;
 };
@@ -52,6 +59,7 @@ const defaultActionDeps: TranslationDrillActionDeps = {
   snoozeTranslationDrillCard,
   disableTranslationDrillCard,
   dismissTranslationDrillCard,
+  recordTranslationDrillChallengeUsage,
   getTranslationDrillDismissSchedule,
   now: () => new Date(),
 };
@@ -77,8 +85,8 @@ const translationDrillActionSchema = z.discriminatedUnion('action', [
   }),
   z.object({
     action: z.literal('challenge-start'),
-    sourceCardIds: z.array(activeCardIdSchema).min(1).max(10).optional(),
-    previousSourceCardIds: z.array(activeCardIdSchema).min(1).max(10).optional(),
+    sourceCardIds: z.array(activeCardIdSchema).min(1).max(2).optional(),
+    previousSourceCardIds: z.array(activeCardIdSchema).min(1).max(2).optional(),
   }),
   z.object({
     action: z.literal('challenge-clear'),
@@ -86,6 +94,8 @@ const translationDrillActionSchema = z.discriminatedUnion('action', [
 ]);
 
 const TRANSLATION_DRILL_DEFAULT_SNOOZE_DURATION_MS = 24 * 60 * 60 * 1_000;
+const TRANSLATION_DRILL_CHALLENGE_SHORTLIST_DIVISOR = 2;
+const TRANSLATION_DRILL_CHALLENGE_SHORTLIST_MIN_SIZE = 2;
 
 export class TranslationDrillRequestError extends Error {
   status: number;
@@ -199,6 +209,13 @@ export type TranslationDrillActionResult =
 
 type ActiveLanguageRecord = Awaited<ReturnType<typeof getActiveUserLanguages>>[number];
 
+type TranslationDrillActionRuntime = {
+  privateEnv?: Record<string, string | undefined>;
+  planChallenge?: (
+    input: TranslationDrillChallengePlannerInput,
+  ) => Promise<TranslationDrillChallengePlan>;
+};
+
 async function assertUserHasLanguage(
   userId: string,
   languageId: string,
@@ -279,6 +296,22 @@ function buildActionMessage(action: TranslationDrillActionInput['action']): stri
   }
 }
 
+function shortlistChallengeCandidateCards(cards: TranslationDrillContextCard[]) {
+  if (cards.length <= 1) {
+    return cards;
+  }
+
+  const shortlistSize = Math.min(
+    cards.length,
+    Math.max(
+      Math.floor(cards.length / TRANSLATION_DRILL_CHALLENGE_SHORTLIST_DIVISOR),
+      TRANSLATION_DRILL_CHALLENGE_SHORTLIST_MIN_SIZE,
+    ),
+  );
+
+  return cards.slice(0, shortlistSize);
+}
+
 function normalizeMutationError(error: unknown): never {
   if (error instanceof TranslationDrillRequestError) {
     throw error;
@@ -323,59 +356,31 @@ async function validateChallengeSourceCards(
   }
 }
 
-function formatChallengeMeaning(card: TranslationDrillContextCard) {
-  return card.meaning?.replace(/^to\s+/i, '') ?? `use "${card.content}"`;
-}
+function assertPlannedChallengeIsValid(
+  challenge: TranslationDrillChallengePlan,
+  candidateCards: readonly TranslationDrillContextCard[],
+  requireExactCandidateMatch: boolean,
+): void {
+  const candidateCardIds = candidateCards.map((card) => card.cardId);
+  const candidateCardIdSet = new Set(candidateCardIds);
 
-function buildChallengePrompt(cards: TranslationDrillContextCard[]) {
-  const [firstCard, secondCard] = cards;
-
-  if (!firstCard) {
-    throw new TranslationDrillRequestError(400, 'Draw or pin at least one active card before starting a challenge.');
+  if (!challenge.prompt.trim()) {
+    throw new TranslationDrillRequestError(500, 'The challenge generator returned an empty prompt.');
   }
 
-  const firstMeaning = formatChallengeMeaning(firstCard);
-  const secondMeaning = secondCard ? formatChallengeMeaning(secondCard) : null;
-
-  return secondMeaning
-    ? `We should ${firstMeaning} this carefully before we ${secondMeaning}.`
-    : `I want to ${firstMeaning} this more clearly today.`;
-}
-
-function selectDefaultChallengeSourceCardIds(
-  cards: TranslationDrillContextCard[],
-  previousSourceCardIds: readonly string[] | undefined,
-) {
-  const cardIds = cards.map((card) => card.cardId);
-
-  if (cardIds.length === 0) {
-    throw new TranslationDrillRequestError(400, 'Draw or pin at least one active card before starting a challenge.');
+  if (challenge.sourceCardIds.length === 0 || challenge.sourceCardIds.some((cardId) => !candidateCardIdSet.has(cardId))) {
+    throw new TranslationDrillRequestError(500, 'The challenge generator returned an invalid source-card selection.');
   }
 
-  if (cardIds.length === 1 || !previousSourceCardIds || previousSourceCardIds.length === 0) {
-    return cardIds.slice(0, Math.min(2, cardIds.length));
+  if (
+    requireExactCandidateMatch
+    && (
+      challenge.sourceCardIds.length !== candidateCardIds.length
+      || challenge.sourceCardIds.some((cardId, index) => cardId !== candidateCardIds[index])
+    )
+  ) {
+    throw new TranslationDrillRequestError(500, 'The challenge generator did not preserve the requested source cards.');
   }
-
-  const previousChallengeKey = previousSourceCardIds.join('|');
-  const firstPreviousIndex = cardIds.indexOf(previousSourceCardIds[0] ?? '');
-
-  if (firstPreviousIndex === -1) {
-    return cardIds.slice(0, Math.min(2, cardIds.length));
-  }
-
-  for (let offset = 1; offset < cardIds.length; offset += 1) {
-    const startIndex = (firstPreviousIndex + offset) % cardIds.length;
-    const candidate = Array.from(
-      { length: Math.min(2, cardIds.length) },
-      (_, index) => cardIds[(startIndex + index) % cardIds.length]!,
-    );
-
-    if (candidate.join('|') !== previousChallengeKey) {
-      return candidate;
-    }
-  }
-
-  return cardIds.slice(0, Math.min(2, cardIds.length));
 }
 
 export async function loadTranslationDrillHomeData(
@@ -447,8 +452,9 @@ export async function applyTranslationDrillAction(
   input: unknown,
   database: DatabaseClient,
   deps: TranslationDrillActionDeps = defaultActionDeps,
+  runtime: TranslationDrillActionRuntime = {},
 ): Promise<TranslationDrillActionResult> {
-  await assertUserHasLanguage(userId, languageId, database, deps);
+  const language = await assertUserHasLanguage(userId, languageId, database, deps);
 
   const parsed = translationDrillActionSchema.safeParse(input);
 
@@ -560,25 +566,53 @@ export async function applyTranslationDrillAction(
       }
 
       case 'challenge-start': {
+        const occurredAt = deps.now();
         const availableChallengeCards = await deps.listTranslationDrillChallengeCards(userId, languageId, database as never);
-        const selectedSourceCardIds = payload.sourceCardIds
-          ?? selectDefaultChallengeSourceCardIds(availableChallengeCards, payload.previousSourceCardIds);
-
-        await validateChallengeSourceCards(userId, languageId, selectedSourceCardIds, database, deps);
-
         const challengeCardById = new Map(availableChallengeCards.map((card) => [card.cardId, card]));
-        const sourceCards = selectedSourceCardIds
-          .map((cardId) => challengeCardById.get(cardId))
-          .filter((card): card is TranslationDrillContextCard => card !== undefined);
+        const requestedSourceCardIds = payload.sourceCardIds
+          ? [...payload.sourceCardIds]
+          : null;
+
+        if (requestedSourceCardIds) {
+          await validateChallengeSourceCards(userId, languageId, requestedSourceCardIds, database, deps);
+        }
+
+        const candidateCards = requestedSourceCardIds
+          ? requestedSourceCardIds
+            .map((cardId) => challengeCardById.get(cardId))
+            .filter((card): card is TranslationDrillContextCard => card !== undefined)
+          : shortlistChallengeCandidateCards(availableChallengeCards);
+        const planChallenge = runtime.planChallenge ?? ((planInput: TranslationDrillChallengePlannerInput) =>
+          planTranslationDrillChallenge({
+            ...planInput,
+            privateEnv: runtime.privateEnv ?? {},
+          }));
+        const plannedChallenge = await planChallenge({
+          userId,
+          languageId,
+          targetLanguageName: language.languageName,
+          cefrLevel: language.cefrLevel ?? null,
+          candidateCards,
+          previousSourceCardIds: payload.previousSourceCardIds,
+          mustUseAllCandidateCards: Boolean(requestedSourceCardIds),
+        });
+        assertPlannedChallengeIsValid(plannedChallenge, candidateCards, Boolean(requestedSourceCardIds));
+        await deps.recordTranslationDrillChallengeUsage(
+          userId,
+          languageId,
+          plannedChallenge.sourceCardIds,
+          { occurredAt },
+          database as never,
+        );
         const challengeId = `translation-drill-${globalThis.crypto?.randomUUID?.() ?? Date.now().toString(36)}`;
 
         return {
           action: 'challenge-start',
           challenge: {
             challengeId,
-            prompt: buildChallengePrompt(sourceCards),
-            sourceCardIds: selectedSourceCardIds,
-            startedAtIso: deps.now().toISOString(),
+            prompt: plannedChallenge.prompt,
+            sourceCardIds: plannedChallenge.sourceCardIds,
+            startedAtIso: occurredAt.toISOString(),
           },
           conversationReset: true,
           message: buildActionMessage('challenge-start'),

--- a/apps/web/src/routes/[lang]/translation-drills/actions/+server.ts
+++ b/apps/web/src/routes/[lang]/translation-drills/actions/+server.ts
@@ -27,7 +27,9 @@ export const POST: RequestHandler = async (event) => {
   try {
     const result = await withTransactionDb(
       env.DATABASE_URL,
-      (database) => applyTranslationDrillAction(userId, languageId, body, database as never),
+      (database) => applyTranslationDrillAction(userId, languageId, body, database as never, undefined, {
+        privateEnv: env,
+      }),
     );
 
     return json(result);

--- a/apps/web/tests/e2e/translation-drills.spec.ts
+++ b/apps/web/tests/e2e/translation-drills.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test, type Page } from '@playwright/test';
+import { getDb, translationDrillContext, upsertTranslationDrillDrawPile } from '@studypuck/database';
+import { resetDatabase, seedActiveCard, seedGroup, seedUser } from './support/database';
+import { signInAs } from './support/session';
+
+const testDatabaseUrl =
+	process.env.TEST_DATABASE_URL ??
+	process.env.DATABASE_URL ??
+	'postgresql://test_user:test_password@localhost:5433/studypuck_test';
+
+async function seedTranslationDrillsUser(page: Page) {
+	await resetDatabase();
+
+	const user = await seedUser({
+		userId: 'auth0|translation-drills-e2e',
+		email: 'translation-drills@example.com',
+		name: 'Translation Drills User',
+		languages: [{ code: 'zh', label: 'Chinese' }],
+	});
+
+	const group = await seedGroup({
+		userId: user.userId,
+		languageId: 'zh',
+		groupId: 'group-core',
+		groupName: 'Core Words',
+	});
+
+	await seedActiveCard({
+		userId: user.userId,
+		languageId: 'zh',
+		cardId: 'card-translation-drills-detail',
+		cardContent: '经历',
+		meaning: 'experience',
+		groupId: group.groupId,
+	});
+
+	const database = getDb(testDatabaseUrl);
+
+	await upsertTranslationDrillDrawPile(user.userId, 'zh', group.groupId, { pileSizeLimit: 4 }, database as never);
+	await database.insert(translationDrillContext).values({
+		userId: user.userId,
+		languageId: 'zh',
+		cardId: 'card-translation-drills-detail',
+		state: 'active',
+		addedFrom: `draw_pile:${group.groupId}`,
+		addedAt: new Date('2026-05-16T12:00:00.000Z'),
+	});
+
+	await signInAs(page, user);
+}
+
+test('translation drills opens the card detail drawer from the context menu', async ({ page }) => {
+	await seedTranslationDrillsUser(page);
+
+	await page.goto('/zh/translation-drills');
+
+	const activeCardRow = page.locator('article[aria-label="经历"]');
+	await expect(activeCardRow).toBeVisible();
+
+	await activeCardRow.getByRole('button', { name: '···' }).click();
+	await page.getByRole('button', { name: 'View card detail' }).click();
+
+	const drawer = page.getByRole('dialog');
+	await expect(drawer).toBeVisible();
+	await expect(drawer.getByRole('textbox', { name: 'Content' })).toHaveValue('经历');
+	await drawer.getByRole('button', { name: 'Close drawer' }).click();
+	await expect(drawer).toHaveCount(0);
+});

--- a/apps/web/tests/e2e/translation-drills.spec.ts
+++ b/apps/web/tests/e2e/translation-drills.spec.ts
@@ -56,11 +56,14 @@ test('translation drills opens the card detail drawer from the context menu', as
 
 	const activeCardRow = page.locator('article[aria-label="经历"]');
 	await expect(activeCardRow).toBeVisible();
-	await activeCardRow.hover();
+	const menuButton = activeCardRow.getByRole('button', { name: '···' });
+	await menuButton.focus();
+	await expect(menuButton).toBeFocused();
+	await menuButton.press('Enter');
 
-	await expect(activeCardRow.getByRole('button', { name: '···' })).toBeVisible();
-	await activeCardRow.getByRole('button', { name: '···' }).click();
-	await page.getByRole('button', { name: 'View card detail' }).click();
+	const viewCardDetailButton = page.getByRole('button', { name: 'View card detail' });
+	await expect(viewCardDetailButton).toBeVisible();
+	await viewCardDetailButton.click();
 
 	const drawer = page.getByRole('dialog');
 	await expect(drawer).toBeVisible();

--- a/apps/web/tests/e2e/translation-drills.spec.ts
+++ b/apps/web/tests/e2e/translation-drills.spec.ts
@@ -56,7 +56,9 @@ test('translation drills opens the card detail drawer from the context menu', as
 
 	const activeCardRow = page.locator('article[aria-label="经历"]');
 	await expect(activeCardRow).toBeVisible();
+	await activeCardRow.hover();
 
+	await expect(activeCardRow.getByRole('button', { name: '···' })).toBeVisible();
 	await activeCardRow.getByRole('button', { name: '···' }).click();
 	await page.getByRole('button', { name: 'View card detail' }).click();
 

--- a/docs/requirements/functionality/translation-drills.md
+++ b/docs/requirements/functionality/translation-drills.md
@@ -66,6 +66,18 @@ The LLM creates English sentences following specific behavioral requirements:
 - **Cross-group Integration**: When possible, use cards from different groups within the same sentence to reinforce connections
 - **Context Awareness**: Draw from currently active cards in the translation context
 
+### Challenge Quality Definition
+
+A good Translation Drills challenge is not just any sentence that mentions a card's dictionary gloss. It must satisfy all of the following:
+
+- **Natural English prompt**: The sentence should sound like something a real person might say or write, not a template or study-app instruction.
+- **Clear lexical target**: The prompt should create a concrete opportunity to use the intended card or cards in the target language.
+- **Focused difficulty**: One focus card is preferred; a second card is only used when it creates a more natural sentence rather than a more crowded one.
+- **Idiomatic respect**: Phrase, collocation, and idiom cards must be exercised in believable situations. The prompt should not flatten them into awkward literal English.
+- **Card-aware grounding**: Card examples, card type, and per-card LLM instructions should influence challenge selection and phrasing.
+- **No brittle gloss splicing**: The system must not build challenge text by mechanically inserting raw card meanings into canned sentence shells.
+- **Evaluation-ready scope**: The resulting challenge should be specific enough that the follow-up feedback can judge whether the learner used the intended structure naturally, while still allowing valid alternative phrasings.
+
 ### User Translation
 
 - **One Sentence at a Time**: Each translation exercise focuses on a single English sentence
@@ -78,6 +90,7 @@ The LLM creates English sentences following specific behavioral requirements:
 - **Grammar Focus**: Emphasis on grammatical accuracy and proper usage patterns
 - **Usage Guidance**: Corrections that explain not just what was wrong but why
 - **Conversational Support**: LLM can engage in follow-up discussion about translation choices, alternative approaches, or related grammar concepts
+- **Card-target awareness**: Feedback should explicitly note whether the learner used the intended focus card or cards naturally, and whether a different phrasing is still acceptable
 
 ## Context Management Operations
 

--- a/packages/database/src/tests/translation-drills.test.ts
+++ b/packages/database/src/tests/translation-drills.test.ts
@@ -21,6 +21,7 @@ import {
   listTranslationDrillContextCards,
   listTranslationDrillDrawPileGroups,
   pinCardToTranslationDrillsContext,
+  recordTranslationDrillChallengeUsage,
   snoozeTranslationDrillCard,
   upsertTranslationDrillDrawPile,
 } from '../translation-drills.js';
@@ -303,6 +304,40 @@ describe('Translation Drills database operations', () => {
 
     expect(drawn.cardId).toBe('card-new');
     expect(dailyStats?.cardsDrawn).toBe(1);
+  });
+
+  it('records selected challenge cards as used', async () => {
+    await seedLibrary();
+
+    await recordTranslationDrillChallengeUsage(
+      TEST_USER.userId,
+      TEST_LANG.languageId,
+      ['card-active', 'card-pinned'],
+      { occurredAt: NOW },
+      db,
+    );
+
+    const storedContextCards = await db
+      .select({
+        cardId: translationDrillContext.cardId,
+        usageCount: translationDrillContext.usageCount,
+        lastUsed: translationDrillContext.lastUsed,
+      })
+      .from(translationDrillContext)
+      .where(eq(translationDrillContext.userId, TEST_USER.userId));
+
+    expect(storedContextCards).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        cardId: 'card-active',
+        usageCount: 2,
+        lastUsed: NOW,
+      }),
+      expect.objectContaining({
+        cardId: 'card-pinned',
+        usageCount: 5,
+        lastUsed: NOW,
+      }),
+    ]));
   });
 
   it('updates snooze, dismiss, and disable state without touching core card status', async () => {

--- a/packages/database/src/tests/translation-drills.test.ts
+++ b/packages/database/src/tests/translation-drills.test.ts
@@ -254,7 +254,7 @@ describe('Translation Drills database operations', () => {
     expect(drawPiles[0]?.activeCards.map((card) => card.cardId)).toEqual(['card-active']);
     expect(drawPiles[0]?.snoozedCards.map((card) => card.cardId)).toEqual(['card-snoozed']);
     expect(contextCards.find((card) => card.cardId === 'card-pinned')?.sourceGroup).toBeNull();
-    expect(challengeCards.map((card) => card.cardId)).toEqual(['card-pinned', 'card-active']);
+    expect(challengeCards.map((card) => card.cardId)).toEqual(['card-active', 'card-pinned']);
   });
 
   it('draws the next eligible card from a configured pile and can pin cards from Card Review', async () => {

--- a/packages/database/src/tests/translation-drills.test.ts
+++ b/packages/database/src/tests/translation-drills.test.ts
@@ -317,24 +317,34 @@ describe('Translation Drills database operations', () => {
       db,
     );
 
-    const storedContextCards = await db
+    const contextCards = await listTranslationDrillContextCards(TEST_USER.userId, TEST_LANG.languageId, db);
+    const storedUsageRows = await db
       .select({
         cardId: translationDrillContext.cardId,
-        usageCount: translationDrillContext.usageCount,
         lastUsed: translationDrillContext.lastUsed,
       })
       .from(translationDrillContext)
       .where(eq(translationDrillContext.userId, TEST_USER.userId));
 
-    expect(storedContextCards).toEqual(expect.arrayContaining([
+    expect(contextCards).toEqual(expect.arrayContaining([
       expect.objectContaining({
         cardId: 'card-active',
         usageCount: 2,
-        lastUsed: NOW,
+        lastUsedAt: NOW,
       }),
       expect.objectContaining({
         cardId: 'card-pinned',
         usageCount: 5,
+        lastUsedAt: NOW,
+      }),
+    ]));
+    expect(storedUsageRows).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        cardId: 'card-active',
+        lastUsed: NOW,
+      }),
+      expect.objectContaining({
+        cardId: 'card-pinned',
         lastUsed: NOW,
       }),
     ]));

--- a/packages/database/src/translation-drills.ts
+++ b/packages/database/src/translation-drills.ts
@@ -840,6 +840,44 @@ export async function disableTranslationDrillCard(
   });
 }
 
+export async function recordTranslationDrillChallengeUsage(
+  userId: string,
+  languageId: string,
+  cardIds: readonly string[],
+  options: { occurredAt?: Date } = {},
+  database?: AnyDb,
+): Promise<void> {
+  const normalizedCardIds = [...new Set(cardIds.map((cardId) => cardId.trim()).filter(Boolean))];
+
+  if (normalizedCardIds.length === 0) {
+    return;
+  }
+
+  const occurredAt = options.occurredAt ?? new Date();
+
+  await runInTransaction(database, async (tx) => {
+    const contextCards = await Promise.all(normalizedCardIds.map(async (cardId) => requireContextCard(userId, languageId, cardId, tx)));
+
+    if (contextCards.some((card) => card.state !== 'active')) {
+      throw new Error('Only active Translation Drills cards can be recorded for challenge usage.');
+    }
+
+    for (const card of contextCards) {
+      await tx
+        .update(translationDrillContext)
+        .set({
+          lastUsed: occurredAt,
+          usageCount: card.usageCount + 1,
+        })
+        .where(and(
+          eq(translationDrillContext.userId, userId),
+          eq(translationDrillContext.languageId, languageId),
+          eq(translationDrillContext.cardId, card.cardId),
+        ));
+    }
+  });
+}
+
 export async function dismissTranslationDrillCard(
   userId: string,
   languageId: string,

--- a/packages/database/src/translation-drills.ts
+++ b/packages/database/src/translation-drills.ts
@@ -362,8 +362,8 @@ async function loadContextRows(
       ...(normalizedCardIds.length > 0 ? [inArray(translationDrillContext.cardId, normalizedCardIds)] : []),
     ))
     .orderBy(
-      sql`${translationDrillContext.lastUsed} ASC NULLS FIRST`,
-      asc(translationDrillContext.usageCount),
+      sql`COALESCE(${translationDrillContext.lastUsed}, to_timestamp(${translationDrillSrs.lastUsed})) ASC NULLS FIRST`,
+      sql`GREATEST(COALESCE(${translationDrillContext.usageCount}, 0), COALESCE(${translationDrillSrs.usageCount}, 0))`,
       desc(cards.updatedAt),
     );
 }
@@ -438,12 +438,16 @@ function buildGroupLookup(groupRows: Array<{ groupId: string; groupName: string 
   return new Map(groupRows.map((group) => [group.groupId, group.groupName]));
 }
 
+function getEffectiveUsageCount(contextUsageCount: number | null, srsUsageCount: number | null): number {
+  return Math.max(contextUsageCount ?? 0, srsUsageCount ?? 0);
+}
+
 function mapContextCard(
   row: TranslationDrillContextRow,
   groupLookup: Map<string, string>,
 ): TranslationDrillContextCard {
   const sourceGroupId = parseDrawPileSourceGroupId(row.addedFrom);
-  const usageCount = row.contextUsageCount ?? row.srsUsageCount ?? 0;
+  const usageCount = getEffectiveUsageCount(row.contextUsageCount, row.srsUsageCount);
 
   return {
     cardId: row.cardId,


### PR DESCRIPTION
## Summary
- harden Translation Drills challenge generation and chat structured-output recovery with deterministic repair, LLM repair, and provider fallback
- fix Translation Drills card-detail drawer regressions and preserve the drawer across safe home refreshes
- record selected challenge cards as used so repeated selection is less biased over time

## Testing
- pnpm --filter web exec vitest run src/lib/server/ai-service.test.ts src/lib/server/chat.test.ts
- pnpm turbo test lint build --filter=web