### PR TITLE
fix: suppress empty overlay when pinned context cards are visible

### DIFF
--- a/apps/web/src/lib/components/translation-drills/TranslationDrillsHome.svelte
+++ b/apps/web/src/lib/components/translation-drills/TranslationDrillsHome.svelte
@@ -191,9 +191,8 @@
       return false;
     }
 
-    return !homeState.summary.hasConfiguredDrawPiles || (
-      !homeState.summary.hasVisibleContext &&
-      homeState.summary.remainingDrawCount === 0
+    return !homeState.summary.hasVisibleContext && (
+      !homeState.summary.hasConfiguredDrawPiles || homeState.summary.remainingDrawCount === 0
     );
   }
 


### PR DESCRIPTION
Fixes #224

## Root cause

\shouldShowEmptyOverlay()\ returned \	rue\ unconditionally when \hasConfiguredDrawPiles\ was false — even when pinned (ungrouped) context cards were present. The overlay covered the entire page, hiding the Pinned cards section.

## Fix

Gate the overlay on \hasVisibleContext\ first:

\\\	s
// Before
return !homeState.summary.hasConfiguredDrawPiles || (
  !homeState.summary.hasVisibleContext &&
  homeState.summary.remainingDrawCount === 0
);

// After
return !homeState.summary.hasVisibleContext && (
  !homeState.summary.hasConfiguredDrawPiles || homeState.summary.remainingDrawCount === 0
);
\\\

The overlay now only appears when there is genuinely nothing to show.