### PR TITLE
feat(#226): AI guesses part_of_speech on draft card creation

### DIFF
--- a/apps/web/src/lib/server/ai-prompts/card-entry.test.ts
+++ b/apps/web/src/lib/server/ai-prompts/card-entry.test.ts
@@ -25,6 +25,25 @@ describe('cardEntryDraftSuggestionSchema', () => {
   it('rejects invalid cardType values', () => {
     expect(() => cardEntryDraftSuggestionSchema.parse({ content: '经历', cardType: 'sentence' })).toThrow();
   });
+
+  it('accepts a valid partOfSpeech value', () => {
+    const result = cardEntryDraftSuggestionSchema.parse({ content: '经历', cardType: 'word', partOfSpeech: 'verb' });
+    expect(result.partOfSpeech).toBe('verb');
+  });
+
+  it('defaults partOfSpeech to null when omitted', () => {
+    const result = cardEntryDraftSuggestionSchema.parse({ content: '经历', cardType: 'word' });
+    expect(result.partOfSpeech).toBeNull();
+  });
+
+  it('accepts null partOfSpeech explicitly', () => {
+    const result = cardEntryDraftSuggestionSchema.parse({ content: '经历', cardType: 'word', partOfSpeech: null });
+    expect(result.partOfSpeech).toBeNull();
+  });
+
+  it('rejects invalid partOfSpeech values', () => {
+    expect(() => cardEntryDraftSuggestionSchema.parse({ content: '经历', cardType: 'word', partOfSpeech: 'gerund' })).toThrow();
+  });
 });
 
 describe('buildCardEntryPreprocessPrompt', () => {
@@ -88,5 +107,24 @@ describe('buildCardEntryPreprocessPrompt', () => {
     expect(userPrompt).toContain('Hanzi');
     expect(userPrompt).toContain('pinyin');
     expect(userPrompt).toContain('English');
+  });
+
+  it('includes partOfSpeech in the JSON shape', () => {
+    const { userPrompt } = buildCardEntryPreprocessPrompt({
+      languageId: 'zh',
+      noteContent: '经历',
+      exampleSentenceFormat: 'sentence_translation',
+    });
+    expect(userPrompt).toContain('partOfSpeech');
+  });
+
+  it('instructs the model to guess POS for word-type cards', () => {
+    const { systemPrompt } = buildCardEntryPreprocessPrompt({
+      languageId: 'zh',
+      noteContent: '经历',
+      exampleSentenceFormat: 'sentence_translation',
+    });
+    expect(systemPrompt).toContain('partOfSpeech');
+    expect(systemPrompt).toContain('null for non-word');
   });
 });

--- a/apps/web/src/lib/server/ai-prompts/card-entry.ts
+++ b/apps/web/src/lib/server/ai-prompts/card-entry.ts
@@ -7,9 +7,15 @@ import {
 
 export const cardEntryCardTypeSchema = z.enum(['word', 'pattern', 'complex_prompt']).default('word');
 
+export const partOfSpeechSchema = z.enum([
+  'noun', 'verb', 'adjective', 'adverb', 'pronoun', 'preposition',
+  'conjunction', 'particle', 'measure_word', 'numeral', 'interjection', 'idiom',
+]).nullable().optional().default(null);
+
 export const cardEntryDraftSuggestionSchema = z.object({
   content: z.string().trim().min(1).max(500),
   cardType: cardEntryCardTypeSchema,
+  partOfSpeech: partOfSpeechSchema,
   meaning: z.string().trim().max(500).nullable().optional().default(null),
   examples: z.array(z.string().trim().min(1).max(500)).max(5).optional().default([]),
   mnemonics: z.array(z.string().trim().min(1).max(500)).max(5).optional().default([]),
@@ -39,6 +45,7 @@ export function buildCardEntryPreprocessPrompt(input: {
       'Keep examples and mnemonics concise and useful for study.',
       'Use the configured example sentence format consistently across every example string and do not mix formats within one response.',
       'If the note is ambiguous, produce the safest likely draft cards instead of refusing.',
+      'For word-type cards, set partOfSpeech to the most likely part of speech: one of noun, verb, adjective, adverb, pronoun, preposition, conjunction, particle, measure_word, numeral, interjection, idiom. Set to null for non-word card types.',
       'Set cardType based on the content: use "word" for a single vocabulary word or very short vocabulary item (e.g. 经历, repasar, bonjour);',
       'use "pattern" for a phrase, expression, grammar pattern, or multi-word construction (e.g. 这还有什么说的, sin embargo, au fur et à mesure);',
       'use "complex_prompt" for a comparative, analytical, or multi-concept prompt (e.g. 东西 vs 事情, ser vs estar).',
@@ -49,7 +56,7 @@ export function buildCardEntryPreprocessPrompt(input: {
       `Example sentence format: ${getCardEntryExampleSentenceFormatLabel(input.exampleSentenceFormat)}.`,
       buildCardEntryExampleSentenceFormatInstruction(input),
       'Return this JSON shape exactly:',
-      '{"draftCards":[{"content":"string","cardType":"word|pattern|complex_prompt","meaning":"string|null","examples":["string"],"mnemonics":["string"],"llmInstructions":"string|null"}]}',
+      '{"draftCards":[{"content":"string","cardType":"word|pattern|complex_prompt","partOfSpeech":"noun|verb|adjective|adverb|pronoun|preposition|conjunction|particle|measure_word|numeral|interjection|idiom|null","meaning":"string|null","examples":["string"],"mnemonics":["string"],"llmInstructions":"string|null"}]}',
       'Source note:',
       input.noteContent,
     ].join('\n'),

--- a/apps/web/src/lib/server/card-entry-ai.ts
+++ b/apps/web/src/lib/server/card-entry-ai.ts
@@ -84,6 +84,7 @@ export async function ensureCardEntryNoteProcessingState(input: {
         draftCards: response.draftCards.map((draftCard) => ({
           content: draftCard.content,
           cardType: draftCard.cardType,
+          partOfSpeech: draftCard.partOfSpeech ?? null,
           meaning: draftCard.meaning,
           examples: draftCard.examples,
           mnemonics: draftCard.mnemonics,


### PR DESCRIPTION
## Summary

Implements issue #226. When the AI generates draft cards during Card Entry, word-type cards now get a \part_of_speech\ guess automatically.

## Changes

- **\card-entry.ts\**: Added \partOfSpeechSchema\ (enum of 12 POS values, nullable) and \partOfSpeech\ field to \cardEntryDraftSuggestionSchema\; updated system prompt to instruct the model to guess POS for word cards and set null for other types; updated JSON shape in user prompt
- **\card-entry-ai.ts\**: Pass \partOfSpeech\ through in the \draftCards.map()\ (DB layer already handles it via \...draftCard\ spread)
- **\card-entry.test.ts\**: Added schema tests for valid POS, null default, invalid POS rejection; added prompt tests for POS guidance

## Behaviour

- \cardType === 'word'\: AI guesses one of: noun, verb, adjective, adverb, pronoun, preposition, conjunction, particle, measure_word, numeral, interjection, idiom
- All other card types: \partOfSpeech\ is null

Closes #226