### PR TITLE
fix: add DATABASE_URL_PRODUCTION to Bitwarden env keys

### DIFF
--- a/scripts/studypuck-env.mjs
+++ b/scripts/studypuck-env.mjs
@@ -11,7 +11,7 @@ export const requiredSecretKeys = [
 	'DATABASE_URL',
 ];
 
-export const optionalSecretKeys = ['NEON_API_KEY', 'GEMINI_API_KEY', 'OPENAI_API_KEY'];
+export const optionalSecretKeys = ['NEON_API_KEY', 'GEMINI_API_KEY', 'OPENAI_API_KEY', 'DATABASE_URL_PRODUCTION'];
 
 const supportedSecretKeys = [...requiredSecretKeys, ...optionalSecretKeys];
 


### PR DESCRIPTION
Small fix missed in #229 — \DATABASE_URL_PRODUCTION\ wasn't listed in \optionalSecretKeys\ in \studypuck-env.mjs\, so \
un-with-bitwarden-env.mjs\ never fetched it from Bitwarden, causing the POS backfill script to fail with 'not set' error even after adding the value to Bitwarden.

Closes #225 