### PR TITLE
Add Translation Drills e2e coverage and accessibility polish

### DIFF
--- a/apps/web/src/lib/components/translation-drills/TranslationDrillsHome.svelte
+++ b/apps/web/src/lib/components/translation-drills/TranslationDrillsHome.svelte
@@ -766,6 +766,8 @@
                     <button
                       type="button"
                       class="card-row__action"
+                      aria-label={`More actions for ${card.content}`}
+                      aria-controls={`translation-drills-menu-${card.cardId}`}
                       aria-expanded={openMenuCardId === card.cardId}
                       aria-haspopup="menu"
                       onclick={() => openMenuCardId = openMenuCardId === card.cardId ? null : card.cardId}
@@ -774,10 +776,16 @@
                     </button>
 
                     {#if openMenuCardId === card.cardId}
-                      <div class="card-row__menu stack" style="--stack-space: var(--space-1)" role="menu">
+                      <div
+                        id={`translation-drills-menu-${card.cardId}`}
+                        class="card-row__menu stack"
+                        style="--stack-space: var(--space-1)"
+                        role="menu"
+                      >
                         <button
                           type="button"
                           class="card-row__menu-button"
+                          role="menuitem"
                           onclick={() => openDrawer(card.cardId)}
                         >
                           View card detail
@@ -785,6 +793,7 @@
                         <button
                           type="button"
                           class="card-row__menu-button"
+                          role="menuitem"
                           disabled={isActionPending(`card:${card.cardId}:disable`)}
                           onclick={() => void handleDisable(card.cardId)}
                         >
@@ -793,6 +802,7 @@
                         <button
                           type="button"
                           class="card-row__menu-button"
+                          role="menuitem"
                           onclick={() => openMenuCardId = null}
                         >
                           Cancel
@@ -824,6 +834,8 @@
                     <button
                       type="button"
                       class="card-row__action"
+                      aria-label={`More actions for ${card.content}`}
+                      aria-controls={`translation-drills-menu-${card.cardId}`}
                       aria-expanded={openMenuCardId === card.cardId}
                       aria-haspopup="menu"
                       onclick={() => openMenuCardId = openMenuCardId === card.cardId ? null : card.cardId}
@@ -832,10 +844,16 @@
                     </button>
 
                     {#if openMenuCardId === card.cardId}
-                      <div class="card-row__menu stack" style="--stack-space: var(--space-1)" role="menu">
+                      <div
+                        id={`translation-drills-menu-${card.cardId}`}
+                        class="card-row__menu stack"
+                        style="--stack-space: var(--space-1)"
+                        role="menu"
+                      >
                         <button
                           type="button"
                           class="card-row__menu-button"
+                          role="menuitem"
                           onclick={() => openDrawer(card.cardId)}
                         >
                           View card detail
@@ -843,6 +861,7 @@
                         <button
                           type="button"
                           class="card-row__menu-button"
+                          role="menuitem"
                           disabled={isActionPending(`card:${card.cardId}:disable`)}
                           onclick={() => void handleDisable(card.cardId)}
                         >
@@ -851,6 +870,7 @@
                         <button
                           type="button"
                           class="card-row__menu-button"
+                          role="menuitem"
                           onclick={() => openMenuCardId = null}
                         >
                           Cancel
@@ -940,6 +960,8 @@
             <button
               type="button"
               class="translation-drills__button translation-drills__button--secondary"
+              aria-controls="translation-drills-overlay-detail"
+              aria-expanded={learnMoreExpanded}
               onclick={() => learnMoreExpanded = !learnMoreExpanded}
             >
               Learn more
@@ -947,7 +969,7 @@
           </div>
 
           {#if learnMoreExpanded}
-            <p class="translation-drills__overlay-detail">
+            <p id="translation-drills-overlay-detail" class="translation-drills__overlay-detail">
               Add groups, mark them as Translation Drills piles, and draw from those piles whenever you want fresh vocabulary in view.
             </p>
           {/if}

--- a/apps/web/src/lib/components/translation-drills/TranslationDrillsHome.test.ts
+++ b/apps/web/src/lib/components/translation-drills/TranslationDrillsHome.test.ts
@@ -96,7 +96,7 @@ describe('TranslationDrillsHome', () => {
     expect(screen.getByRole('button', { name: 'HSK2 draw pile — 2 cards remaining' })).toBeTruthy();
   });
 
-  it('shows the empty-context overlay when no drill groups or cards are available', () => {
+  it('shows the empty-context overlay when no drill groups or cards are available', async () => {
     render(TranslationDrillsHome, {
       props: {
         lang: 'zh',
@@ -120,7 +120,14 @@ describe('TranslationDrillsHome', () => {
     });
 
     expect(screen.getByRole('heading', { name: 'Add groups to start drilling' })).toBeTruthy();
+    const learnMoreButton = screen.getByRole('button', { name: 'Learn more' });
+    expect(learnMoreButton.getAttribute('aria-expanded')).toBe('false');
     expect(screen.getByRole('link', { name: 'Go to Groups' }).getAttribute('href')).toBe('/zh/cards/groups');
+
+    await fireEvent.click(learnMoreButton);
+
+    expect(learnMoreButton.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByText(/Add groups, mark them as Translation Drills piles/)).toBeTruthy();
   });
 
   it('draws cards from a pile and updates the visible count', async () => {
@@ -258,8 +265,8 @@ describe('TranslationDrillsHome', () => {
 
     const activeCardRow = screen.getByLabelText('经历').closest('article');
     expect(activeCardRow).toBeTruthy();
-    await fireEvent.click(within(activeCardRow as HTMLElement).getByRole('button', { name: '···' }));
-    await fireEvent.click(screen.getByRole('button', { name: 'View card detail' }));
+    await fireEvent.click(within(activeCardRow as HTMLElement).getByRole('button', { name: 'More actions for 经历' }));
+    await fireEvent.click(screen.getByRole('menuitem', { name: 'View card detail' }));
 
     const closeButton = await screen.findByRole('button', { name: 'Close drawer' });
     expect(closeButton.hasAttribute('disabled')).toBe(false);
@@ -282,8 +289,8 @@ describe('TranslationDrillsHome', () => {
 
     const activeCardRow = screen.getByLabelText('经历').closest('article');
     expect(activeCardRow).toBeTruthy();
-    await fireEvent.click(within(activeCardRow as HTMLElement).getByRole('button', { name: '···' }));
-    await fireEvent.click(screen.getByRole('button', { name: 'View card detail' }));
+    await fireEvent.click(within(activeCardRow as HTMLElement).getByRole('button', { name: 'More actions for 经历' }));
+    await fireEvent.click(screen.getByRole('menuitem', { name: 'View card detail' }));
 
     await screen.findByRole('button', { name: 'Close drawer' });
 

--- a/apps/web/src/lib/server/translation-drill-challenges.test.ts
+++ b/apps/web/src/lib/server/translation-drill-challenges.test.ts
@@ -1,0 +1,89 @@
+import type { TranslationDrillContextCard } from '@studypuck/database';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { planTranslationDrillChallenge } from './translation-drill-challenges.js';
+
+function createCandidateCard(overrides: Partial<TranslationDrillContextCard> = {}): TranslationDrillContextCard {
+  return {
+    cardId: 'card-1',
+    content: '经历',
+    meaning: 'experience',
+    cardType: 'word',
+    sourceGroup: { groupId: 'group-core', groupName: 'Core Words' },
+    examples: [],
+    mnemonics: [],
+    llmInstructions: null,
+    usageCount: 0,
+    lastUsedAt: null,
+    cefrOverride: null,
+    addedFrom: 'draw_pile:group-core',
+    addedAt: new Date('2026-05-16T12:00:00.000Z'),
+    state: 'active',
+    stateUntil: null,
+    nextDueAt: null,
+    intervalDays: null,
+    performanceScore: null,
+    metadata: null,
+    updatedAt: new Date('2026-05-16T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('planTranslationDrillChallenge', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('uses a deterministic local planner in e2e mode', async () => {
+    vi.stubEnv('E2E_TEST_MODE', 'enabled');
+    const generateStructured = vi.fn();
+
+    const plan = await planTranslationDrillChallenge({
+      userId: 'auth0|translation-drills',
+      languageId: 'zh',
+      targetLanguageName: 'Chinese (Mandarin)',
+      cefrLevel: 'B1',
+      candidateCards: [
+        createCandidateCard(),
+        createCandidateCard({
+          cardId: 'card-2',
+          content: '谈论',
+          meaning: 'discuss',
+        }),
+      ],
+      privateEnv: {},
+      generateStructured,
+    });
+
+    expect(plan).toEqual({
+      prompt: 'Use experience in a natural sentence.',
+      sourceCardIds: ['card-1'],
+    });
+    expect(generateStructured).not.toHaveBeenCalled();
+  });
+
+  it('rotates away from the previous source card in e2e mode when another candidate exists', async () => {
+    vi.stubEnv('E2E_TEST_MODE', 'enabled');
+
+    const plan = await planTranslationDrillChallenge({
+      userId: 'auth0|translation-drills',
+      languageId: 'zh',
+      targetLanguageName: 'Chinese (Mandarin)',
+      cefrLevel: 'B1',
+      candidateCards: [
+        createCandidateCard(),
+        createCandidateCard({
+          cardId: 'card-2',
+          content: '谈论',
+          meaning: 'discuss',
+        }),
+      ],
+      previousSourceCardIds: ['card-1'],
+      privateEnv: {},
+    });
+
+    expect(plan).toEqual({
+      prompt: 'Use discuss in a natural sentence.',
+      sourceCardIds: ['card-2'],
+    });
+  });
+});

--- a/apps/web/src/lib/server/translation-drill-challenges.ts
+++ b/apps/web/src/lib/server/translation-drill-challenges.ts
@@ -36,6 +36,14 @@ export type TranslationDrillChallengePlan = {
   sourceCardIds: string[];
 };
 
+function isE2ETestModeEnabled() {
+  if (typeof process === 'undefined') {
+    return false;
+  }
+
+  return process.env?.E2E_TEST_MODE === 'enabled';
+}
+
 function toPromptCard(card: TranslationDrillContextCard): TranslationDrillChallengePromptCard {
   return {
     cardId: card.cardId,
@@ -88,6 +96,22 @@ function validateChallengePlan(
   };
 }
 
+function buildE2EChallengePlan(input: TranslationDrillChallengePlannerInput): TranslationDrillChallengePlan {
+  const previousSourceCardIds = new Set(normalizeSourceCardIds(input.previousSourceCardIds ?? []));
+  const nextCandidates = input.mustUseAllCandidateCards
+    ? input.candidateCards
+    : input.candidateCards.filter((card) => !previousSourceCardIds.has(card.cardId));
+  const selectedCards = (nextCandidates.length > 0 ? nextCandidates : input.candidateCards).slice(
+    0,
+    input.mustUseAllCandidateCards ? input.candidateCards.length : 1,
+  );
+
+  return {
+    prompt: `Use ${selectedCards.map((card) => card.meaning?.trim() || card.content.trim()).join(' + ')} in a natural sentence.`,
+    sourceCardIds: selectedCards.map((card) => card.cardId),
+  };
+}
+
 export async function planTranslationDrillChallenge(
   input: TranslationDrillChallengePlannerInput & {
     privateEnv: Record<string, string | undefined>;
@@ -96,6 +120,10 @@ export async function planTranslationDrillChallenge(
 ): Promise<TranslationDrillChallengePlan> {
   if (input.candidateCards.length === 0) {
     throw new Error('Draw or pin at least one active card before starting a challenge.');
+  }
+
+  if (isE2ETestModeEnabled()) {
+    return validateChallengePlan(buildE2EChallengePlan(input), input);
   }
 
   const prompt = buildTranslationDrillChallengePrompt({

--- a/apps/web/tests/e2e/translation-drills.spec.ts
+++ b/apps/web/tests/e2e/translation-drills.spec.ts
@@ -8,66 +8,277 @@ const testDatabaseUrl =
 	process.env.DATABASE_URL ??
 	'postgresql://test_user:test_password@localhost:5433/studypuck_test';
 
-async function seedTranslationDrillsUser(page: Page) {
+type SeedTranslationDrillCard = {
+	cardId: string;
+	content: string;
+	meaning: string;
+};
+
+type SeedTranslationDrillsPageOptions = {
+	groupName?: string | null;
+	activeGroupCards?: SeedTranslationDrillCard[];
+	snoozedGroupCards?: SeedTranslationDrillCard[];
+	remainingGroupCards?: SeedTranslationDrillCard[];
+	ungroupedCards?: SeedTranslationDrillCard[];
+};
+
+async function insertContextCard(input: {
+	userId: string;
+	languageId: string;
+	cardId: string;
+	state: 'active' | 'snoozed';
+	addedFrom: string;
+	addedAt: Date;
+	stateUntil?: Date | null;
+}) {
+	const database = getDb(testDatabaseUrl);
+
+	await database.insert(translationDrillContext).values({
+		userId: input.userId,
+		languageId: input.languageId,
+		cardId: input.cardId,
+		state: input.state,
+		addedFrom: input.addedFrom,
+		addedAt: input.addedAt,
+		stateUntil: input.stateUntil ?? null,
+	});
+}
+
+async function seedTranslationDrillsPage(page: Page, options: SeedTranslationDrillsPageOptions = {}) {
 	await resetDatabase();
 
 	const user = await seedUser({
 		userId: 'auth0|translation-drills-e2e',
 		email: 'translation-drills@example.com',
 		name: 'Translation Drills User',
-		languages: [{ code: 'zh', label: 'Chinese' }],
+		languages: [{ code: 'zh', label: 'Chinese (Mandarin)' }],
 	});
 
-	const group = await seedGroup({
-		userId: user.userId,
-		languageId: 'zh',
-		groupId: 'group-core',
-		groupName: 'Core Words',
-	});
+	const groupName = options.groupName ?? 'Core Words';
+	let groupId: string | null = null;
 
-	await seedActiveCard({
-		userId: user.userId,
-		languageId: 'zh',
-		cardId: 'card-translation-drills-detail',
-		cardContent: '经历',
-		meaning: 'experience',
-		groupId: group.groupId,
-	});
+	if (groupName) {
+		const group = await seedGroup({
+			userId: user.userId,
+			languageId: 'zh',
+			groupId: 'group-core',
+			groupName,
+		});
 
-	const database = getDb(testDatabaseUrl);
+		groupId = group.groupId;
+		await upsertTranslationDrillDrawPile(user.userId, 'zh', group.groupId, { pileSizeLimit: 4 }, getDb(testDatabaseUrl) as never);
+	}
 
-	await upsertTranslationDrillDrawPile(user.userId, 'zh', group.groupId, { pileSizeLimit: 4 }, database as never);
-	await database.insert(translationDrillContext).values({
-		userId: user.userId,
-		languageId: 'zh',
-		cardId: 'card-translation-drills-detail',
-		state: 'active',
-		addedFrom: `draw_pile:${group.groupId}`,
-		addedAt: new Date('2026-05-16T12:00:00.000Z'),
-	});
+	for (const [index, card] of (options.activeGroupCards ?? []).entries()) {
+		if (!groupId) {
+			throw new Error('Active group cards require a configured Translation Drills group.');
+		}
+
+		await seedActiveCard({
+			userId: user.userId,
+			languageId: 'zh',
+			cardId: card.cardId,
+			cardContent: card.content,
+			meaning: card.meaning,
+			groupId,
+		});
+		await insertContextCard({
+			userId: user.userId,
+			languageId: 'zh',
+			cardId: card.cardId,
+			state: 'active',
+			addedFrom: `draw_pile:${groupId}`,
+			addedAt: new Date(`2026-05-16T12:0${index}:00.000Z`),
+		});
+	}
+
+	for (const [index, card] of (options.snoozedGroupCards ?? []).entries()) {
+		if (!groupId) {
+			throw new Error('Snoozed group cards require a configured Translation Drills group.');
+		}
+
+		await seedActiveCard({
+			userId: user.userId,
+			languageId: 'zh',
+			cardId: card.cardId,
+			cardContent: card.content,
+			meaning: card.meaning,
+			groupId,
+		});
+		await insertContextCard({
+			userId: user.userId,
+			languageId: 'zh',
+			cardId: card.cardId,
+			state: 'snoozed',
+			addedFrom: `draw_pile:${groupId}`,
+			addedAt: new Date(`2026-05-16T12:1${index}:00.000Z`),
+			stateUntil: new Date(`2026-05-21T12:1${index}:00.000Z`),
+		});
+	}
+
+	for (const card of options.remainingGroupCards ?? []) {
+		if (!groupId) {
+			throw new Error('Remaining draw-pile cards require a configured Translation Drills group.');
+		}
+
+		await seedActiveCard({
+			userId: user.userId,
+			languageId: 'zh',
+			cardId: card.cardId,
+			cardContent: card.content,
+			meaning: card.meaning,
+			groupId,
+		});
+	}
+
+	for (const [index, card] of (options.ungroupedCards ?? []).entries()) {
+		await seedActiveCard({
+			userId: user.userId,
+			languageId: 'zh',
+			cardId: card.cardId,
+			cardContent: card.content,
+			meaning: card.meaning,
+		});
+		await insertContextCard({
+			userId: user.userId,
+			languageId: 'zh',
+			cardId: card.cardId,
+			state: 'active',
+			addedFrom: 'pinned',
+			addedAt: new Date(`2026-05-16T12:2${index}:00.000Z`),
+		});
+	}
 
 	await signInAs(page, user);
 }
 
-test('translation drills opens the card detail drawer from the context menu', async ({ page }) => {
-	await seedTranslationDrillsUser(page);
+async function submitCommand(page: Page, input: string) {
+	const commandBar = page.getByRole('textbox', { name: 'Command bar' });
+	await commandBar.fill(input);
+	await commandBar.press('Enter');
+}
+
+test('translation drills shows the empty-context onboarding overlay and setup affordances', async ({ page }) => {
+	await seedTranslationDrillsPage(page, { groupName: null });
 
 	await page.goto('/zh/translation-drills');
 
+	await expect(page.locator('.command-bar__context-value')).toHaveText('Translation Drills');
+	await expect(page.getByRole('heading', { name: 'Context overview' })).toBeVisible();
+	await expect(page.getByRole('heading', { name: 'Add groups to start drilling' })).toBeVisible();
+
+	const learnMoreButton = page.getByRole('button', { name: 'Learn more' });
+	await expect(learnMoreButton).toHaveAttribute('aria-expanded', 'false');
+	await learnMoreButton.click();
+	await expect(learnMoreButton).toHaveAttribute('aria-expanded', 'true');
+	await expect(
+		page.getByText('Add groups, mark them as Translation Drills piles, and draw from those piles whenever you want fresh vocabulary in view.')
+	).toBeVisible();
+	await expect(page.getByRole('link', { name: 'Go to Groups' })).toHaveAttribute('href', '/zh/cards/groups');
+});
+
+test('translation drills covers card detail, draw piles, snooze, and dismiss flows', async ({ page }) => {
+	await seedTranslationDrillsPage(page, {
+		activeGroupCards: [{ cardId: 'card-experience', content: '经历', meaning: 'experience' }],
+		snoozedGroupCards: [{ cardId: 'card-feeling', content: '感觉', meaning: 'feeling' }],
+		remainingGroupCards: [{ cardId: 'card-study', content: '学习', meaning: 'study' }],
+	});
+
+	await page.goto('/zh/translation-drills');
+
+	await expect(page.getByRole('button', { name: 'Core Words draw pile — 1 card remaining' })).toBeVisible();
+	await expect(page.locator('article[aria-label="感觉, snoozed"]')).toBeVisible();
+
 	const activeCardRow = page.locator('article[aria-label="经历"]');
 	await expect(activeCardRow).toBeVisible();
-	await activeCardRow.hover();
-	const menuButton = activeCardRow.getByRole('button', { name: '···' });
-	await menuButton.click();
+	const menuButton = activeCardRow.getByRole('button', { name: 'More actions for 经历' });
+	await menuButton.focus();
+	await menuButton.press('Enter');
 	await expect(menuButton).toHaveAttribute('aria-expanded', 'true');
-
-	const viewCardDetailButton = activeCardRow.getByRole('button', { name: 'View card detail' });
-	await expect(viewCardDetailButton).toBeVisible();
-	await viewCardDetailButton.click();
+	const viewCardDetailButton = activeCardRow.getByRole('menuitem', { name: 'View card detail' });
+	await viewCardDetailButton.focus();
+	await viewCardDetailButton.press('Enter');
 
 	const drawer = page.getByRole('dialog');
 	await expect(drawer).toBeVisible();
 	await expect(drawer.getByRole('textbox', { name: 'Content' })).toHaveValue('经历');
 	await drawer.getByRole('button', { name: 'Close drawer' }).click();
 	await expect(drawer).toHaveCount(0);
+
+	await page.getByRole('button', { name: 'Core Words draw pile — 1 card remaining' }).click();
+	await expect(page.locator('article[aria-label="学习"]')).toBeVisible();
+	await expect(page.getByRole('button', { name: 'Core Words draw pile — Pile empty' })).toBeDisabled();
+
+	const snoozeButton = activeCardRow.getByRole('button', { name: '💤 Snooze' });
+	await snoozeButton.focus();
+	await snoozeButton.press('Enter');
+	await expect(page.locator('article[aria-label="经历, snoozed"]')).toBeVisible();
+
+	const drawnCardRow = page.locator('article[aria-label="学习"]');
+	const dismissButton = drawnCardRow.getByRole('button', { name: '✕ Dismiss' });
+	await dismissButton.focus();
+	await dismissButton.press('Enter');
+
+	const dialog = page.getByRole('dialog', { name: '学习' });
+	await expect(dialog).toBeVisible();
+	await expect(dialog.getByText('When should it return?')).toBeVisible();
+	await expect(dialog.getByRole('radio').first()).toBeVisible();
+	await dialog.getByRole('button', { name: 'Dismiss', exact: true }).click();
+
+	await expect(page.locator('article[aria-label="学习"]')).toHaveCount(0);
+	await expect(page.getByRole('status')).toContainText('学习 dismissed');
+});
+
+test('translation drills command-bar flows cover context, draw, snooze, dismiss, and challenge reset behavior', async ({ page }) => {
+	await seedTranslationDrillsPage(page, {
+		activeGroupCards: [
+			{ cardId: 'card-experience', content: '经历', meaning: 'experience' },
+			{ cardId: 'card-discuss', content: '谈论', meaning: 'discuss' },
+		],
+		remainingGroupCards: [{ cardId: 'card-express', content: '表达', meaning: 'express' }],
+	});
+
+	await page.goto('/zh/translation-drills');
+
+	await expect(page.locator('.command-bar__context-value')).toHaveText('Translation Drills');
+	await expect(page.getByRole('button', { name: 'Collapse cards view' })).toBeVisible();
+	await page.getByRole('button', { name: 'Collapse cards view' }).click();
+	const openCardsViewButtons = page.locator('button[aria-label="Open cards view"]');
+	await expect(openCardsViewButtons.first()).toBeVisible();
+	await openCardsViewButtons.first().click();
+
+	const conversationView = page.getByRole('complementary', { name: 'Conversation view' });
+
+	await submitCommand(page, '/context');
+	await expect(
+		conversationView.getByText(/Active context: (经历, 谈论|谈论, 经历)\. No active challenge yet\./)
+	).toBeVisible();
+
+	await submitCommand(page, '/draw Core');
+	await expect(conversationView.getByText('表达 drawn into context.')).toBeVisible();
+	await expect(page.locator('article[aria-label="表达"]')).toBeVisible();
+
+	await submitCommand(page, '/snooze');
+	await expect(conversationView.getByText('谈论 snoozed.')).toBeVisible();
+	await expect(page.locator('article[aria-label="谈论, snoozed"]')).toBeVisible();
+
+	await submitCommand(page, '/dismiss');
+	await expect(conversationView.getByText('Choose when the card should return in the dismiss dialog.')).toBeVisible();
+	const dismissDialog = page.getByRole('dialog', { name: '谈论' });
+	await expect(dismissDialog).toBeVisible();
+	await dismissDialog.getByRole('button', { name: 'Dismiss', exact: true }).click();
+	await expect(page.locator('article[aria-label="谈论, snoozed"]')).toHaveCount(0);
+
+	await submitCommand(page, '/next');
+	await expect(conversationView.getByText('New conversation')).toBeVisible();
+	await expect(conversationView.getByText('New challenge ready. Translate to Chinese (Mandarin): "Use express in a natural sentence."')).toBeVisible();
+	await expect(page.getByRole('status').filter({ hasText: 'Translate to Chinese (Mandarin)' })).toContainText('Use express in a natural sentence.');
+	await expect(
+		conversationView.getByText(/Active context: (经历, 谈论|谈论, 经历)\. No active challenge yet\./)
+	).toHaveCount(0);
+
+	await submitCommand(page, '/next');
+	await expect(conversationView.getByText('New challenge ready. Translate to Chinese (Mandarin): "Use experience in a natural sentence."')).toBeVisible();
+	await expect(page.getByRole('status').filter({ hasText: 'Translate to Chinese (Mandarin)' })).toContainText('Use experience in a natural sentence.');
+	await expect(conversationView.getByText('Use express in a natural sentence.')).toHaveCount(0);
 });

--- a/scripts/neon-ephemeral-branch.mjs
+++ b/scripts/neon-ephemeral-branch.mjs
@@ -54,7 +54,8 @@ export const runCommandStreaming = (command, commandArgs, env, cwd) =>
 		});
 	});
 
-export const runNeon = (args, env) => runCommandCapture('npx', ['--yes', 'neonctl', ...args], env);
+export const runNeon = (args, env) =>
+	runCommandCapture(process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm', ['exec', 'neonctl', ...args], env);
 
 export const deleteBranch = (branchName, env) => {
 	runNeon(['branches', 'delete', branchName, '--force'], env);

--- a/scripts/neon-ephemeral-branch.mjs
+++ b/scripts/neon-ephemeral-branch.mjs
@@ -28,6 +28,14 @@ export const runCommandCapture = (command, commandArgs, env) => {
 	}).trim();
 };
 
+const tryRunCommandCapture = (command, commandArgs, env) => {
+	try {
+		return runCommandCapture(command, commandArgs, env);
+	} catch {
+		return null;
+	}
+};
+
 export const runCommandStreaming = (command, commandArgs, env, cwd) =>
 	new Promise((resolve) => {
 		const child =
@@ -54,8 +62,16 @@ export const runCommandStreaming = (command, commandArgs, env, cwd) =>
 		});
 	});
 
-export const runNeon = (args, env) =>
-	runCommandCapture(process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm', ['exec', 'neonctl', ...args], env);
+export const runNeon = (args, env) => {
+	const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+	const pnpmResult = tryRunCommandCapture(pnpmCommand, ['exec', 'neonctl', ...args], env);
+
+	if (pnpmResult !== null) {
+		return pnpmResult;
+	}
+
+	return runCommandCapture(process.platform === 'win32' ? 'npx.cmd' : 'npx', ['--yes', 'neonctl', ...args], env);
+};
 
 export const deleteBranch = (branchName, env) => {
 	runNeon(['branches', 'delete', branchName, '--force'], env);

--- a/scripts/run-playwright-neon.mjs
+++ b/scripts/run-playwright-neon.mjs
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { createServer } from 'node:net';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -18,11 +19,11 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
 const webAppDir = resolve(repoRoot, 'apps', 'web');
 const viteCliPath = resolve(webAppDir, 'node_modules', 'vite', 'bin', 'vite.js');
+const playwrightArgs = process.argv.slice(2);
 const BRANCH_PREFIX = 'test-e2e-web-';
 const PARENT_BRANCH = 'development';
 const SERVER_HOST = '127.0.0.1';
-const SERVER_PORT = Number(process.env.PLAYWRIGHT_PORT ?? 4173);
-const SERVER_URL = `http://${SERVER_HOST}:${SERVER_PORT}`;
+const DEFAULT_SERVER_PORT = 4173;
 const SERVER_START_TIMEOUT_MS = 180_000;
 
 const startLongRunningCommand = (command, commandArgs, env, cwd) =>
@@ -40,6 +41,25 @@ const startLongRunningCommand = (command, commandArgs, env, cwd) =>
 			});
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const findAvailablePort = async (preferredPort) => {
+	for (let port = preferredPort; port < preferredPort + 20; port += 1) {
+		const isAvailable = await new Promise((resolve) => {
+			const server = createServer();
+			server.unref();
+			server.once('error', () => resolve(false));
+			server.listen(port, SERVER_HOST, () => {
+				server.close(() => resolve(true));
+			});
+		});
+
+		if (isAvailable) {
+			return port;
+		}
+	}
+
+	throw new Error(`Unable to find an available Playwright port starting at ${preferredPort}.`);
+};
 
 const waitForServer = async (url, timeoutMs) => {
 	const deadline = Date.now() + timeoutMs;
@@ -111,6 +131,11 @@ try {
 		DATABASE_URL: testDatabaseUrl,
 		E2E_TEST_MODE: 'enabled',
 	};
+	const requestedPort = process.env.PLAYWRIGHT_PORT;
+	const serverPort = requestedPort
+		? Number(requestedPort)
+		: await findAvailablePort(DEFAULT_SERVER_PORT);
+	const serverUrl = `http://${SERVER_HOST}:${serverPort}`;
 
 	const migrateExitCode = await runCommandStreaming(
 		'pnpm',
@@ -130,23 +155,32 @@ try {
 			'--host',
 			SERVER_HOST,
 			'--port',
-			String(SERVER_PORT),
+			String(serverPort),
 			'--strictPort',
 		],
 		testEnv,
 		webAppDir
 	);
 
-	await waitForServer(SERVER_URL, SERVER_START_TIMEOUT_MS);
+	if (!requestedPort && serverPort !== DEFAULT_SERVER_PORT) {
+		console.log(`Port ${DEFAULT_SERVER_PORT} is busy; using Playwright port ${serverPort} instead.`);
+	}
+
+	await waitForServer(serverUrl, SERVER_START_TIMEOUT_MS);
 
 	const exitCode = await runCommandStreaming(
 		'pnpm',
-		['--dir', webAppDir, 'test:e2e'],
+		[
+			'--dir',
+			webAppDir,
+			'test:e2e',
+			...(playwrightArgs.length > 0 ? ['--', ...playwrightArgs] : []),
+		],
 		{
 			...testEnv,
 			PLAYWRIGHT_MANAGED_SERVER: '1',
-			PLAYWRIGHT_BASE_URL: SERVER_URL,
-			PLAYWRIGHT_PORT: String(SERVER_PORT),
+			PLAYWRIGHT_BASE_URL: serverUrl,
+			PLAYWRIGHT_PORT: String(serverPort),
 		},
 		repoRoot
 	);


### PR DESCRIPTION
## Summary
- add Translation Drills browser coverage for onboarding, draw pile actions, card detail, dismiss flow, and command-bar drill interactions
- add deterministic Translation Drills challenge planner tests for e2e mode
- harden the secure Playwright Neon runner to auto-pick an open port, forward targeted spec args, and use pnpm exec neonctl

## Validation
- 
ode scripts\\run-playwright-neon.mjs tests/e2e/translation-drills.spec.ts
- pnpm --filter web test
- pnpm --filter web lint
- pnpm --filter web build

Closes #201