### PR TITLE
Fix Card Entry sign-off transaction failure

### DIFF
--- a/apps/web/tests/e2e/translation-drills.spec.ts
+++ b/apps/web/tests/e2e/translation-drills.spec.ts
@@ -57,11 +57,10 @@ test('translation drills opens the card detail drawer from the context menu', as
 	const activeCardRow = page.locator('article[aria-label="经历"]');
 	await expect(activeCardRow).toBeVisible();
 	const menuButton = activeCardRow.getByRole('button', { name: '···' });
-	await menuButton.focus();
-	await expect(menuButton).toBeFocused();
-	await menuButton.press('Enter');
+	await menuButton.click();
+	await expect(menuButton).toHaveAttribute('aria-expanded', 'true');
 
-	const viewCardDetailButton = page.getByRole('button', { name: 'View card detail' });
+	const viewCardDetailButton = activeCardRow.getByRole('button', { name: 'View card detail' });
 	await expect(viewCardDetailButton).toBeVisible();
 	await viewCardDetailButton.click();
 

--- a/apps/web/tests/e2e/translation-drills.spec.ts
+++ b/apps/web/tests/e2e/translation-drills.spec.ts
@@ -56,6 +56,7 @@ test('translation drills opens the card detail drawer from the context menu', as
 
 	const activeCardRow = page.locator('article[aria-label="经历"]');
 	await expect(activeCardRow).toBeVisible();
+	await activeCardRow.hover();
 	const menuButton = activeCardRow.getByRole('button', { name: '···' });
 	await menuButton.click();
 	await expect(menuButton).toHaveAttribute('aria-expanded', 'true');

--- a/packages/database/src/card-entry.ts
+++ b/packages/database/src/card-entry.ts
@@ -700,7 +700,7 @@ export async function signOffNote(
       throw new Error(`Cannot sign off note ${noteId} because it has no linked draft cards`);
     }
 
-    await promoteDraftCards(userId, languageId, draftCardIds, tx);
+    await promoteDraftCardsInTransaction(userId, languageId, draftCardIds, tx);
     const noteResult = await tx
       .select()
       .from(inboxNotes)
@@ -718,105 +718,112 @@ export async function signOffNote(
   });
 }
 
+async function promoteDraftCardsInTransaction(
+  userId: string,
+  languageId: string,
+  cardIds: string[],
+  tx: AnyDb
+): Promise<PromoteDraftCardsResult> {
+  const uniqueCardIds = [...new Set(cardIds)];
+
+  if (uniqueCardIds.length === 0) {
+    return {
+      promotedCardIds: [],
+      processedNoteIds: [],
+    };
+  }
+
+  const draftCards = await tx
+    .select({ cardId: cards.cardId })
+    .from(cards)
+    .where(and(
+      eq(cards.userId, userId),
+      eq(cards.languageId, languageId),
+      eq(cards.status, 'draft'),
+      inArray(cards.cardId, uniqueCardIds)
+    ));
+
+  const foundCardIds = draftCards.map((card) => card.cardId);
+
+  if (foundCardIds.length !== uniqueCardIds.length) {
+    const foundCardIdSet = new Set(foundCardIds);
+    const missingCardId = uniqueCardIds.find((cardId) => !foundCardIdSet.has(cardId));
+    throw new Error(`Draft card not found: ${missingCardId}`);
+  }
+
+  const groupedCardRows = await tx
+    .select({ cardId: cardGroups.cardId })
+    .from(cardGroups)
+    .where(and(
+      eq(cardGroups.userId, userId),
+      eq(cardGroups.languageId, languageId),
+      inArray(cardGroups.cardId, uniqueCardIds)
+    ));
+
+  const groupedCardIds = new Set(groupedCardRows.map((row) => row.cardId));
+  const cardIdMissingGroup = uniqueCardIds.find((cardId) => !groupedCardIds.has(cardId));
+
+  if (cardIdMissingGroup) {
+    throw new Error(`Draft card requires at least one group before promotion: ${cardIdMissingGroup}`);
+  }
+
+  const linkedNoteRows = await tx
+    .select({ noteId: noteCardLinks.noteId })
+    .from(noteCardLinks)
+    .where(and(
+      eq(noteCardLinks.userId, userId),
+      eq(noteCardLinks.languageId, languageId),
+      inArray(noteCardLinks.cardId, uniqueCardIds)
+    ));
+
+  const affectedNoteIds = [...new Set(linkedNoteRows.map((row) => row.noteId))];
+  const now = new Date();
+
+  await tx
+    .update(cards)
+    .set({
+      status: 'active',
+      updatedAt: now,
+    })
+    .where(and(
+      eq(cards.userId, userId),
+      eq(cards.languageId, languageId),
+      inArray(cards.cardId, uniqueCardIds)
+    ));
+
+  const remainingDraftNoteIds = await getRemainingDraftNoteIds(userId, languageId, affectedNoteIds, tx);
+  const remainingDraftNoteIdSet = new Set(remainingDraftNoteIds);
+  const processedNoteIds = affectedNoteIds.filter((noteId) => !remainingDraftNoteIdSet.has(noteId));
+
+  if (processedNoteIds.length > 0) {
+    await tx
+      .update(inboxNotes)
+      .set({ state: 'processed' })
+      .where(and(
+        eq(inboxNotes.userId, userId),
+        eq(inboxNotes.languageId, languageId),
+        inArray(inboxNotes.noteId, processedNoteIds)
+      ));
+  }
+
+  await incrementCardEntryDailyStats(userId, languageId, {
+    notesProcessed: processedNoteIds.length,
+    cardsPromotedToActive: uniqueCardIds.length,
+  }, tx);
+
+  return {
+    promotedCardIds: uniqueCardIds,
+    processedNoteIds,
+  };
+}
+
 export async function promoteDraftCards(
   userId: string,
   languageId: string,
   cardIds: string[],
   db?: AnyDb
 ): Promise<PromoteDraftCardsResult> {
-  return withTransaction(db, async (tx) => {
-    const uniqueCardIds = [...new Set(cardIds)];
-
-    if (uniqueCardIds.length === 0) {
-      return {
-        promotedCardIds: [],
-        processedNoteIds: [],
-      };
-    }
-
-    const draftCards = await tx
-      .select({ cardId: cards.cardId })
-      .from(cards)
-      .where(and(
-        eq(cards.userId, userId),
-        eq(cards.languageId, languageId),
-        eq(cards.status, 'draft'),
-        inArray(cards.cardId, uniqueCardIds)
-      ));
-
-    const foundCardIds = draftCards.map((card) => card.cardId);
-
-    if (foundCardIds.length !== uniqueCardIds.length) {
-      const foundCardIdSet = new Set(foundCardIds);
-      const missingCardId = uniqueCardIds.find((cardId) => !foundCardIdSet.has(cardId));
-      throw new Error(`Draft card not found: ${missingCardId}`);
-    }
-
-    const groupedCardRows = await tx
-      .select({ cardId: cardGroups.cardId })
-      .from(cardGroups)
-      .where(and(
-        eq(cardGroups.userId, userId),
-        eq(cardGroups.languageId, languageId),
-        inArray(cardGroups.cardId, uniqueCardIds)
-      ));
-
-    const groupedCardIds = new Set(groupedCardRows.map((row) => row.cardId));
-    const cardIdMissingGroup = uniqueCardIds.find((cardId) => !groupedCardIds.has(cardId));
-
-    if (cardIdMissingGroup) {
-      throw new Error(`Draft card requires at least one group before promotion: ${cardIdMissingGroup}`);
-    }
-
-    const linkedNoteRows = await tx
-      .select({ noteId: noteCardLinks.noteId })
-      .from(noteCardLinks)
-      .where(and(
-        eq(noteCardLinks.userId, userId),
-        eq(noteCardLinks.languageId, languageId),
-        inArray(noteCardLinks.cardId, uniqueCardIds)
-      ));
-
-    const affectedNoteIds = [...new Set(linkedNoteRows.map((row) => row.noteId))];
-    const now = new Date();
-
-    await tx
-      .update(cards)
-      .set({
-        status: 'active',
-        updatedAt: now,
-      })
-      .where(and(
-        eq(cards.userId, userId),
-        eq(cards.languageId, languageId),
-        inArray(cards.cardId, uniqueCardIds)
-      ));
-
-    const remainingDraftNoteIds = await getRemainingDraftNoteIds(userId, languageId, affectedNoteIds, tx);
-    const remainingDraftNoteIdSet = new Set(remainingDraftNoteIds);
-    const processedNoteIds = affectedNoteIds.filter((noteId) => !remainingDraftNoteIdSet.has(noteId));
-
-    if (processedNoteIds.length > 0) {
-      await tx
-        .update(inboxNotes)
-        .set({ state: 'processed' })
-        .where(and(
-          eq(inboxNotes.userId, userId),
-          eq(inboxNotes.languageId, languageId),
-          inArray(inboxNotes.noteId, processedNoteIds)
-        ));
-    }
-
-    await incrementCardEntryDailyStats(userId, languageId, {
-      notesProcessed: processedNoteIds.length,
-      cardsPromotedToActive: uniqueCardIds.length,
-    }, tx);
-
-    return {
-      promotedCardIds: uniqueCardIds,
-      processedNoteIds,
-    };
-  });
+  return withTransaction(db, async (tx) => promoteDraftCardsInTransaction(userId, languageId, cardIds, tx));
 }
 
 export async function deleteDraftCards(

--- a/packages/database/src/tests/card-entry.unit.test.ts
+++ b/packages/database/src/tests/card-entry.unit.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { signOffNote } from '../card-entry.js';
+
+class FakeQuery<T> {
+  constructor(private readonly result: T) {}
+
+  from() {
+    return this;
+  }
+
+  where() {
+    return this;
+  }
+
+  orderBy() {
+    return this;
+  }
+
+  limit() {
+    return this;
+  }
+
+  innerJoin() {
+    return this;
+  }
+
+  returning() {
+    return this;
+  }
+
+  then<TResult1 = T, TResult2 = never>(
+    onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ) {
+    return Promise.resolve(this.result).then(onfulfilled, onrejected);
+  }
+}
+
+describe('Card Entry transaction behavior', () => {
+  it('signs off notes without requiring nested transaction support on the inner transaction client', async () => {
+    const note = {
+      userId: 'auth0|card-entry-user',
+      languageId: 'es',
+      noteId: 'note-signoff-no-nested-tx',
+      content: 'repasar para que',
+      sourceType: 'manual',
+      state: 'unprocessed' as const,
+      aiState: 'failed' as const,
+      createdAt: new Date('2026-04-01T00:00:00.000Z'),
+    };
+
+    const selectResults = [
+      [note],
+      [{ cardId: 'draft-no-nested-tx' }],
+      [{ cardId: 'draft-no-nested-tx' }],
+      [{ cardId: 'draft-no-nested-tx' }],
+      [{ cardId: 'draft-no-nested-tx' }],
+      [{ noteId: note.noteId }],
+      [],
+      [],
+      [{ ...note, state: 'processed' as const }],
+    ];
+
+    const updateResults = [[], []];
+    const insertResults = [[{
+      userId: note.userId,
+      languageId: note.languageId,
+      date: '2026-04-01',
+      notesCaptured: 0,
+      notesProcessed: 1,
+      notesDeferred: 0,
+      notesDeleted: 0,
+      draftCardsCreated: 0,
+      cardsPromotedToActive: 1,
+      groupsCreated: 0,
+    }]];
+
+    const tx = {
+      select: () => new FakeQuery(selectResults.shift() ?? []),
+      update: () => ({
+        set: () => new FakeQuery(updateResults.shift() ?? []),
+      }),
+      insert: () => ({
+        values: () => new FakeQuery(insertResults.shift() ?? []),
+      }),
+    };
+
+    const outerDb = {
+      transaction: async <T>(callback: (database: typeof tx) => Promise<T>) => callback(tx),
+    };
+
+    const result = await signOffNote(note.userId, note.languageId, note.noteId, outerDb as never);
+
+    expect(result.promotedCardIds).toEqual(['draft-no-nested-tx']);
+    expect(result.note.state).toBe('processed');
+  });
+});


### PR DESCRIPTION
## Summary
- avoid opening a nested transaction while signing off Card Entry notes
- reuse the active transaction for draft promotion during note sign-off
- add a regression test for transaction clients that do not expose nested transaction support

## Validation
- pnpm --filter @studypuck/database test:branch:raw src/tests/card-entry.unit.test.ts
- pnpm turbo test lint build --filter=web