### PR TITLE
Fix Translation Drills dismiss schedule ordering

### DIFF
--- a/apps/web/src/lib/components/translation-drills/TranslationDrillsHome.svelte
+++ b/apps/web/src/lib/components/translation-drills/TranslationDrillsHome.svelte
@@ -13,6 +13,10 @@
     translationDrillSessionActions,
     type TranslationDrillLocalResponse,
   } from '$lib/stores/translationDrillSessionActions.js';
+  import {
+    getTranslationDrillDismissDefaultDays,
+    getTranslationDrillDismissOptions,
+  } from '$lib/translation-drills/dismiss-schedule.js';
 
   export let lang: string;
   export let home: TranslationDrillHomeData | null;
@@ -98,7 +102,7 @@
   }
 
   $: dismissCard = dismissCardId ? findCard(dismissCardId)?.card ?? null : null;
-  $: dismissOptions = dismissCard?.dismissSchedule?.optionDays ?? [1];
+  $: dismissOptions = getTranslationDrillDismissOptions(dismissCard?.dismissSchedule);
   $: drawerCard = drawerCardId ? findCard(drawerCardId)?.card ?? null : null;
   $: drawerCardDetail = drawerCard ? toDrawerCard(drawerCard) : null;
   $: availableDrawerGroups = homeState?.availableGroups ?? [];
@@ -450,7 +454,7 @@
 
     setFocusedCard(cardId);
     dismissCardId = cardId;
-    dismissReturnInDays = card.dismissSchedule?.recommendedDays ?? card.dismissSchedule?.optionDays[0] ?? 1;
+    dismissReturnInDays = getTranslationDrillDismissDefaultDays(card.dismissSchedule);
     openMenuCardId = null;
     actionError = null;
   }

--- a/apps/web/src/lib/components/translation-drills/TranslationDrillsHome.test.ts
+++ b/apps/web/src/lib/components/translation-drills/TranslationDrillsHome.test.ts
@@ -219,6 +219,34 @@ describe('TranslationDrillsHome', () => {
     });
   });
 
+  it('shows Tomorrow first and keeps the recommended option selected in the dismiss dialog', async () => {
+    const home = createHome();
+    home.configuredGroups[0]!.activeCards = [createCard({
+      dismissSchedule: {
+        recommendedDays: 14,
+        optionDays: [30, 14],
+      },
+    })];
+
+    render(TranslationDrillsHome, {
+      props: {
+        lang: 'zh',
+        home,
+        loadError: null,
+      },
+    });
+
+    await fireEvent.click(screen.getAllByRole('button', { name: '✕ Dismiss' })[0]);
+
+    const dialog = screen.getByRole('dialog');
+    const radios = within(dialog).getAllByRole('radio') as HTMLInputElement[];
+
+    expect(radios.map((radio) => radio.value)).toEqual(['1', '14', '30']);
+    expect(radios[0]?.closest('label')?.textContent).toContain('Tomorrow');
+    expect(radios[1]?.checked).toBe(true);
+    expect(radios[1]?.closest('label')?.textContent).toContain('Recommended');
+  });
+
   it('opens card detail from the drill context and lets the user close the drawer', async () => {
     render(TranslationDrillsHome, {
       props: {

--- a/apps/web/src/lib/server/translation-drills.test.ts
+++ b/apps/web/src/lib/server/translation-drills.test.ts
@@ -202,6 +202,25 @@ describe('Translation Drills server helpers', () => {
       status: 404,
     } satisfies Partial<TranslationDrillRequestError>);
   });
+
+  it('normalizes dismiss schedules so Tomorrow is always first', async () => {
+    baseDeps.getTranslationDrillDismissSchedule.mockImplementation(async (_userId: string, _languageId: string, cardId: string) => ({
+      cardId,
+      recommendedDays: 14,
+      optionDays: [30, 14],
+    }));
+
+    const result = await loadTranslationDrillHomeData('user-1', 'zh', database, deps);
+
+    expect(result.configuredGroups[0]?.activeCards[0]?.dismissSchedule).toEqual({
+      recommendedDays: 14,
+      optionDays: [1, 14, 30],
+    });
+    expect(result.challenge.generationInput.cards[0]?.dismissSchedule).toEqual({
+      recommendedDays: 14,
+      optionDays: [1, 14, 30],
+    });
+  });
 });
 
 describe('applyTranslationDrillAction', () => {

--- a/apps/web/src/lib/server/translation-drills.ts
+++ b/apps/web/src/lib/server/translation-drills.ts
@@ -21,6 +21,7 @@ import {
   type TranslationDrillChallengePlan,
   type TranslationDrillChallengePlannerInput,
 } from '$lib/server/translation-drill-challenges.js';
+import { normalizeTranslationDrillDismissSchedule } from '$lib/translation-drills/dismiss-schedule.js';
 
 type DatabaseClient = ReturnType<typeof getDb>;
 
@@ -236,6 +237,10 @@ function toIsoString(date: Date | null): string | null {
   return date ? date.toISOString() : null;
 }
 
+function toDismissScheduleData(schedule: TranslationDrillDismissScheduleData): TranslationDrillDismissScheduleData {
+  return normalizeTranslationDrillDismissSchedule(schedule);
+}
+
 function mapContextCard(
   card: TranslationDrillContextCard,
   dismissSchedules: ReadonlyMap<string, TranslationDrillDismissScheduleData> = new Map(),
@@ -406,10 +411,10 @@ export async function loadTranslationDrillHomeData(
 
       return [
         card.cardId,
-        {
+        toDismissScheduleData({
           recommendedDays: schedule.recommendedDays,
           optionDays: schedule.optionDays,
-        } satisfies TranslationDrillDismissScheduleData,
+        }),
       ] as const;
     }),
   );
@@ -480,10 +485,10 @@ export async function applyTranslationDrillAction(
           action: 'draw',
           card: mapContextCard(drawnCard, new Map([[
             drawnCard.cardId,
-            {
+            toDismissScheduleData({
               recommendedDays: schedule.recommendedDays,
               optionDays: schedule.optionDays,
-            },
+            }),
           ]])),
           message: buildActionMessage('draw'),
         };

--- a/apps/web/src/lib/translation-drills/dismiss-schedule.ts
+++ b/apps/web/src/lib/translation-drills/dismiss-schedule.ts
@@ -1,0 +1,46 @@
+export const TRANSLATION_DRILL_TOMORROW_DAYS = 1;
+
+type DismissScheduleLike = {
+  recommendedDays: number;
+  optionDays: number[];
+};
+
+function isValidDismissDays(days: number | null | undefined): days is number {
+  return typeof days === 'number' && Number.isInteger(days) && days >= TRANSLATION_DRILL_TOMORROW_DAYS;
+}
+
+export function getTranslationDrillDismissOptions(schedule: DismissScheduleLike | null | undefined): number[] {
+  const recommendedDays = isValidDismissDays(schedule?.recommendedDays) ? schedule.recommendedDays : null;
+  const optionDays = schedule?.optionDays.filter((days) => isValidDismissDays(days)) ?? [];
+
+  return [...new Set([
+    TRANSLATION_DRILL_TOMORROW_DAYS,
+    ...optionDays,
+    ...(recommendedDays === null ? [] : [recommendedDays]),
+  ])].sort((left, right) => {
+    if (left === TRANSLATION_DRILL_TOMORROW_DAYS) {
+      return -1;
+    }
+
+    if (right === TRANSLATION_DRILL_TOMORROW_DAYS) {
+      return 1;
+    }
+
+    return left - right;
+  });
+}
+
+export function getTranslationDrillDismissDefaultDays(schedule: DismissScheduleLike | null | undefined): number {
+  if (isValidDismissDays(schedule?.recommendedDays)) {
+    return schedule.recommendedDays;
+  }
+
+  return getTranslationDrillDismissOptions(schedule)[0] ?? TRANSLATION_DRILL_TOMORROW_DAYS;
+}
+
+export function normalizeTranslationDrillDismissSchedule<T extends DismissScheduleLike>(schedule: T): T {
+  return {
+    ...schedule,
+    optionDays: getTranslationDrillDismissOptions(schedule),
+  };
+}


### PR DESCRIPTION
## Summary
- always include Tomorrow as the first dismiss option for Translation Drills cards
- preserve the recommended SRS interval as the default selected option
- add UI and server coverage for normalized dismiss schedules

Closes #208