### PR TITLE
fix: guard against unmigrated partOfSpeech string value in mappers and chip handlers

### DIFF
--- a/apps/web/src/lib/components/card-entry/DraftCardEditor.svelte
+++ b/apps/web/src/lib/components/card-entry/DraftCardEditor.svelte
@@ -426,7 +426,7 @@
             aria-pressed={draft.partOfSpeech?.includes(opt.value) ?? false}
             disabled={disabled}
             on:click={() => {
-              const current = draft.partOfSpeech ?? [];
+              const current = Array.isArray(draft.partOfSpeech) ? draft.partOfSpeech : [];
               draft = {
                 ...draft,
                 partOfSpeech: current.includes(opt.value)

--- a/apps/web/src/lib/components/cards/ActiveCardDrawer.svelte
+++ b/apps/web/src/lib/components/cards/ActiveCardDrawer.svelte
@@ -616,7 +616,7 @@
               aria-pressed={draft.partOfSpeech?.includes(opt.value) ?? false}
               disabled={disabled || removePending}
               on:click={() => {
-                const current = draft.partOfSpeech ?? [];
+                const current = Array.isArray(draft.partOfSpeech) ? draft.partOfSpeech : [];
                 draft = {
                   ...draft,
                   partOfSpeech: current.includes(opt.value)

--- a/apps/web/src/lib/server/card-entry.ts
+++ b/apps/web/src/lib/server/card-entry.ts
@@ -282,7 +282,7 @@ function mapDraftCard(
     content: draftCard.content,
     meaning: draftCard.meaning ?? null,
     cardType: draftCard.cardType ?? null,
-    partOfSpeech: draftCard.partOfSpeech ?? [],
+    partOfSpeech: Array.isArray(draftCard.partOfSpeech) ? draftCard.partOfSpeech : [],
     examples: normalizeStringList(draftCard.examples),
     mnemonics: normalizeStringList(draftCard.mnemonics),
     llmInstructions: parseOptionalText(draftCard.llmInstructions ?? ''),

--- a/apps/web/src/lib/server/card-review.ts
+++ b/apps/web/src/lib/server/card-review.ts
@@ -235,7 +235,7 @@ function mapSessionItem(item: CardReviewQueueItem): CardReviewSessionItemData {
     content: item.content,
     meaning: item.meaning,
     cardType: item.cardType,
-    partOfSpeech: item.partOfSpeech ?? [],
+    partOfSpeech: Array.isArray(item.partOfSpeech) ? item.partOfSpeech : [],
     examples: item.examples,
     mnemonics: item.mnemonics,
     llmInstructions: item.llmInstructions,

--- a/apps/web/src/lib/server/cards.ts
+++ b/apps/web/src/lib/server/cards.ts
@@ -393,7 +393,7 @@ function mapActiveCardDetail(card: ActiveCardDetail): CardLibraryCardDetailData 
     content: card.content,
     meaning: card.meaning,
     cardType: card.cardType,
-    partOfSpeech: card.partOfSpeech ?? [],
+    partOfSpeech: Array.isArray(card.partOfSpeech) ? card.partOfSpeech : [],
     examples: normalizeStringList(card.examples),
     mnemonics: normalizeStringList(card.mnemonics),
     llmInstructions: card.llmInstructions ?? null,


### PR DESCRIPTION
## Root Cause
Migration \