### PR TITLE
feat: invite-only signup gate

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -30,6 +30,15 @@ TEST_DATABASE_URL=postgresql://test_user:test_password@localhost:5433/studypuck_
 # @optional
 NEON_TEST_DATABASE_URL=
 
+# --- Access Control ---
+
+# Comma-separated list of email addresses allowed to sign in (all logins, not just first signup).
+# When unset or empty, ALL sign-ins are denied — the app is fully locked.
+# Production/Preview: set in Cloudflare Pages → Settings → Environment variables.
+# Local dev: stored in Bitwarden (non-sensitive field, resolved via optional secret helper).
+# @optional
+ALLOWED_EMAILS=exec('node scripts/bitwarden-optional-secret.mjs ALLOWED_EMAILS')
+
 # --- Authentication ---
 
 # Session signing secret for Auth.js.

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -60,6 +60,21 @@ const { handle: authHandle, signIn, signOut } = SvelteKitAuth(async (event) => {
 				return normalizeRedirectTarget({ url, baseUrl, publicOrigin });
 			},
 
+			async signIn({ user }) {
+				// Allowlist gate: fully locked when ALLOWED_EMAILS is unset or empty.
+				if (isE2ETestRequestAllowed(event)) return true;
+
+				const allowedEmailsEnv = env.ALLOWED_EMAILS?.trim() ?? '';
+				if (!allowedEmailsEnv) return false;
+
+				const allowedEmails = allowedEmailsEnv
+					.split(',')
+					.map((e) => e.trim().toLowerCase())
+					.filter(Boolean);
+
+				return allowedEmails.includes((user.email ?? '').toLowerCase());
+			},
+
 			async jwt({ token, user, profile }) {
 				// Store user data in JWT when user first signs in
 				if (user && profile) {

--- a/apps/web/src/routes/auth/error/+page.svelte
+++ b/apps/web/src/routes/auth/error/+page.svelte
@@ -4,6 +4,7 @@
 
   let errorMessage = 'An unknown error occurred during authentication.';
   const commonErrors = {
+    'AccessDenied': 'StudyPuck is currently invite-only. If you\'d like access, please reach out to Zach.',
     'access_denied': 'You have declined to grant the application access. If this was a mistake, you can try signing in again.',
     'configuration_error': 'There is a server-side configuration error with the authentication provider.',
     'invalid_request': 'The request to the authentication provider was invalid. Please try again.',


### PR DESCRIPTION
## Summary

Closes the open signup door. StudyPuck is now invite-only.

## What changed

- **\hooks.server.ts\**: Added \signIn\ callback that checks the user's email against \ALLOWED_EMAILS\
- **\.env.schema\**: Documents the new \ALLOWED_EMAILS\ variable (optional; empty = fully locked)
- **\/auth/error\**: Added friendly \AccessDenied\ message for uninvited users

## How the gate works

- \ALLOWED_EMAILS\ is a comma-separated list of permitted email addresses managed in **Cloudflare Pages → Settings → Environment variables**
- When unset or empty → **all sign-ins are denied** (fully locked)
- When set → only listed emails can sign in (case-insensitive)
- **No redeploy needed** to add/remove someone — just update the env var

## e2e tests

Unaffected — the e2e cookie session path never touches the \signIn\ callback.

## After merging

Set \ALLOWED_EMAILS\ in Cloudflare Pages with your email(s) before anyone tries to log in.