### PR TITLE
fix: document direct DB URL requirement for migrations in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,9 @@ jobs:
           fi
 
       # Phase 1: Database Migration (BEFORE code deployment)
+      # CRITICAL: PROD_DATABASE_URL must be a DIRECT Neon connection string (no -pooler in hostname).
+      # Pooled/PgBouncer URLs silently break drizzle-kit migrate — DDL won't commit and migration
+      # tracking won't update, but the step still exits 0. See ops/database-branching-guide.md.
       - name: Apply migrations to production database
         env:
           DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}


### PR DESCRIPTION
Adds a CRITICAL comment above the production migration step explaining that PROD_DATABASE_URL must be a direct Neon connection string (no \-pooler\ in hostname).

Pooled/PgBouncer URLs silently break \drizzle-kit migrate\ — DDL won't commit and migration tracking won't update, but the step still exits 0. This was the root cause of the \