### PR TITLE
fix: eliminate subrequest fan-out in Translation Drills loader

### DIFF
--- a/apps/web/src/lib/server/translation-drills.test.ts
+++ b/apps/web/src/lib/server/translation-drills.test.ts
@@ -148,11 +148,6 @@ describe('Translation Drills server helpers', () => {
         performanceScore: null,
       },
     ]),
-    getTranslationDrillDismissSchedule: vi.fn(async (_userId: string, _languageId: string, cardId: string) => ({
-      cardId,
-      recommendedDays: 5,
-      optionDays: [1, 5, 15, 30],
-    })),
     listAvailablePosPiles: vi.fn(async () => []),
   };
   const deps = baseDeps as unknown as TranslationDrillLoaderDeps;
@@ -180,7 +175,7 @@ describe('Translation Drills server helpers', () => {
       activeCardCount: 2,
       cefrLevel: 'B1',
       cards: [
-        expect.objectContaining({ cardId: 'card-2', dismissSchedule: expect.objectContaining({ recommendedDays: 5 }) }),
+        expect.objectContaining({ cardId: 'card-2', dismissSchedule: expect.objectContaining({ recommendedDays: 6 }) }),
         expect.objectContaining({ cardId: 'card-1', dismissSchedule: expect.objectContaining({ recommendedDays: 5 }) }),
       ],
       suggestedSourceCardIds: ['card-2', 'card-1'],
@@ -204,23 +199,36 @@ describe('Translation Drills server helpers', () => {
     } satisfies Partial<TranslationDrillRequestError>);
   });
 
-  it('normalizes dismiss schedules so Tomorrow is always first', async () => {
-    baseDeps.getTranslationDrillDismissSchedule.mockImplementation(async (_userId: string, _languageId: string, cardId: string) => ({
-      cardId,
-      recommendedDays: 14,
-      optionDays: [30, 14],
-    }));
+  it('computes dismiss schedule from card intervalDays without extra DB queries', async () => {
+    // Mock context with card-2 having intervalDays: 7
+    // Expected: baseInterval=7 → recommendedDays=14 → optionDays=[1, 14, 42, 84]
+    baseDeps.listTranslationDrillContextCards.mockResolvedValueOnce([{
+      cardId: 'card-2',
+      content: '把握',
+      meaning: 'to grasp',
+      cardType: 'word',
+      examples: [],
+      mnemonics: [],
+      llmInstructions: null,
+      updatedAt: new Date('2026-05-02T12:00:00.000Z'),
+      sourceGroup: null,
+      addedFrom: 'pinned_from_review' as const,
+      addedAt: new Date('2026-05-09T12:00:00.000Z'),
+      lastUsedAt: null,
+      usageCount: 0,
+      state: 'active' as const,
+      stateUntil: null,
+      cefrOverride: null,
+      metadata: null,
+      nextDueAt: null,
+      intervalDays: 7,
+      performanceScore: null,
+    }] as never);
 
     const result = await loadTranslationDrillHomeData('user-1', 'zh', database, deps);
 
-    expect(result.configuredGroups[0]?.activeCards[0]?.dismissSchedule).toEqual({
-      recommendedDays: 14,
-      optionDays: [1, 14, 30],
-    });
-    expect(result.challenge.generationInput.cards[0]?.dismissSchedule).toEqual({
-      recommendedDays: 14,
-      optionDays: [1, 14, 30],
-    });
+    const card2Schedule = result.challenge.generationInput.cards.find((c) => c.cardId === 'card-2')?.dismissSchedule;
+    expect(card2Schedule).toEqual({ recommendedDays: 14, optionDays: [1, 14, 42, 84] });
   });
 });
 

--- a/apps/web/src/lib/server/translation-drills.ts
+++ b/apps/web/src/lib/server/translation-drills.ts
@@ -7,6 +7,7 @@ import {
   getDb,
   getGroups,
   recordTranslationDrillChallengeUsage,
+  computeTranslationDrillDismissSchedule,
   getTranslationDrillDismissSchedule,
   listTranslationDrillChallengeCards,
   listTranslationDrillContextCards,
@@ -35,7 +36,6 @@ export type TranslationDrillLoaderDeps = {
   listAvailablePosPiles: typeof listAvailablePosPiles;
   listTranslationDrillContextCards: typeof listTranslationDrillContextCards;
   listTranslationDrillChallengeCards: typeof listTranslationDrillChallengeCards;
-  getTranslationDrillDismissSchedule: typeof getTranslationDrillDismissSchedule;
 };
 
 export type TranslationDrillActionDeps = Pick<TranslationDrillLoaderDeps, 'getActiveUserLanguages' | 'listTranslationDrillChallengeCards'> & {
@@ -56,7 +56,6 @@ const defaultLoaderDeps: TranslationDrillLoaderDeps = {
   listAvailablePosPiles,
   listTranslationDrillContextCards,
   listTranslationDrillChallengeCards,
-  getTranslationDrillDismissSchedule,
 };
 
 const defaultActionDeps: TranslationDrillActionDeps = {
@@ -258,7 +257,7 @@ function toIsoString(date: Date | null): string | null {
 }
 
 function toDismissScheduleData(schedule: TranslationDrillDismissScheduleData): TranslationDrillDismissScheduleData {
-  return normalizeTranslationDrillDismissSchedule(schedule);
+  return normalizeTranslationDrillDismissSchedule({ recommendedDays: schedule.recommendedDays, optionDays: schedule.optionDays });
 }
 
 function mapContextCard(
@@ -441,20 +440,12 @@ export async function loadTranslationDrillHomeData(
 
   const configuredGroupIds = new Set(configuredGroups.map((group) => group.groupId));
   const visibleContextCards = contextCards.filter((card) => card.state === 'active' || card.state === 'snoozed');
-  const dismissScheduleEntries = await Promise.all(
-    visibleContextCards.map(async (card) => {
-      const schedule = await deps.getTranslationDrillDismissSchedule(userId, languageId, card.cardId, database as never);
-
-      return [
-        card.cardId,
-        toDismissScheduleData({
-          recommendedDays: schedule.recommendedDays,
-          optionDays: schedule.optionDays,
-        }),
-      ] as const;
+  const dismissSchedules = new Map(
+    visibleContextCards.map((card) => {
+      const schedule = computeTranslationDrillDismissSchedule(card.cardId, card.intervalDays);
+      return [card.cardId, toDismissScheduleData(schedule)] as const;
     }),
   );
-  const dismissSchedules = new Map(dismissScheduleEntries);
   const ungroupedContextCards = contextCards
     .filter((card) => card.state === 'active' || card.state === 'snoozed')
     .filter((card) => !card.sourceGroup || !configuredGroupIds.has(card.sourceGroup.groupId))

--- a/packages/database/src/translation-drills.ts
+++ b/packages/database/src/translation-drills.ts
@@ -801,26 +801,11 @@ export async function listAvailablePosPiles(
   return allPosPiles.sort((a, b) => a.pos.localeCompare(b.pos));
 }
 
-export async function getTranslationDrillDismissSchedule(
-  userId: string,
-  languageId: string,
+export function computeTranslationDrillDismissSchedule(
   cardId: string,
-  database?: AnyDb,
-): Promise<TranslationDrillDismissSchedule> {
-  await requireContextCard(userId, languageId, cardId, database);
-
-  const [row] = await getConn(database)
-    .select({
-      intervalDays: translationDrillSrs.intervalDays,
-    })
-    .from(translationDrillSrs)
-    .where(and(
-      eq(translationDrillSrs.userId, userId),
-      eq(translationDrillSrs.languageId, languageId),
-      eq(translationDrillSrs.cardId, cardId),
-    ));
-
-  const baseInterval = Math.max(row?.intervalDays ?? 1, 1);
+  intervalDays: number | null,
+): TranslationDrillDismissSchedule {
+  const baseInterval = Math.max(intervalDays ?? 1, 1);
   const recommendedDays = Math.min(60, Math.max(5, Math.round(baseInterval * 2)));
   const optionDays = [...new Set([
     1,
@@ -829,11 +814,17 @@ export async function getTranslationDrillDismissSchedule(
     Math.min(90, Math.max(30, Math.round(recommendedDays * 6))),
   ])].sort((left, right) => left - right);
 
-  return {
-    cardId,
-    recommendedDays,
-    optionDays,
-  };
+  return { cardId, recommendedDays, optionDays };
+}
+
+export async function getTranslationDrillDismissSchedule(
+  userId: string,
+  languageId: string,
+  cardId: string,
+  database?: AnyDb,
+): Promise<TranslationDrillDismissSchedule> {
+  const card = await requireContextCard(userId, languageId, cardId, database);
+  return computeTranslationDrillDismissSchedule(card.cardId, card.intervalDays);
 }
 
 export async function activateTranslationDrillCard(


### PR DESCRIPTION
## Problem

Translation Drills became permanently unavailable in production. Cloudflare Workers log showed:

\\\
NeonDbError: Error connecting to database: Too many subrequests by single Worker invocation
\\\

**Root cause**: \loadTranslationDrillHomeData\ was calling \getTranslationDrillDismissSchedule\ for each visible context card. The \
eon-http\ driver counts each SQL query as 1 HTTP subrequest. Each call made 3 subrequests (2 for \equireContextCard\ + 1 SRS SELECT). After drawing several cards, the total exceeded Cloudflare's default 50-subrequest limit. Every subsequent page load hit the same path → permanent outage.

## Fix

- **Extract \computeTranslationDrillDismissSchedule()\** as a pure function taking \cardId + intervalDays\. The \intervalDays\ field already exists on context cards via a LEFT JOIN in \loadContextRows\ — no extra DB call needed.
- **Replace the async \Promise.all\ loop** in \loadTranslationDrillHomeData\ with a synchronous \Map\ from \isibleContextCards.map()\, reducing 3×N subrequests to **0** for the loader path.
- **Refactor \getTranslationDrillDismissSchedule\** (used in draw/snooze/dismiss action paths) to reuse \computeTranslationDrillDismissSchedule\ from the card returned by \equireContextCard\, eliminating 1 redundant SELECT (3 → 2 subrequests per action).
- **Fix \	oDismissScheduleData\** to explicitly project \{recommendedDays, optionDays}\ before normalizing — prevents \cardId\ from leaking into the schedule payload via the spread in \
ormalizeTranslationDrillDismissSchedule\.

## Testing

All 12 \	ranslation-drills.test.ts\ tests pass. svelte-check clean. Build passes. (The 2 pre-existing flaky \CommandBar.dom.test.ts\ timeouts are unrelated.)